### PR TITLE
fix: Correct Docker workflow tag trigger configuration

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,11 +4,11 @@ on:
   # Automatic triggers
   push:
     branches: [develop, main]
+    tags:
+      - 'v*.*.*'  # Semantic version tags like v1.0.0, v1.0.0-application
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened]
-    tags:
-      - 'v*.*.*'  # Semantic version tags like v1.0.0
 
   # Manual trigger from GitHub Actions UI
   workflow_dispatch:


### PR DESCRIPTION
### **User description**
Moves tags trigger from pull_request to push section.


___

### **PR Type**
Bug fix


___

### **Description**
- Moves semantic version tags trigger from `pull_request` to `push` section

- Ensures Docker images are built and published only on tag pushes

- Corrects workflow trigger configuration for proper CI/CD behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Workflow Triggers"] --> B["push section"]
  A --> C["pull_request section"]
  B --> D["branches: develop, main"]
  B --> E["tags: v*.*.*"]
  C --> F["branches: develop, main"]
  C --> G["types: opened, synchronize, reopened"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Relocate tags trigger to push section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Relocated semantic version tags trigger from <code>pull_request</code> to <code>push</code> <br>section<br> <li> Tags pattern <code>v*.*.*</code> now only triggers on push events, not pull <br>requests<br> <li> Maintains existing branch triggers and pull request type filters</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/page-scraper/pull/45/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

