### PR TITLE
Parse each labeled MFC dimension separately instead of concatenating W/L/H digits

### DIFF
--- a/src/__tests__/unit/companyArtistExtractorExtended.test.ts
+++ b/src/__tests__/unit/companyArtistExtractorExtended.test.ts
@@ -320,6 +320,143 @@ describe('companyArtistExtractor - extended', () => {
       expect(fields.dimensions).toBe('H=150mm');
     });
 
+    // Multi-dimension figures: MFC renders each labeled dimension as its own
+    // <small>LABEL=</small><strong>value</strong><small>unit</small> triple.
+    // The previous parser ran find('strong').text() across ALL strongs, which
+    // Cheerio concatenates (e.g. 250+210+470 -> "250210470") and then mislabeled
+    // the blob as height. Each dimension must be captured separately by its label.
+    it('should extract multi-dimension figure without concatenating values (Mahina W/L/H)', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <a class="item-scale"><small>1/</small>6</a>
+            <small>W=</small><strong>250</strong><small>mm</small>
+            <small>L=</small><strong>210</strong><small>mm</small>
+            <small>H=</small><strong>470</strong><small>mm</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('1/6, W=250mm, L=210mm, H=470mm');
+      // Regression guard: the corrupted concatenation must never appear.
+      expect(fields.dimensions).not.toContain('250210470');
+    });
+
+    it('should keep height labeled correctly for Yan (W=320 L=330 H=420)', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>W=</small><strong>320</strong><small>mm</small>
+            <small>L=</small><strong>330</strong><small>mm</small>
+            <small>H=</small><strong>420</strong><small>mm</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('W=320mm, L=330mm, H=420mm');
+      expect(fields.dimensions).not.toContain('320330420');
+    });
+
+    it('should handle a four-dimension figure including depth (W/L/H/D)', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>W=</small><strong>195</strong><small>mm</small>
+            <small>L=</small><strong>225</strong><small>mm</small>
+            <small>H=</small><strong>242</strong><small>mm</small>
+            <small>D=</small><strong>90</strong><small>mm</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('W=195mm, L=225mm, H=242mm, D=90mm');
+    });
+
+    it('should accept full-word labels (Width/Length/Height)', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>Width=</small><strong>100</strong><small>mm</small>
+            <small>Height=</small><strong>200</strong><small>mm</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('W=100mm, H=200mm');
+    });
+
+    it('should convert centimeters to millimeters', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>H=</small><strong>26</strong><small>cm</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('H=260mm');
+    });
+
+    it('should convert inches to millimeters', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>H=</small><strong>10</strong><small>in</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('H=254mm');
+    });
+
+    it('should skip unrecognized dimension labels instead of fabricating height', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>X=</small><strong>999</strong><small>mm</small>
+            <small>H=</small><strong>300</strong><small>mm</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('H=300mm');
+      expect(fields.dimensions).not.toContain('999');
+    });
+
+    it('should keep fractional millimeters when converting inches', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>H=</small><strong>9.5</strong><small>in</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('H=241.3mm');
+    });
+
+    it('should skip a dimension whose value is not numeric', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Dimensions</span>
+          <span class="data-value">
+            <small>W=</small><strong>n/a</strong><small>mm</small>
+            <small>H=</small><strong>200</strong><small>mm</small>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.dimensions).toBe('H=200mm');
+    });
+
     it('should extract tags from Various field', () => {
       const html = `
         <div class="data-field">

--- a/src/services/companyArtistExtractor.ts
+++ b/src/services/companyArtistExtractor.ts
@@ -126,6 +126,43 @@ export function extractIndividualRoleEntries(
 }
 
 /**
+ * Normalize an MFC dimension label to a single canonical letter.
+ * Accepts abbreviations ("W=", "H=") and full words ("Width", "Height").
+ * Returns undefined for anything unrecognized so bogus values are skipped
+ * rather than fabricated into a height.
+ */
+function normalizeDimensionLabel(raw: string): string | undefined {
+  const key = raw.replace(/[^a-z]/gi, '').toLowerCase();
+  if (key === 'w' || key === 'width') return 'W';
+  if (key === 'h' || key === 'height') return 'H';
+  if (key === 'l' || key === 'length') return 'L';
+  if (key === 'd' || key === 'depth') return 'D';
+  return undefined;
+}
+
+/**
+ * Convert a dimension value to millimeters based on its unit label.
+ * MFC is overwhelmingly millimeters; centimeters and inches are handled for
+ * resilience. Unknown or empty units are assumed to already be millimeters.
+ */
+function toMillimeters(value: number, unit: string): number {
+  const u = unit.trim().toLowerCase();
+  if (u === 'cm') return value * 10;
+  if (u === 'in' || u === 'inch' || u === 'inches' || u === '"' || u === '″') {
+    return value * 25.4;
+  }
+  return value;
+}
+
+/**
+ * Format a numeric millimeter value for the dimensions string, dropping
+ * insignificant decimals (470 stays "470", 234.95 stays "234.95").
+ */
+function formatMillimeters(n: number): string {
+  return Number.isInteger(n) ? String(n) : String(Number(n.toFixed(2)));
+}
+
+/**
  * Extract a text value from a .data-value element based on the strategy.
  * Standalone helper that handles all MFC HTML structures for text fields.
  */
@@ -150,20 +187,28 @@ export function extractTextValue(
     if (catSpan.length > 0) return catSpan.text().trim();
   }
 
-  // Dimensions: scale + height sub-elements
+  // Dimensions: optional scale + one or more labeled dimension triples.
+  // Each dimension is <small>LABEL=</small><strong>value</strong><small>unit</small>
+  // (e.g. W=250mm, L=210mm, H=470mm). Every <strong> must be paired with its own
+  // preceding label and following unit; running .text() across all <strong>
+  // elements at once concatenates their digits into one bogus number
+  // (250 + 210 + 470 -> "250210470") that then gets mislabeled as height.
   if (strategy === 'dimensions-field') {
     const parts: string[] = [];
     // Scale: <a class="item-scale"><small>1/</small>6</a>
     const scaleLink = $dataValue.find('a.item-scale');
     if (scaleLink.length > 0) {
-      parts.push(scaleLink.text().trim());
+      const scale = scaleLink.text().trim();
+      if (scale) parts.push(scale);
     }
-    // Height: <small>H=</small><strong>260</strong><small>mm</small>
-    const heightStrong = $dataValue.find('strong');
-    if (heightStrong.length > 0) {
-      const height = heightStrong.text().trim();
-      parts.push(`H=${height}mm`);
-    }
+    $dataValue.find('strong').each((_, strongEl) => {
+      const $strong = $(strongEl);
+      const label = normalizeDimensionLabel($strong.prev('small').text());
+      const value = parseFloat($strong.text().trim());
+      if (!label || !Number.isFinite(value)) return;
+      const mm = toMillimeters(value, $strong.next('small').text());
+      parts.push(`${label}=${formatMillimeters(mm)}mm`);
+    });
     if (parts.length > 0) return parts.join(', ');
   }
 


### PR DESCRIPTION
Cheerio .text() on the multi-element strong selection silently concatenated all dimension digits (W250/L210/H470 -> 250210470 mislabeled as height). Walk each strong, read its own label/unit, emit labeled dims: 1/6, W=250mm, L=210mm, H=470mm. cm/in converted to mm. 10 new tests; 59/59 extractor, 740 unit pass, zero regression.