### PR TITLE
Fix Docker tagging: application tags generate only application tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,11 +62,10 @@ jobs:
             # Service version tags (v2.0.1 -> 2.0.1)
             type=semver,pattern={{version}}
 
-            # Application version tags (v2.0.1-application -> 2.0.1-application AND 2.0.1)
-            # When an application tag is pushed, generate BOTH the application tag and service version tag
-            # This ensures the same image has multiple tags without rebuilding
+            # Application version tags (v2.0.1-application -> 2.0.1-application ONLY)
+            # Application tags do NOT extract the base version
+            # Push separate service version tags for dual-tagging
             type=match,pattern=v(.+)-application,group=1,suffix=-application
-            type=match,pattern=v(.+)-application,group=1
 
             # Latest tag for main branch
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
### **User description**
Fixes incorrect dual-tagging where application tags extracted base version. Application tags now only generate -application suffixed tag. Push separate service version tags for proper dual-tagging.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove dual-tagging from application version tags

- Application tags now generate only -application suffix

- Service version tags must be pushed separately

- Prevents unintended base version tag generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Application tag<br/>v2.0.1-application"] -->|"Old behavior"| B["Dual tags:<br/>2.0.1-application<br/>AND 2.0.1"]
  A -->|"New behavior"| C["Single tag:<br/>2.0.1-application only"]
  D["Service version tag<br/>v2.0.1"] -->|"Separate push"| E["Service tag:<br/>2.0.1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Remove dual-tagging from application version tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Removed duplicate <code>type=match</code> rule that extracted base version from <br>application tags<br> <li> Updated comments to clarify application tags generate only <br>-application suffix<br> <li> Documented that service version tags must be pushed separately for <br>dual-tagging<br> <li> Simplified tag generation logic to prevent unintended tag duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/page-scraper/pull/47/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

