### PR TITLE
Bump Chrome to 149.0.7827.115 (security)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # =============================================================================
-# BASE STAGE - Secure Ubuntu 24.04 + Node 24.16.0 LTS + Chrome 149.0.7827.54
+# BASE STAGE - Secure Ubuntu 24.04 + Node 24.16.0 LTS + Chrome 149.0.7827.115
 # =============================================================================
 FROM ubuntu:24.04 AS base
 
 # Cache-bust ARG to invalidate Docker layers when dependencies change
-ARG CACHE_BUST=2026-05-31-chrome-149-node-24.16-vuln-fix
+ARG CACHE_BUST=2026-06-12-chrome-149.0.7827.115-cve-fix
 
 # Update all packages for latest security patches (openssl, gnupg, glibc)
 # Install Node.js 24 using official binaries (avoids NodeSource CVE false positives)
@@ -63,9 +63,9 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Download and install Chrome for Testing (149.0.7827.54) - latest stable, fixes all known CVEs
+# Download and install Chrome for Testing (149.0.7827.115) - latest stable, fixes all known CVEs
 RUN apt-get update && apt-get install -y wget unzip \
-    && wget -q https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.54/linux64/chrome-linux64.zip \
+    && wget -q https://storage.googleapis.com/chrome-for-testing-public/149.0.7827.115/linux64/chrome-linux64.zip \
     && unzip chrome-linux64.zip \
     && mv chrome-linux64 /opt/chrome \
     && rm chrome-linux64.zip \


### PR DESCRIPTION
Remediates HIGH/CRITICAL CVEs in the pinned Chrome-for-Testing binary in the scraper image, including the **known-exploited (KEV)** CVE-2026-11645 plus several other HIGH/critical (CVE-2026-11638/11654/11659/11651, etc.).

149.0.7827.54 → **149.0.7827.115** (latest CfT build for milestone 149 — verified via the CfT versions API; stays on the same Chrome major for Puppeteer compatibility). Dockerfile `CACHE_BUST` bumped to force a fresh layer.

Pre-existing image vuln surfaced during the June-2026 release-time triage; independent of the observability work that just merged.