### PR TITLE
HOTFIX: Move cheerio from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:ci": "jest --ci --coverage --testPathIgnorePatterns='inter-service'"
   },
   "dependencies": {
+    "cheerio": "^1.1.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.0",
@@ -33,13 +34,11 @@
     }
   },
   "devDependencies": {
-    "@types/cheerio": "^1.0.0",
     "@types/cors": "^2.8.14",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.9.1",
     "@types/supertest": "^6.0.3",
-    "cheerio": "^1.1.2",
     "jest": "^30.2.0",
     "supertest": "^7.1.4",
     "testcontainers": "^11.7.1",


### PR DESCRIPTION
## CRITICAL - Production Crash Fix

The scraper v2.1.0 production container fails to start with:
```
Error: Cannot find module 'cheerio'
```

### Root Cause
`cheerio` was listed as a `devDependency` but is imported at runtime by `companyArtistExtractor.ts`. The production Dockerfile uses `npm install --omit=dev` (line 148), so cheerio is not installed in the production container.

### Fix
- Move `cheerio` from `devDependencies` to `dependencies` in package.json
- Remove duplicate `@types/cheerio` (cheerio 1.x ships its own types)

### Verification
- `npm run build` - compiles cleanly
- `npm test` - 598 passed, 24 suites, 0 failures