### PR TITLE
Remove broken SHA tag from Docker metadata

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,9 +70,6 @@ jobs:
             # Manual trigger tag
             type=raw,value=${{ github.event.inputs.tag || 'manual' }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-            # Git SHA for traceability
-            type=sha,prefix={{branch}}-,enable=${{ github.event_name == 'push' }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
### **User description**
**Issue**: Docker metadata action was generating invalid tags like `-c1d2a53` (hyphen at start) due to broken {{branch}} placeholder in SHA tag prefix.

**Fix**: Remove the SHA tag entirely - it's redundant since we already have:
- Branch tags (`develop`, `main`) via `type=ref,event=branch`
- Semver tags (`2.0.0`, `2.0`, `2`) via `type=semver`

**Priority**: Should merge before version bump PR to prevent build failures.


___

### **PR Type**
Bug fix


___

### **Description**
- Removes broken SHA tag from Docker metadata configuration

- SHA tag was generating invalid tags with leading hyphens

- Redundant since branch and semver tags already provide identification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker metadata tags"] -->|"Remove invalid"| B["type=sha with {{branch}} prefix"]
  A -->|"Keep valid"| C["Branch tags develop/main"]
  A -->|"Keep valid"| D["Semver tags 2.0.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Remove redundant and broken SHA tag configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Removed <code>type=sha,prefix={{branch}}-</code> tag configuration<br> <li> Eliminated invalid tag generation with leading hyphens<br> <li> Retained branch and semver tags for container identification</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/page-scraper/pull/43/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

