### PR TITLE
Release v2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scraper",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scraper",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "dependencies": {
         "cheerio": "^1.1.2",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scraper",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Generic web page scraping service with browser automation",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add retry with exponential backoff to webhook client for transient failures (429, 5xx, network errors)

## Changes since v2.1.3
- `fix/webhook-retry-backoff`: Webhook `sendWebhook()` now retries up to 3 times with exponential backoff, respects Retry-After headers

## Test plan
- [x] All 606 scraper tests pass (21 webhook client tests including 7 new retry tests)
- [x] CodeQL clean
- [ ] Verify webhook retries work correctly during bulk sync