### PR TITLE
Release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Scraper service will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2026-02-13
+
+### Changed
+- **Organization Migration**: Moved repository from `rpgoldberg` to `FigureCollecting` org
+- **Docker Publish Workflow**: Fixed OCI case-sensitivity bug in image verification step
+- **Security Scan Workflow**: Added `security-events: write` permission for SARIF uploads
+
+### Fixed
+- **Cheerio Production Dependency**: Moved cheerio from devDependencies to dependencies
+
+---
+
 ## [2.0.6] - 2026-01-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scraper",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scraper",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "cheerio": "^1.1.2",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:ci": "jest --ci --coverage --testPathIgnorePatterns='inter-service'"
   },
   "dependencies": {
+    "cheerio": "^1.1.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.0",
@@ -33,13 +34,11 @@
     }
   },
   "devDependencies": {
-    "@types/cheerio": "^1.0.0",
     "@types/cors": "^2.8.14",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.9.1",
     "@types/supertest": "^6.0.3",
-    "cheerio": "^1.1.2",
     "jest": "^30.2.0",
     "supertest": "^7.1.4",
     "testcontainers": "^11.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scraper",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Generic web page scraping service with browser automation",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Organization migration from `rpgoldberg` to `FigureCollecting`
- Fix OCI case-sensitivity bug in docker-publish verification step
- Add `security-events: write` permission for SARIF uploads in security scan workflow
- Fix cheerio production dependency (moved from devDependencies to dependencies)

## Changes
- Version bump: 2.1.1 → 2.1.2
- CHANGELOG updated