### PR TITLE
Fix sync cancellation crash and document BACKEND_URL config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ PORT=3080
 # Default: PHPSESSID,sesUID,sesDID,cf_clearance
 MFC_ALLOWED_COOKIES=PHPSESSID,sesUID,sesDID,cf_clearance
 
+# Backend Webhook URL (required in production/Docker)
+# Used by the webhook client to send sync progress callbacks to the backend.
+# Must be set to the backend's Docker hostname when running in containers.
+# Example: http://fc-backend:5050
+# BACKEND_URL=http://fc-backend:5050
+
 # Debug Logging (optional)
 # Enable debug output for specific namespaces
 # DEBUG=scraper:*

--- a/README.md
+++ b/README.md
@@ -683,6 +683,13 @@ See `.env.example` for complete configuration template.
 - `PORT`: Server port (prod: 3050, local dev: 3080, test: 3070, Coolify dev: 3090)
 - `NODE_ENV`: Environment mode (development, test, production)
 
+**Required in Docker/Production:**
+- `BACKEND_URL`: Backend service URL for webhook callbacks during MFC sync
+  - Docker prod: `http://backend:5050`
+  - Docker Coolify dev: `http://backend:5090`
+  - Local dev: `http://localhost:5080`
+  - (Must be reachable from the scraper container; used by the webhook client to send sync progress to backend)
+
 **Optional:**
 - `PUPPETEER_EXECUTABLE_PATH`: Custom Chrome/Chromium executable path
   - Useful for CI/CD environments or custom browser installations

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -388,6 +388,8 @@ export class ScrapeQueue {
       const promise = new Promise<ScrapedData>((resolve, reject) => {
         existingItem.resolvers.push({ resolve, reject });
       });
+      // Prevent unhandled rejection crash when items are cancelled
+      promise.catch(() => {});
 
       console.log(`[SCRAPE QUEUE] Deduplicated request for MFC ${mfcId} (${existingItem.waitingUserIds.length} users waiting)`);
 
@@ -428,6 +430,8 @@ export class ScrapeQueue {
     const promise = new Promise<ScrapedData>((resolve, reject) => {
       item.resolvers.push({ resolve, reject });
     });
+    // Prevent unhandled rejection crash when items are cancelled
+    promise.catch(() => {});
 
     // Add to appropriate queue
     this.addToQueue(item);


### PR DESCRIPTION
## Summary
- Prevent unhandled promise rejection crash when cancelling sync sessions (Node.js v24 treats unhandled rejections as fatal)
- Document BACKEND_URL environment variable required for production webhook callbacks in .env.example and README

## Changes
- `src/services/scrapeQueue.ts`: Added `promise.catch(() => {})` on both promise creation paths in `enqueue()` to prevent unhandled rejection when `cancel()` rejects promises
- `.env.example`: Added BACKEND_URL documentation with production example
- `README.md`: Added BACKEND_URL to Environment Variables section

## Root cause
The `cancel()` method calls `reject(cancelError)` on promises created in `enqueue()`, but those promises had no `.catch()` handlers attached. In Node.js v24 (`--unhandled-rejections=throw` default since Node 15), this crashes the process.

## Test plan
- [ ] All 86 scraper tests pass
- [ ] Cancelling a sync session no longer crashes the scraper process
- [ ] BACKEND_URL is documented in .env.example for deployment reference