### PR TITLE
Fix Docker dual-tagging strategy for application releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,16 +59,17 @@ jobs:
             # PR tags (pr-123)
             type=ref,event=pr
 
-            # Version tags (v1.0.0 -> 1.0.0, latest)
+            # Service version tags (v2.0.1 -> 2.0.1)
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+
+            # Application version tags (v2.0.1-application -> 2.0.1-application AND 2.0.1)
+            # When an application tag is pushed, generate BOTH the application tag and service version tag
+            # This ensures the same image has multiple tags without rebuilding
+            type=match,pattern=v(.+)-application,group=1,suffix=-application
+            type=match,pattern=v(.+)-application,group=1
 
             # Latest tag for main branch
             type=raw,value=latest,enable={{is_default_branch}}
-
-            # Manual trigger tag
-            type=raw,value=${{ github.event.inputs.tag || 'manual' }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
### **User description**
## Problem

When pushing application tags (v2.0.1-application), the Docker workflow only generated the application tag suffix. This required manual retagging to add service version tags (2.0.1), which created different image digests.

Additionally, the workflow was generating unwanted floating tags (2, 2.0, manual) from semver major/minor patterns.

## Solution

Updated `docker-publish.yml` to intelligently handle application tags:

**Before:**
- `v2.0.1-application` → generated only `2.0.1-application`
- Required manual `docker pull/tag/push` to add `2.0.1` (creates different digest)

**After:**
- `v2.0.1-application` → generates BOTH `2.0.1-application` AND `2.0.1`
- Same image, same digest, multiple tags at build time

## Changes

- Removed floating `{{major}}.{{minor}}` and `{{major}}` tag patterns
- Removed problematic `manual` tag generation
- Added `type=match` patterns to detect application tags with `-application` suffix
- Application tags now generate both the service version AND application version

## Impact

- ✅ Same Docker image digest for both tags
- ✅ No more unwanted 2, 2.0, manual tags
- ✅ Simpler deployment: use either tag, same image
- ✅ No manual retagging required

## Testing

After merge, delete old incorrect tags and re-trigger v2.0.1-application build to verify.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed Docker dual-tagging strategy for application releases

- Application tags now generate both service and application versions simultaneously

- Removed unwanted floating tags (major, major.minor) and manual trigger tags

- Ensures same image digest for multiple tags without manual retagging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Application Tag<br/>v2.0.1-application"] -->|"type=match<br/>pattern 1"| B["Application Version<br/>2.0.1-application"]
  A -->|"type=match<br/>pattern 2"| C["Service Version<br/>2.0.1"]
  B -->|"Same Image<br/>Same Digest"| D["Docker Registry"]
  C -->|"Same Image<br/>Same Digest"| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Implement dual-tagging for application releases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Removed floating tag patterns <code>{{major}}.{{minor}}</code> and <code>{{major}}</code> to <br>prevent unwanted tags<br> <li> Removed manual trigger tag generation from workflow_dispatch events<br> <li> Added two <code>type=match</code> patterns to handle application tags with <br><code>-application</code> suffix<br> <li> Application tags now generate both the application version tag and <br>service version tag simultaneously</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/page-scraper/pull/46/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

