### PR TITLE
Wire fc-shared redaction into logs and OTLP export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scraper",
       "version": "2.2.0",
       "dependencies": {
-        "@figurecollecting/fc-shared": "^1.2.1",
+        "@figurecollecting/fc-shared": "^1.3.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.76.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -1043,9 +1043,9 @@
       }
     },
     "node_modules/@figurecollecting/fc-shared": {
-      "version": "1.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/fc-shared/1.2.1/ed3cfd2e1739e88d4e2eec9c24e3978e9fffc946",
-      "integrity": "sha512-NtQsJyyqEk95KDdv1fQQtnUPCBl6TIuE2r3IQ50JWlAYYLf6ArWXsG1bl5+D8j1btxZuBHRHbDlzXjdEAE6VAg==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/fc-shared/1.3.0/0fc7bbaada8d37b687aca810971ae803e1ae1dbe",
+      "integrity": "sha512-FFuFMFKiw1cPdgocxTnKvN74d6NVkk88jJev9Zbr55L8uHQ63GMktbnUg7/vuGQhBYDBi+K222/k34eqpdx8Vw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:ci": "jest --ci --coverage --testPathIgnorePatterns='inter-service'"
   },
   "dependencies": {
-    "@figurecollecting/fc-shared": "^1.2.1",
+    "@figurecollecting/fc-shared": "^1.3.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.76.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",

--- a/src/__tests__/unit/loggerRedaction.test.ts
+++ b/src/__tests__/unit/loggerRedaction.test.ts
@@ -1,0 +1,54 @@
+import { logger } from '../../utils/logger';
+
+/**
+ * Proves fc-shared's redactValue is layered on top of the logger's existing
+ * field-name sanitizeData, so both secret-SHAPE values (a bare 'Bearer ...'
+ * string) and sensitive fields ({ token }) are scrubbed from the serialized log
+ * payload before it reaches the console. Belt-and-suspenders with the legacy
+ * field redaction — neither shape should ever leak.
+ */
+describe('logger payload redaction', () => {
+  let logSpy: jest.SpyInstance;
+  let errSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('redacts a token field AND a Bearer secret hidden under an innocent field name', () => {
+    logger.info('auth attempt', {
+      token: 'x',
+      // 'header' is NOT in sanitizeData's field-name list — only redactValue's
+      // secret-SHAPE matching catches the Bearer value here. This isolates the
+      // new redaction layer from the legacy field-name sanitizer.
+      header: 'Bearer abcdefghij',
+      keepMe: 'visible',
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const serialized = logSpy.mock.calls[0][1] as string;
+
+    expect(serialized).not.toContain('Bearer abcdefghij');
+    expect(serialized).not.toContain('"token": "x"');
+    expect(serialized).toContain('[REDACTED]');
+    // Non-sensitive fields survive.
+    expect(serialized).toContain('visible');
+  });
+
+  it('redacts a Bearer secret string passed as the whole error payload', () => {
+    logger.error('auth failure', { header: 'Bearer abcdefghij', token: 'x' });
+
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const serialized = errSpy.mock.calls[0][1] as string;
+
+    expect(serialized).not.toContain('Bearer abcdefghij');
+    expect(serialized).not.toContain('"token": "x"');
+    expect(serialized).toContain('[REDACTED]');
+  });
+});

--- a/src/__tests__/unit/spanRedaction.test.ts
+++ b/src/__tests__/unit/spanRedaction.test.ts
@@ -1,0 +1,59 @@
+import { RedactingSpanExporter } from '../../tracing';
+import { ExportResultCode } from '@opentelemetry/core';
+import type { ExportResult } from '@opentelemetry/core';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+
+/**
+ * Proves RedactingSpanExporter scrubs secret/PII span attributes (via fc-shared's
+ * redactAttributes) before the wrapped exporter ever sees them — so even with a
+ * collector attached, an 'authorization' header stamped onto a span never leaves
+ * the host. Non-sensitive attributes pass through untouched, and lifecycle calls
+ * delegate.
+ */
+describe('RedactingSpanExporter', () => {
+  function makeSpan(attributes: Record<string, unknown>): ReadableSpan {
+    return { attributes } as unknown as ReadableSpan;
+  }
+
+  it('scrubs sensitive attributes before the delegate receives the span', () => {
+    const received: ReadableSpan[] = [];
+    const delegate: SpanExporter = {
+      export(spans: ReadableSpan[], cb: (r: ExportResult) => void): void {
+        received.push(...spans);
+        cb({ code: ExportResultCode.SUCCESS });
+      },
+      shutdown: () => Promise.resolve(),
+    };
+
+    const exporter = new RedactingSpanExporter(delegate);
+    const span = makeSpan({ authorization: 'Bearer abcdefghij', 'http.method': 'GET' });
+
+    const cb = jest.fn();
+    exporter.export([span], cb);
+
+    expect(cb).toHaveBeenCalledWith({ code: ExportResultCode.SUCCESS });
+    expect(received).toHaveLength(1);
+    const attrs = received[0].attributes as Record<string, unknown>;
+    expect(attrs.authorization).toBe('[REDACTED]');
+    // Non-sensitive attribute survives the scrub.
+    expect(attrs['http.method']).toBe('GET');
+  });
+
+  it('delegates shutdown and forceFlush to the wrapped exporter', async () => {
+    const shutdown = jest.fn().mockResolvedValue(undefined);
+    const forceFlush = jest.fn().mockResolvedValue(undefined);
+    const delegate = {
+      export: jest.fn(),
+      shutdown,
+      forceFlush,
+    } as unknown as SpanExporter;
+
+    const exporter = new RedactingSpanExporter(delegate);
+
+    await exporter.shutdown();
+    await exporter.forceFlush();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(forceFlush).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -32,6 +32,7 @@ import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { SimpleSpanProcessor, SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { redactAttributes } from '@figurecollecting/fc-shared';
 
 /**
  * A SpanExporter that ships nothing. Paired with a real SimpleSpanProcessor it
@@ -47,6 +48,33 @@ class NoopSpanExporter implements SpanExporter {
   }
   shutdown(): Promise<void> {
     return Promise.resolve();
+  }
+}
+
+/**
+ * A SpanExporter wrapper that scrubs secret/PII span attributes (via fc-shared's
+ * redactAttributes) before handing spans to the real OTLP exporter. Auto- and
+ * manual-instrumentation can stamp request headers, URLs, or db statements onto
+ * span attributes, so this guarantees nothing sensitive leaves the host even once
+ * a collector is attached. Pure delegation otherwise — lifecycle (shutdown,
+ * forceFlush) passes straight through to the wrapped exporter.
+ */
+export class RedactingSpanExporter implements SpanExporter {
+  constructor(private readonly delegate: SpanExporter) {}
+
+  export(spans: ReadableSpan[], cb: (r: ExportResult) => void): void {
+    for (const s of spans) {
+      (s as any).attributes = redactAttributes(s.attributes as any);
+    }
+    this.delegate.export(spans, cb);
+  }
+
+  shutdown(): Promise<void> {
+    return this.delegate.shutdown();
+  }
+
+  forceFlush(): Promise<void> {
+    return this.delegate.forceFlush ? this.delegate.forceFlush() : Promise.resolve();
   }
 }
 
@@ -90,7 +118,7 @@ export function startTracing(env: NodeJS.ProcessEnv = process.env): NodeSDK | un
     // trace IDs for log correlation) but drop spans through a no-op exporter, so
     // nothing leaves the host and there are no connection errors.
     ...(endpoint
-      ? { traceExporter: new OTLPTraceExporter() }
+      ? { traceExporter: new RedactingSpanExporter(new OTLPTraceExporter()) }
       : { spanProcessors: [new SimpleSpanProcessor(new NoopSpanExporter())] }),
     instrumentations: [getNodeAutoInstrumentations()],
   });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,7 +12,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { getTraceContext } from '@figurecollecting/fc-shared';
+import { getTraceContext, redactValue } from '@figurecollecting/fc-shared';
 
 export interface Logger {
   debug: (namespace: string, message: string, data?: any) => void;
@@ -111,7 +111,7 @@ class DebugLogger implements Logger {
     if (!this.isNamespaceEnabled(namespace)) return;
 
     const timestamp = new Date().toISOString();
-    const sanitizedData = this.sanitizeData(data);
+    const sanitizedData = redactValue(this.sanitizeData(data));
 
     console.log(`[${timestamp}] [DEBUG] [${namespace}]${this.traceTag()} ${message}`,
       sanitizedData ? JSON.stringify(sanitizedData, null, 2) : '');
@@ -119,7 +119,7 @@ class DebugLogger implements Logger {
 
   info(message: string, data?: any): void {
     const timestamp = new Date().toISOString();
-    const sanitizedData = this.sanitizeData(data);
+    const sanitizedData = redactValue(this.sanitizeData(data));
 
     console.log(`[${timestamp}] [INFO]${this.traceTag()} ${message}`,
       sanitizedData ? JSON.stringify(sanitizedData, null, 2) : '');
@@ -127,7 +127,7 @@ class DebugLogger implements Logger {
 
   warn(message: string, data?: any): void {
     const timestamp = new Date().toISOString();
-    const sanitizedData = this.sanitizeData(data);
+    const sanitizedData = redactValue(this.sanitizeData(data));
 
     console.warn(`[${timestamp}] [WARN]${this.traceTag()} ${message}`,
       sanitizedData ? JSON.stringify(sanitizedData, null, 2) : '');
@@ -145,7 +145,7 @@ class DebugLogger implements Logger {
         name: error.name
       };
     } else {
-      errorData = this.sanitizeData(error);
+      errorData = redactValue(this.sanitizeData(error));
     }
 
     console.error(`[${timestamp}] [ERROR]${this.traceTag()} ${message}`,


### PR DESCRIPTION
Bump @figurecollecting/fc-shared to ^1.3.0 and wire its redaction primitives into the scraper.

- Logger (src/utils/logger.ts): layer redactValue on top of the existing field-name sanitizeData in debug/info/warn/error (redactValue(this.sanitizeData(data))). Belt-and-suspenders — secret-SHAPE values (e.g. a bare 'Bearer ...' string under an innocent field name) and broader PII are now caught in addition to the legacy field-name redaction. sanitizeData, namespaces, traceTag, CWE-117 sanitization, file logging, and enrichmentLogger are all preserved.
- OTLP export (src/tracing.ts): new RedactingSpanExporter wraps the real OTLPTraceExporter and runs redactAttributes over each span's attributes before export, so secrets/PII stamped onto spans (headers, URLs, db statements) never leave the host. Active only when OTEL_EXPORTER_OTLP_ENDPOINT is set; the no-endpoint NoopSpanExporter branch is unchanged.
- Tests (src/__tests__/unit/): loggerRedaction.test.ts asserts a token field and a Bearer secret hidden under a non-sensitive field name are redacted from logged payloads; spanRedaction.test.ts feeds a fake ReadableSpan with an 'authorization' attribute through RedactingSpanExporter.export and asserts the delegate receives scrubbed attributes (and that shutdown/forceFlush delegate).

Verification: npx tsc --noEmit clean; full suite npx jest green (31 suites, 770 passed + 3 todo / 773 total, zero regression); npm audit --omit=dev reports 5 moderate / 0 high / 0 critical.