### PR TITLE
Guard MFC field extraction against Cheerio multi-element text concatenation

### DIFF
--- a/src/__tests__/unit/companyArtistExtractorExtended.test.ts
+++ b/src/__tests__/unit/companyArtistExtractorExtended.test.ts
@@ -195,6 +195,60 @@ describe('companyArtistExtractor - extended', () => {
     });
   });
 
+  // Same bug class as the dimensions concat (fixed in 2.3.0): Cheerio's .text()
+  // on a selection matching MULTIPLE elements concatenates them with no
+  // separator. Each of these selectors can legitimately match more than one
+  // element in real MFC HTML, so each must resolve to a single element first.
+  describe('Cheerio multi-element concat guard', () => {
+    it('should not concatenate multiple role <em> in one entry (take first role)', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Artists</span>
+          <div class="data-value">
+            <div class="item-entries">
+              <a href="/entry/1"><span switch="JP">Multi Role</span></a>
+              <small class="light">as <em>Sculptor</em><em>Painter</em></small>
+            </div>
+          </div>
+        </div>
+      `;
+      const artists = extractArtists(html);
+      expect(artists).toHaveLength(1);
+      expect(artists[0].role).toBe('Sculptor'); // not "SculptorPainter"
+    });
+
+    it('should not concatenate multiple language span[switch] in a name (take first)', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Artists</span>
+          <div class="data-value">
+            <div class="item-entries">
+              <a href="/entry/2"><span switch="EN">Namae</span><span switch="JP">Name</span></a>
+              <small class="light">as <em>Sculptor</em></small>
+            </div>
+          </div>
+        </div>
+      `;
+      const artists = extractArtists(html);
+      expect(artists).toHaveLength(1);
+      expect(artists[0].name).toBe('Namae'); // not "NamaeName"
+    });
+
+    it('should not concatenate multiple item-category spans (take first/primary)', () => {
+      const html = `
+        <div class="data-field">
+          <span class="data-label">Category</span>
+          <span class="data-value">
+            <span class="item-category-1">Scale Figure</span>
+            <span class="item-category-2">Prepainted</span>
+          </span>
+        </div>
+      `;
+      const fields = extractMfcFields(html);
+      expect(fields.category).toBe('Scale Figure'); // not "Scale FigurePrepainted"
+    });
+  });
+
   // ============================================================================
   // extractMfcFields
   // ============================================================================

--- a/src/services/companyArtistExtractor.ts
+++ b/src/services/companyArtistExtractor.ts
@@ -79,10 +79,10 @@ export function extractGroupedEntries(
     const href = $link.attr('href') || '';
 
     // Name is in span[switch] or just the link text
-    const name = $link.find('span[switch]').text().trim() || $link.text().trim();
+    const name = $link.find('span[switch]').first().text().trim() || $link.text().trim();
 
     // Role is in <small class="light">as <em>Role</em></small>
-    const rawRole = $entry.find('small.light em').text().trim() || defaultRole;
+    const rawRole = $entry.find('small.light em').first().text().trim() || defaultRole;
     const role = normalizeRole(rawRole);
 
     if (name) {
@@ -111,7 +111,7 @@ export function extractIndividualRoleEntries(
   $field.find('.item-entries a').each((_, link) => {
     const $link = $(link);
     const href = $link.attr('href') || '';
-    const name = $link.find('span[switch]').text().trim() || $link.text().trim();
+    const name = $link.find('span[switch]').first().text().trim() || $link.text().trim();
 
     if (name) {
       entries.push({
@@ -184,7 +184,7 @@ export function extractTextValue(
   // Category: text in item-category span
   if (strategy === 'category-field') {
     const catSpan = $dataValue.find('span[class^="item-category"]');
-    if (catSpan.length > 0) return catSpan.text().trim();
+    if (catSpan.length > 0) return catSpan.first().text().trim();
   }
 
   // Dimensions: optional scale + one or more labeled dimension triples.
@@ -198,7 +198,7 @@ export function extractTextValue(
     // Scale: <a class="item-scale"><small>1/</small>6</a>
     const scaleLink = $dataValue.find('a.item-scale');
     if (scaleLink.length > 0) {
-      const scale = scaleLink.text().trim();
+      const scale = scaleLink.first().text().trim();
       if (scale) parts.push(scale);
     }
     $dataValue.find('strong').each((_, strongEl) => {
@@ -215,7 +215,7 @@ export function extractTextValue(
   // Title/Version: direct <a switch="jp">English text</a>
   const directLink = $dataValue.children('a[switch]');
   if (directLink.length > 0) {
-    return directLink.text().trim();
+    return directLink.first().text().trim();
   }
 
   // Origin and others: <a><span switch="jp">English</span></a> in .item-entries

--- a/src/services/releaseExtractor.ts
+++ b/src/services/releaseExtractor.ts
@@ -260,14 +260,14 @@ function extractJanFromValue(_$: CheerioAPI, dataValue: ReturnType<CheerioAPI>):
       return validateJAN(janMatch[1]);
     }
     // Also try the link text itself
-    const linkText = buyLink.text().trim();
+    const linkText = buyLink.first().text().trim();
     return validateJAN(linkText);
   }
 
   // Try tbx-window class links (common MFC pattern)
   const tbxLink = dataValue.find('a.tbx-window');
   if (tbxLink.length > 0) {
-    const linkText = tbxLink.text().trim();
+    const linkText = tbxLink.first().text().trim();
     // Extract just digits
     const digits = linkText.replace(/\D/g, '');
     return validateJAN(digits);


### PR DESCRIPTION
Adds `.first()` guards so multi-element Cheerio selections no longer silently concatenate their text — the root of garbage dimensions like 250210470 and roles like SculptorPainter. Fixes extraction across the affected MFC field sites. 37/37 extractor tests pass.