### PR TITLE
Revert production Dockerfile to npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ COPY package*.json ./
 
 # Install only production dependencies
 RUN npm config set fetch-timeout 300000 && npm config set fetch-retry-maxtimeout 300000
-RUN timeout 600 npm ci --no-audit --no-fund --omit=dev
+RUN timeout 600 npm install --no-audit --no-fund --omit=dev
 
 # Remove any Chrome that might have been downloaded by Puppeteer
 RUN rm -rf /root/.cache/puppeteer \


### PR DESCRIPTION
## Summary
- Reverts production stage `npm ci` back to `npm install` in Dockerfile
- `npm ci --omit=dev` was not properly installing cheerio (production dependency), causing container crash at startup
- The `npm ci` change was originally made to pin minimatch 10.2.4 for grype, but that's now handled via `.grype.yaml` ignores

## Test plan
- [ ] Docker image builds successfully
- [ ] Container starts without `Cannot find module 'cheerio'` error
- [ ] Health check passes