### PR TITLE
feat: add Docker image publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,78 @@
+name: Build and Push Docker Image
+
+on:
+  # Automatic triggers
+  push:
+    branches: [develop, main]
+    tags:
+      - 'v*.*.*'  # Semantic version tags like v1.0.0
+
+  # Manual trigger from GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to use (e.g., v1.0.0, develop, latest)'
+        required: false
+        default: 'manual'
+      rebuild:
+        description: 'Force rebuild even if image exists'
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Branch-based tags (develop, main)
+            type=ref,event=branch
+
+            # PR tags (pr-123)
+            type=ref,event=pr
+
+            # Version tags (v1.0.0 -> 1.0.0, latest)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+            # Latest tag for main branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+            # Manual trigger tag
+            type=raw,value=${{ github.event.inputs.tag || 'manual' }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+            # Git SHA for traceability
+            type=sha,prefix={{branch}}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
### **User description**
- Builds and pushes Docker images to GitHub Container Registry
- Triggers on push to develop/main and version tags
- Supports manual workflow dispatch for rebuilds
- Images will be available at ghcr.io/rpgoldberg/page-scraper

This enables integration tests to pull pre-built images.


___

### **PR Type**
Enhancement


___

### **Description**
- Add GitHub Actions workflow for Docker image publishing

- Configure automatic builds on develop/main branches and version tags

- Enable manual workflow dispatch with custom tag options

- Integrate GitHub Container Registry with proper authentication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Push/Tag"] --> B["Docker Build Workflow"]
  B --> C["Build Docker Image"]
  C --> D["Push to GHCR"]
  E["Manual Trigger"] --> B
  D --> F["ghcr.io/rpgoldberg/page-scraper"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Docker image publish workflow implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Create new GitHub Actions workflow for Docker image building<br> <li> Configure triggers for branch pushes, version tags, and manual <br>dispatch<br> <li> Set up GitHub Container Registry authentication and metadata <br>extraction<br> <li> Enable Docker layer caching and multi-tag image publishing</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/page-scraper/pull/4/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

