### PR TITLE
fix: add Docker Buildx setup to resolve build failures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,6 +67,9 @@ jobs:
             # Git SHA for traceability
             type=sha,prefix={{branch}}-
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -74,5 +77,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
### **User description**
## Summary
- Added docker/setup-buildx-action step before build
- Removed unsupported cache configuration that was causing failures
- Fixes 'Cache export is not supported for the docker driver' error

## Context
The Docker publish workflow was failing because it tried to use GitHub Actions cache (type=gha) without setting up buildx first. This PR fixes that issue so Docker images can be built and pushed to the registry.

## Test Plan
- Workflow will run successfully after merge
- Docker image will be pushed to ghcr.io/rpgoldberg/page-scraper:develop


___

### **PR Type**
Bug fix


___

### **Description**
- Add Docker Buildx setup step to workflow

- Remove unsupported GitHub Actions cache configuration

- Fix 'Cache export not supported for docker driver' error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Workflow"] --> B["Add Buildx Setup"]
  B --> C["Remove Cache Config"]
  C --> D["Fix Build Failures"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Add Buildx setup and remove cache config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Add <code>docker/setup-buildx-action@v3</code> step before build<br> <li> Remove <code>cache-from</code> and <code>cache-to</code> configuration lines<br> <li> Fix workflow to prevent Docker driver cache errors</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/page-scraper/pull/5/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

