### PR TITLE
Fix YAML syntax error in security scan workflow

### DIFF
--- a/.github/workflows/scheduled-security-scan.yml
+++ b/.github/workflows/scheduled-security-scan.yml
@@ -187,8 +187,7 @@ jobs:
               issue.title.includes(serviceName) && issue.title.includes('Security:')
             );
 
-            const body = `
-${report}
+            const body = report + `
 
 ---
 **Scan Date**: ${new Date().toISOString()}


### PR DESCRIPTION
### **User description**
## Summary
Fix YAML syntax error caused by `${report}` at start of template literal line.

Changed from:
```javascript
const body = `
${report}
...
```

To:
```javascript
const body = report + `
...
```

## Test plan
- [ ] Verify workflow YAML parses correctly
- [ ] Confirm workflow runs without syntax errors


___

### **PR Type**
Bug fix


___

### **Description**
- Fix YAML syntax error in workflow template literal

- Changed template literal concatenation to avoid invalid syntax

- Concatenate report variable before template string starts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Template literal with leading variable"] -- "Fix syntax error" --> B["Concatenate variable before template string"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduled-security-scan.yml</strong><dd><code>Fix template literal syntax in issue body</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/scheduled-security-scan.yml

<ul><li>Fixed YAML syntax error by moving <code>${report}</code> variable outside template <br>literal<br> <li> Changed from backtick-prefixed template literal to string <br>concatenation<br> <li> Ensures workflow YAML parses correctly without syntax errors</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/scraper/pull/81/files#diff-b984377047d142d74f657b6ab3404b4c79f94ca3dbeba6d07440d0b84e82672d">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

