### PR TITLE
Scan only own service image

### DIFF
--- a/.github/workflows/scheduled-security-scan.yml
+++ b/.github/workflows/scheduled-security-scan.yml
@@ -38,13 +38,8 @@ jobs:
     strategy:
       matrix:
         service:
-          - name: fc-backend
-            tag: latest
-          - name: fc-frontend
-            tag: latest
           - name: scraper
             tag: latest
-          # version-manager removed - repo archived
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### **User description**
## Summary
Change scheduled security scan to only scan this repo's own Docker image instead of all 3 services.

Previously each repo (scraper, fc-frontend, fc-backend) was scanning all 3 service images, creating 3x redundant scans and notifications.

## Test plan
- [ ] Verify workflow only scans scraper image
- [ ] Confirm no duplicate security issues created


___

### **PR Type**
Enhancement


___

### **Description**
- Removes redundant scanning of other services

- Workflow now scans only scraper service image

- Eliminates duplicate security notifications across repos


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scheduled Security Scan"] --> B["Matrix Strategy"]
  B --> C["fc-backend removed"]
  B --> D["fc-frontend removed"]
  B --> E["scraper kept"]
  C --> F["Single Service Scan"]
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduled-security-scan.yml</strong><dd><code>Limit matrix to scraper service only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/scheduled-security-scan.yml

<ul><li>Removed fc-backend and fc-frontend from service matrix<br> <li> Kept only scraper service in matrix strategy<br> <li> Removed archived version-manager comment<br> <li> Workflow now scans single service instead of three</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/scraper/pull/85/files#diff-b984377047d142d74f657b6ab3404b4c79f94ca3dbeba6d07440d0b84e82672d">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

