### PR TITLE
Merge back v2.1.3 release to develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scraper",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scraper",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "dependencies": {
         "cheerio": "^1.1.2",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scraper",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Generic web page scraping service with browser automation",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Merge the v2.1.3 release (version bump) back to develop to keep branches in sync.