### PR TITLE
Capture raw HTML + hash and emit on webhook behind PERSIST_RAW_HTML

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,10 @@ MFC_ALLOWED_COOKIES=PHPSESSID,sesUID,sesDID,cf_clearance
 # DEBUG=scraper:mfc
 # DEBUG=scraper:browser
 # SERVICE_AUTH_TOKEN_DEBUG=false
+
+# Raw HTML Capture (optional, default OFF)
+# When true, gzips the raw scraped page HTML and attaches rawHtmlGz (base64),
+# htmlSha (sha256 hex), and rawHtmlBytes to the item-complete webhook payload
+# for the backend to persist and reprocess. The scraper never writes this to
+# any store itself -- it only emits it on the webhook.
+# PERSIST_RAW_HTML=true

--- a/src/__tests__/unit/genericScraperExtended.test.ts
+++ b/src/__tests__/unit/genericScraperExtended.test.ts
@@ -4,6 +4,8 @@
  * scrapeMFC convenience function, and Cloudflare detection paths
  */
 import puppeteer from 'puppeteer';
+import zlib from 'zlib';
+import crypto from 'crypto';
 import {
   calculateSimilarity,
   getEditDistance,
@@ -616,5 +618,75 @@ describe('genericScraper - scrapeGeneric extended', () => {
     expect(result).toBeDefined();
     // Should NOT have called waitForFunction for Cloudflare (no challenge)
     expect(mockPage.waitForFunction).not.toHaveBeenCalled();
+  });
+
+  describe('raw HTML capture (PERSIST_RAW_HTML)', () => {
+    const originalEnv = process.env.PERSIST_RAW_HTML;
+    const html = '<html><body><div class="data-field">raw capture fixture</div></body></html>';
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.PERSIST_RAW_HTML;
+      } else {
+        process.env.PERSIST_RAW_HTML = originalEnv;
+      }
+    });
+
+    it('should emit rawHtmlGz/htmlSha/rawHtmlBytes when PERSIST_RAW_HTML=true', async () => {
+      process.env.PERSIST_RAW_HTML = 'true';
+      mockPage.content.mockResolvedValue(html);
+
+      const result = await scrapeGeneric('https://myfigurecollection.net/item/12345', {});
+
+      expect(result.rawHtmlGz).toBeDefined();
+      expect(typeof result.rawHtmlGz).toBe('string');
+      const gunzipped = zlib.gunzipSync(Buffer.from(result.rawHtmlGz as string, 'base64')).toString('utf-8');
+      expect(gunzipped).toBe(html);
+
+      const expectedSha = crypto.createHash('sha256').update(html, 'utf-8').digest('hex');
+      expect(result.htmlSha).toBe(expectedSha);
+
+      expect(result.rawHtmlBytes).toBe(Buffer.byteLength(html, 'utf-8'));
+    });
+
+    it('should omit rawHtmlGz/htmlSha/rawHtmlBytes when PERSIST_RAW_HTML is unset (default OFF)', async () => {
+      delete process.env.PERSIST_RAW_HTML;
+      mockPage.content.mockResolvedValue(html);
+
+      const result = await scrapeGeneric('https://myfigurecollection.net/item/12345', {});
+
+      expect(result.rawHtmlGz).toBeUndefined();
+      expect(result.htmlSha).toBeUndefined();
+      expect(result.rawHtmlBytes).toBeUndefined();
+    });
+
+    it('should omit rawHtmlGz/htmlSha/rawHtmlBytes when PERSIST_RAW_HTML=false', async () => {
+      process.env.PERSIST_RAW_HTML = 'false';
+      mockPage.content.mockResolvedValue(html);
+
+      const result = await scrapeGeneric('https://myfigurecollection.net/item/12345', {});
+
+      expect(result.rawHtmlGz).toBeUndefined();
+      expect(result.htmlSha).toBeUndefined();
+      expect(result.rawHtmlBytes).toBeUndefined();
+    });
+
+    it('should not fail the scrape when raw HTML capture throws', async () => {
+      process.env.PERSIST_RAW_HTML = 'true';
+      mockPage.content.mockResolvedValue(html);
+      const gzipSpy = jest.spyOn(zlib, 'gzipSync').mockImplementation(() => {
+        throw new Error('gzip failed');
+      });
+
+      const result = await scrapeGeneric('https://myfigurecollection.net/item/12345', {});
+
+      // Capture failure is non-fatal: scrape still succeeds without the raw HTML fields
+      expect(result).toBeDefined();
+      expect(result.rawHtmlGz).toBeUndefined();
+      expect(result.htmlSha).toBeUndefined();
+      expect(result.rawHtmlBytes).toBeUndefined();
+
+      gzipSpy.mockRestore();
+    });
   });
 });

--- a/src/__tests__/unit/scrapeQueueProcessing.test.ts
+++ b/src/__tests__/unit/scrapeQueueProcessing.test.ts
@@ -247,6 +247,31 @@ describe('ScrapeQueue - processing loop', () => {
     expect(mockNotifyItemSuccess).toHaveBeenCalledWith('session1', '12345', expect.any(Object));
   });
 
+  it('should pass raw HTML capture fields through to the item-complete webhook payload unmodified', async () => {
+    // Proves the queue threads scrapedData straight through to the webhook client without
+    // stripping fields -- so whatever genericScraper attaches (e.g. under PERSIST_RAW_HTML)
+    // reaches the backend on the item-complete webhook.
+    const scrapedData = {
+      name: 'Figure',
+      rawHtmlGz: 'base64gzipfixture==',
+      htmlSha: 'a'.repeat(64),
+      rawHtmlBytes: 1234,
+    };
+    mockScrapeMFC.mockResolvedValue(scrapedData);
+
+    queue = new ScrapeQueue(false);
+    const result = queue.enqueue('12345', {
+      priority: 'WARM',
+      sessionId: 'session1',
+    });
+
+    await advanceAndFlush(500);
+    await advanceAndFlush(3000);
+
+    await result.promise;
+    expect(mockNotifyItemSuccess).toHaveBeenCalledWith('session1', '12345', scrapedData);
+  });
+
   it('should call webhook on permanent failure for non-cookie session items', async () => {
     mockScrapeMFC.mockRejectedValue(new Error('AUTH: required'));
 

--- a/src/services/genericScraper.ts
+++ b/src/services/genericScraper.ts
@@ -1,4 +1,6 @@
 import puppeteer, { Browser, Page } from 'puppeteer';
+import zlib from 'zlib';
+import crypto from 'crypto';
 import { sanitizeForLog, isValidMfcUrl, capWaitTime, truncateString, MAX_STRING_LENGTH } from '../utils/security.js';
 import { ICompanyEntry, IArtistEntry, extractCompanies, extractArtists, extractMfcFields, extractRelatedItems } from './companyArtistExtractor.js';
 import { IRelease, extractReleases } from './releaseExtractor.js';
@@ -26,6 +28,11 @@ export interface ScrapedData {
   dimensions?: string;      // e.g., "1/6, H=260mm"
   jan?: string;             // JAN/UPC barcode
   tags?: string[];          // Various tags (e.g., "18+", "Castoff", "Limited")
+  // Raw HTML capture (only populated when PERSIST_RAW_HTML=true; scraper never persists
+  // this itself, it is only emitted on the item-complete webhook for the backend to store)
+  rawHtmlGz?: string;       // Base64-encoded gzip of the raw page HTML at scrape time
+  htmlSha?: string;         // SHA-256 hex digest of the raw (uncompressed) page HTML
+  rawHtmlBytes?: number;    // Byte length of the raw (uncompressed) page HTML
   [key: string]: any;       // Allow additional fields
 }
 
@@ -928,6 +935,23 @@ export async function scrapeGeneric(url: string, config: ScrapeConfig): Promise<
     // This runs in Node.js context using cheerio, not in browser
     try {
       const pageHtml = await page.content();
+
+      // Optional raw HTML capture (enabled via PERSIST_RAW_HTML=true env var).
+      // Default OFF: zero overhead, no extra fields on the payload.
+      // The scraper only EMITS these fields on the item-complete webhook -- it never
+      // writes them to any store itself (no S3/MinIO creds live in this service).
+      if (process.env.PERSIST_RAW_HTML === 'true') {
+        try {
+          const htmlBuffer = Buffer.from(pageHtml, 'utf-8');
+          scrapedData.rawHtmlGz = zlib.gzipSync(htmlBuffer).toString('base64');
+          scrapedData.htmlSha = crypto.createHash('sha256').update(htmlBuffer).digest('hex');
+          scrapedData.rawHtmlBytes = htmlBuffer.byteLength;
+        } catch (rawHtmlError) {
+          console.error('[GENERIC SCRAPER] Raw HTML capture failed:', rawHtmlError);
+          // Don't fail the scrape - just continue without raw HTML capture
+        }
+      }
+
       const companies = extractCompanies(pageHtml);
       const artists = extractArtists(pageHtml);
 


### PR DESCRIPTION
Env-gated (PERSIST_RAW_HTML, default off) capture of gzipped raw page HTML + sha256 + byte length, attached to the item-complete webhook payload. The scraper writes to no store — the backend persists. 787 tests pass, tsc clean.