### PR TITLE
Add generic plugin-loading seam (loader, registry, engine-service adapters, bootstrap)

### DIFF
--- a/src/__tests__/fixtures/plugins/@mockscope/scoped-ruleset/index.js
+++ b/src/__tests__/fixtures/plugins/@mockscope/scoped-ruleset/index.js
@@ -1,0 +1,11 @@
+/**
+ * Fixture: a valid plugin published under a scoped package name, to prove
+ * the loader recurses into @scope/* directories under node_modules.
+ */
+module.exports = {
+  name: '@mockscope/scoped-ruleset',
+  version: '2.0.0',
+  async register(registry, context) {
+    context.logger.info('scoped mock plugin registered');
+  },
+};

--- a/src/__tests__/fixtures/plugins/@mockscope/scoped-ruleset/package.json
+++ b/src/__tests__/fixtures/plugins/@mockscope/scoped-ruleset/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@mockscope/scoped-ruleset",
+  "version": "1.0.0",
+  "main": "index.js",
+  "keywords": ["scraper-ruleset"]
+}

--- a/src/__tests__/fixtures/plugins/broken-plugin/index.js
+++ b/src/__tests__/fixtures/plugins/broken-plugin/index.js
@@ -1,0 +1,10 @@
+/**
+ * Fixture: advertises the "scraper-ruleset" keyword but does NOT implement
+ * the ScraperPlugin contract (no register function). Used to prove the
+ * loader's type guard rejects malformed packages instead of crashing.
+ */
+module.exports = {
+  name: 'broken-plugin',
+  version: '1.0.0',
+  // register intentionally omitted
+};

--- a/src/__tests__/fixtures/plugins/broken-plugin/package.json
+++ b/src/__tests__/fixtures/plugins/broken-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "broken-plugin",
+  "version": "1.0.0",
+  "main": "index.js",
+  "keywords": ["scraper-ruleset"]
+}

--- a/src/__tests__/fixtures/plugins/missing-entry-plugin/package.json
+++ b/src/__tests__/fixtures/plugins/missing-entry-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "missing-entry-plugin",
+  "version": "1.0.0",
+  "main": "does-not-exist.js",
+  "keywords": ["scraper-ruleset"]
+}

--- a/src/__tests__/fixtures/plugins/mock-scraper-ruleset/index.js
+++ b/src/__tests__/fixtures/plugins/mock-scraper-ruleset/index.js
@@ -1,0 +1,55 @@
+/**
+ * Fixture: a well-formed mock ScraperPlugin used by pluginLoader.test.ts and
+ * pluginBootstrap.test.ts. Deliberately plain CommonJS (no site-specific
+ * logic) so it can stand in for any real plugin package.
+ */
+module.exports = {
+  name: 'mock-scraper-ruleset',
+  version: '1.0.0',
+
+  async register(registry, context) {
+    context.logger.info('mock plugin registered');
+
+    registry.registerSite({
+      siteId: 'mock',
+      name: 'Mock Site',
+      domains: ['mock.example.test'],
+      rateLimit: {
+        domain: 'mock.example.test',
+        baseDelayMs: 1000,
+        minDelayMs: 500,
+        maxDelayMs: 5000,
+        backoffMultiplier: 1.5,
+        recoveryDivisor: 1.5,
+        successThreshold: 3,
+      },
+      requiresBrowser: false,
+      allowedCookies: [],
+    });
+
+    registry.registerRuleset({
+      siteId: 'mock',
+      version: '1.0.0',
+      extract(html, url) {
+        return {
+          source: { site: 'mock', itemId: '1', url, extractedAt: new Date(), rulesetVersion: '1.0.0' },
+          fields: {},
+          warnings: [],
+        };
+      },
+      validate() {
+        return { valid: true, errors: [], warnings: [] };
+      },
+    });
+  },
+
+  registerRoutes(router) {
+    router.get('/mock/ping', (req, res) => {
+      res.json({ ok: true, plugin: 'mock-scraper-ruleset' });
+    });
+  },
+
+  async shutdown() {
+    // no-op; presence is what integration tests assert on
+  },
+};

--- a/src/__tests__/fixtures/plugins/mock-scraper-ruleset/package.json
+++ b/src/__tests__/fixtures/plugins/mock-scraper-ruleset/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mock-scraper-ruleset",
+  "version": "1.0.0",
+  "main": "index.js",
+  "keywords": ["scraper-ruleset"]
+}

--- a/src/__tests__/fixtures/plugins/not-a-ruleset/index.js
+++ b/src/__tests__/fixtures/plugins/not-a-ruleset/index.js
@@ -1,0 +1,6 @@
+/**
+ * Fixture: an ordinary package with NO "scraper-ruleset" keyword. This file
+ * throws if it is ever imported, so pluginLoader.test.ts can prove the
+ * loader filters on the keyword before importing anything.
+ */
+throw new Error('not-a-ruleset should never be imported by the plugin loader');

--- a/src/__tests__/fixtures/plugins/not-a-ruleset/package.json
+++ b/src/__tests__/fixtures/plugins/not-a-ruleset/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "not-a-ruleset",
+  "version": "1.0.0",
+  "main": "index.js",
+  "keywords": ["some-other-keyword"]
+}

--- a/src/__tests__/integration/pluginBootstrap.test.ts
+++ b/src/__tests__/integration/pluginBootstrap.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration test for the plugin bootstrap seam: discovers/registers
+ * plugins against a real Express app and asserts a mock plugin's routes
+ * actually mount and respond, and that shutdown hooks are wired correctly.
+ */
+import path from 'path';
+import request from 'supertest';
+import express from 'express';
+import { jest } from '@jest/globals';
+import { bootstrapPlugins, shutdownPlugins } from '../../services/pluginBootstrap';
+import { ScraperPlugin, ExtractionRegistry, PluginContext, ExpressRouter } from '../../services/pluginTypes';
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'plugins');
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  return app;
+}
+
+function buildSpyPlugin(overrides: Partial<ScraperPlugin> = {}): ScraperPlugin {
+  return {
+    name: 'spy-plugin',
+    version: '1.0.0',
+    register: jest.fn<ScraperPlugin['register']>().mockResolvedValue(undefined),
+    registerRoutes: jest.fn<NonNullable<ScraperPlugin['registerRoutes']>>(),
+    shutdown: jest.fn<NonNullable<ScraperPlugin['shutdown']>>().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('bootstrapPlugins', () => {
+  it('discovers a real plugin package via node_modules keyword scan and mounts its routes', async () => {
+    const app = buildApp();
+
+    const { plugins } = await bootstrapPlugins(app, { nodeModulesDir: FIXTURES_DIR });
+
+    expect(plugins.map(p => p.name)).toContain('mock-scraper-ruleset');
+
+    const response = await request(app).get('/mock/ping');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true, plugin: 'mock-scraper-ruleset' });
+  });
+
+  it('registers the plugin-provided site into the shared ExtractionRegistry', async () => {
+    const app = buildApp();
+
+    const { registry } = await bootstrapPlugins(app, { nodeModulesDir: FIXTURES_DIR });
+
+    expect(registry.getSiteConfigForUrl('https://mock.example.test/item/1')?.siteId).toBe('mock');
+    expect(registry.getRulesetForUrl('https://mock.example.test/item/1')?.siteId).toBe('mock');
+  });
+
+  it('calls register() with a PluginContext exposing logger/config/services', async () => {
+    const app = buildApp();
+    const plugin = buildSpyPlugin();
+
+    await bootstrapPlugins(app, { discover: async () => [plugin] });
+
+    expect(plugin.register).toHaveBeenCalledTimes(1);
+    const [registry, context] = (plugin.register as jest.Mock).mock.calls[0] as [ExtractionRegistry, PluginContext];
+
+    expect(typeof registry.registerSite).toBe('function');
+    expect(typeof registry.registerRuleset).toBe('function');
+
+    expect(typeof context.logger.info).toBe('function');
+    expect(typeof context.logger.warn).toBe('function');
+    expect(typeof context.logger.error).toBe('function');
+    expect(typeof context.logger.debug).toBe('function');
+
+    expect(typeof context.config.get).toBe('function');
+    expect(typeof context.config.getFeatureFlag).toBe('function');
+
+    expect(typeof context.services.scraping.scrapePage).toBe('function');
+    expect(typeof context.services.queue.enqueue).toBe('function');
+    expect(typeof context.services.sessions.getAllSessions).toBe('function');
+    expect(typeof context.services.webhooks.notifyItemComplete).toBe('function');
+  });
+
+  it('calls registerRoutes() with a router that gets mounted on the app', async () => {
+    const app = buildApp();
+    const plugin = buildSpyPlugin({
+      registerRoutes: jest.fn((router: ExpressRouter) => {
+        router.get('/spy/hello', (req: any, res: any) => res.json({ hello: 'spy' }));
+      }),
+    });
+
+    await bootstrapPlugins(app, { discover: async () => [plugin] });
+
+    expect(plugin.registerRoutes).toHaveBeenCalledTimes(1);
+    const response = await request(app).get('/spy/hello');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ hello: 'spy' });
+  });
+
+  it('does not fail bootstrap when a plugin has no registerRoutes or shutdown', async () => {
+    const app = buildApp();
+    const minimalPlugin: ScraperPlugin = {
+      name: 'minimal-plugin',
+      version: '1.0.0',
+      register: jest.fn<ScraperPlugin['register']>().mockResolvedValue(undefined),
+    };
+
+    const { plugins } = await bootstrapPlugins(app, { discover: async () => [minimalPlugin] });
+
+    expect(plugins).toHaveLength(1);
+  });
+
+  it('skips (does not throw for) a plugin whose register() rejects, and still loads the rest', async () => {
+    const app = buildApp();
+    const failingPlugin = buildSpyPlugin({
+      name: 'failing-plugin',
+      register: jest.fn<ScraperPlugin['register']>().mockRejectedValue(new Error('boom')),
+    });
+    const healthyPlugin = buildSpyPlugin({ name: 'healthy-plugin' });
+
+    const { plugins } = await bootstrapPlugins(app, { discover: async () => [failingPlugin, healthyPlugin] });
+
+    expect(plugins.map(p => p.name)).toEqual(['healthy-plugin']);
+  });
+
+  it('shutdownPlugins calls shutdown() on every loaded plugin', async () => {
+    const pluginA = buildSpyPlugin({ name: 'a' });
+    const pluginB = buildSpyPlugin({ name: 'b' });
+
+    await shutdownPlugins([pluginA, pluginB]);
+
+    expect(pluginA.shutdown).toHaveBeenCalledTimes(1);
+    expect(pluginB.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('shutdownPlugins tolerates one plugin rejecting and still shuts down the others', async () => {
+    const pluginA = buildSpyPlugin({
+      name: 'a',
+      shutdown: jest.fn<NonNullable<ScraperPlugin['shutdown']>>().mockRejectedValue(new Error('shutdown failed')),
+    });
+    const pluginB = buildSpyPlugin({ name: 'b' });
+
+    await expect(shutdownPlugins([pluginA, pluginB])).resolves.not.toThrow();
+    expect(pluginB.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('shutdownPlugins skips plugins with no shutdown() without error', async () => {
+    const minimalPlugin: ScraperPlugin = {
+      name: 'minimal-plugin',
+      version: '1.0.0',
+      register: jest.fn<ScraperPlugin['register']>().mockResolvedValue(undefined),
+    };
+
+    await expect(shutdownPlugins([minimalPlugin])).resolves.not.toThrow();
+  });
+});

--- a/src/__tests__/unit/engineServices/pluginLogger.test.ts
+++ b/src/__tests__/unit/engineServices/pluginLogger.test.ts
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { logger } from '../../../utils/logger';
+import { createPluginLogger } from '../../../services/engineServices/pluginLogger';
+
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+describe('createPluginLogger', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefixes info messages with the plugin namespace', () => {
+    const pluginLogger = createPluginLogger('plugin:mock-scraper-ruleset');
+    pluginLogger.info('registered', { siteCount: 1 });
+
+    expect(mockedLogger.info).toHaveBeenCalledWith('[plugin:mock-scraper-ruleset] registered', { siteCount: 1 });
+  });
+
+  it('prefixes warn messages with the plugin namespace', () => {
+    const pluginLogger = createPluginLogger('plugin:mock-scraper-ruleset');
+    pluginLogger.warn('slow response');
+
+    expect(mockedLogger.warn).toHaveBeenCalledWith('[plugin:mock-scraper-ruleset] slow response', undefined);
+  });
+
+  it('prefixes error messages with the plugin namespace', () => {
+    const pluginLogger = createPluginLogger('plugin:mock-scraper-ruleset');
+    pluginLogger.error('failed', { code: 'E_TIMEOUT' });
+
+    expect(mockedLogger.error).toHaveBeenCalledWith('[plugin:mock-scraper-ruleset] failed', { code: 'E_TIMEOUT' });
+  });
+
+  it('routes debug messages through the namespaced debug channel', () => {
+    const pluginLogger = createPluginLogger('plugin:mock-scraper-ruleset');
+    pluginLogger.debug('verbose detail', { step: 1 });
+
+    expect(mockedLogger.debug).toHaveBeenCalledWith('plugin:mock-scraper-ruleset', 'verbose detail', { step: 1 });
+  });
+});

--- a/src/__tests__/unit/engineServices/queueService.test.ts
+++ b/src/__tests__/unit/engineServices/queueService.test.ts
@@ -1,0 +1,105 @@
+import { jest } from '@jest/globals';
+import { createQueueService } from '../../../services/engineServices/queueService';
+
+function buildFakeQueue() {
+  return {
+    enqueue: jest.fn(),
+    enqueueBulk: jest.fn(),
+    getStats: jest.fn(),
+    resumeSession: jest.fn(),
+    cancelFailedItems: jest.fn(),
+    cancelAllForSession: jest.fn(),
+    clear: jest.fn(),
+  };
+}
+
+describe('createQueueService', () => {
+  it('maps enqueue() id -> itemId and forwards options', () => {
+    const queue = buildFakeQueue();
+    const promise = Promise.resolve({});
+    queue.enqueue.mockReturnValue({ id: 'item-123', deduplicated: false, position: 2, promise });
+
+    const service = createQueueService(queue as any);
+    const result = service.enqueue('item-123', { priority: 'HOT' });
+
+    expect(queue.enqueue).toHaveBeenCalledWith('item-123', { priority: 'HOT' });
+    expect(result).toEqual({ itemId: 'item-123', deduplicated: false, position: 2 });
+  });
+
+  it('never leaks an unhandled rejection when the underlying promise rejects', async () => {
+    const queue = buildFakeQueue();
+    queue.enqueue.mockReturnValue({
+      id: 'item-1',
+      deduplicated: false,
+      position: 0,
+      promise: Promise.reject(new Error('scrape failed')),
+    });
+
+    const service = createQueueService(queue as any);
+    expect(() => service.enqueue('item-1')).not.toThrow();
+
+    // Flush microtasks; if the adapter did not attach a .catch, this test
+    // process would surface an unhandledRejection.
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
+  it('maps enqueueBulk() items and results', () => {
+    const queue = buildFakeQueue();
+    queue.enqueueBulk.mockReturnValue([
+      { id: 'a', deduplicated: false, position: 0, promise: Promise.resolve({}) },
+      { id: 'b', deduplicated: true, position: 1, promise: Promise.resolve({}) },
+    ]);
+
+    const service = createQueueService(queue as any);
+    const results = service.enqueueBulk([
+      { itemId: 'a', options: { priority: 'WARM' } },
+      { itemId: 'b' },
+    ]);
+
+    expect(queue.enqueueBulk).toHaveBeenCalledWith([
+      { mfcId: 'a', priority: 'WARM' },
+      { mfcId: 'b' },
+    ]);
+    expect(results).toEqual([
+      { itemId: 'a', deduplicated: false, position: 0 },
+      { itemId: 'b', deduplicated: true, position: 1 },
+    ]);
+  });
+
+  it('passes getStats() through unchanged', () => {
+    const queue = buildFakeQueue();
+    const stats = {
+      hot: 1, warm: 2, cold: 3, total: 6, processing: 1,
+      completed: 10, failed: 0, rateLimited: false, currentDelay: 500,
+    };
+    queue.getStats.mockReturnValue(stats);
+
+    const service = createQueueService(queue as any);
+    expect(service.getStats()).toEqual(stats);
+  });
+
+  it('forwards resumeSession/cancelFailedItems/cancelAllForSession', () => {
+    const queue = buildFakeQueue();
+    queue.resumeSession.mockReturnValue(true);
+    queue.cancelFailedItems.mockReturnValue(3);
+    queue.cancelAllForSession.mockReturnValue(5);
+
+    const service = createQueueService(queue as any);
+
+    expect(service.resumeSession('sess-1')).toBe(true);
+    expect(service.cancelFailedItems('sess-1')).toBe(3);
+    expect(service.cancelAllForSession('sess-1')).toBe(5);
+    expect(queue.resumeSession).toHaveBeenCalledWith('sess-1');
+    expect(queue.cancelFailedItems).toHaveBeenCalledWith('sess-1');
+    expect(queue.cancelAllForSession).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('maps reset() to the legacy queue.clear()', () => {
+    const queue = buildFakeQueue();
+    const service = createQueueService(queue as any);
+
+    service.reset?.();
+
+    expect(queue.clear).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/engineServices/runtimeConfig.test.ts
+++ b/src/__tests__/unit/engineServices/runtimeConfig.test.ts
@@ -1,0 +1,48 @@
+import { createRuntimeConfig } from '../../../services/engineServices/runtimeConfig';
+
+describe('createRuntimeConfig (env-backed RuntimeConfig)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns undefined for a key with no matching env var', () => {
+    const config = createRuntimeConfig();
+    expect(config.get('vndb.apiToken')).toBeUndefined();
+  });
+
+  it('reads a dotted key from the uppercased, underscored env var', () => {
+    process.env.VNDB_APITOKEN = 'shh';
+    const config = createRuntimeConfig();
+    expect(config.get('vndb.apiToken')).toBe('shh');
+  });
+
+  it('JSON-parses env values that are valid JSON (booleans/numbers)', () => {
+    process.env.SOME_FLAG = 'true';
+    process.env.SOME_LIMIT = '42';
+    const config = createRuntimeConfig();
+    expect(config.get('some.flag')).toBe(true);
+    expect(config.get('some.limit')).toBe(42);
+  });
+
+  it('falls back to the raw string when the env value is not valid JSON', () => {
+    process.env.SOME_NAME = 'not-json-just-text';
+    const config = createRuntimeConfig();
+    expect(config.get('some.name')).toBe('not-json-just-text');
+  });
+
+  it('getFeatureFlag returns true only when the env var is exactly "true"', () => {
+    process.env.FEATURE_MFC_STEALTH = 'true';
+    process.env.FEATURE_MFC_LEGACY = 'false';
+    const config = createRuntimeConfig();
+
+    expect(config.getFeatureFlag('mfc', 'stealth')).toBe(true);
+    expect(config.getFeatureFlag('mfc', 'legacy')).toBe(false);
+  });
+
+  it('getFeatureFlag returns false when the flag env var is unset', () => {
+    const config = createRuntimeConfig();
+    expect(config.getFeatureFlag('unknownsite', 'unknownfeature')).toBe(false);
+  });
+});

--- a/src/__tests__/unit/engineServices/scrapingService.test.ts
+++ b/src/__tests__/unit/engineServices/scrapingService.test.ts
@@ -1,0 +1,157 @@
+import { jest } from '@jest/globals';
+import puppeteer from 'puppeteer';
+import type { Page, Browser } from 'puppeteer';
+import { BrowserPool } from '../../../services/genericScraper';
+import { createScrapingService } from '../../../services/engineServices/scrapingService';
+
+describe('createScrapingService', () => {
+  let mockPage: jest.Mocked<Page>;
+  let mockBrowser: jest.Mocked<Browser>;
+  let mockContext: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await BrowserPool.reset();
+    (BrowserPool as any).stealthBrowser = null;
+
+    mockPage = {
+      goto: jest.fn<(...args: any[]) => any>().mockResolvedValue({ status: () => 200 }),
+      title: jest.fn<(...args: any[]) => any>().mockResolvedValue('Mock Page Title'),
+      content: jest.fn<(...args: any[]) => any>().mockResolvedValue('<html><body>mock</body></html>'),
+      evaluate: jest.fn<(...args: any[]) => any>().mockResolvedValue('mock body text'),
+      setViewport: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+      setUserAgent: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+      setCookie: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+      close: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Page>;
+
+    mockContext = {
+      newPage: jest.fn<(...args: any[]) => any>().mockResolvedValue(mockPage),
+      close: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+    };
+
+    mockBrowser = {
+      newPage: jest.fn<(...args: any[]) => any>().mockResolvedValue(mockPage),
+      close: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+      connected: true,
+      createBrowserContext: jest.fn<(...args: any[]) => any>().mockResolvedValue(mockContext),
+    } as unknown as jest.Mocked<Browser>;
+
+    jest.mocked(puppeteer.launch).mockClear();
+    jest.mocked(puppeteer.launch).mockResolvedValue(mockBrowser);
+  });
+
+  it('scrapePage navigates a pooled browser and returns html/title/url/statusCode', async () => {
+    const service = createScrapingService();
+
+    const result = await service.scrapePage('https://alpha.example.test/item/1');
+
+    expect(mockPage.goto).toHaveBeenCalledWith(
+      'https://alpha.example.test/item/1',
+      expect.objectContaining({ waitUntil: 'domcontentloaded' })
+    );
+    expect(result).toEqual({
+      html: '<html><body>mock</body></html>',
+      url: 'https://alpha.example.test/item/1',
+      title: 'Mock Page Title',
+      statusCode: 200,
+    });
+  });
+
+  it('scrapePage returns the browser to the pool after use', async () => {
+    const service = createScrapingService();
+    await service.scrapePage('https://alpha.example.test/item/1');
+
+    expect(BrowserPool.getPoolSize()).toBe(BrowserPool.getPoolCapacity());
+    expect(mockContext.close).toHaveBeenCalled();
+  });
+
+  it('scrapePage sets cookies scoped to the request domain when provided', async () => {
+    const service = createScrapingService();
+
+    await service.scrapePage('https://alpha.example.test/item/1', {
+      cookies: { session: 'abc123' },
+    });
+
+    expect(mockPage.setCookie).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'session', value: 'abc123', domain: '.alpha.example.test' })
+    );
+  });
+
+  it('scrapePageStealth uses the stealth browser, not the pooled one', async () => {
+    const service = createScrapingService();
+
+    await service.scrapePageStealth('https://alpha.example.test/item/1');
+
+    // Stealth browser is a singleton, never returned to the regular pool.
+    expect(BrowserPool.getPoolSize()).toBe(0);
+  });
+
+  it('withBrowser hands the caller a raw browser and returns it to the pool afterward', async () => {
+    const service = createScrapingService();
+    const seen: Browser[] = [];
+
+    const result = await service.withBrowser(async (browser: Browser) => {
+      seen.push(browser);
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(seen).toHaveLength(1);
+    expect(BrowserPool.getPoolSize()).toBe(BrowserPool.getPoolCapacity());
+  });
+
+  it('withPage hands the caller a managed page and cleans up the context', async () => {
+    const service = createScrapingService();
+
+    const title = await service.withPage(async (page: Page) => page.title());
+
+    expect(title).toBe('Mock Page Title');
+    expect(mockContext.close).toHaveBeenCalled();
+  });
+
+  it('withPage applies a custom viewport and user agent when provided', async () => {
+    const service = createScrapingService();
+
+    await service.withPage(async (page: Page) => page.title(), {
+      viewport: { width: 800, height: 600 },
+      userAgent: 'CustomUA/1.0',
+    });
+
+    expect(mockPage.setViewport).toHaveBeenCalledWith({ width: 800, height: 600 });
+    expect(mockPage.setUserAgent).toHaveBeenCalledWith('CustomUA/1.0');
+  });
+
+  it('waits for the configured waitTime after navigation', async () => {
+    const service = createScrapingService();
+    const start = Date.now();
+
+    await service.scrapePage('https://alpha.example.test/item/1', { waitTime: 50 });
+
+    expect(Date.now() - start).toBeGreaterThanOrEqual(45);
+  });
+
+  it('waits an extra beat when a Cloudflare-style challenge is detected in title/body', async () => {
+    mockPage.title.mockResolvedValue('Just a moment...');
+    mockPage.evaluate.mockResolvedValue('checking your browser before accessing');
+
+    const service = createScrapingService();
+    const result = await service.scrapePage('https://alpha.example.test/item/1', {
+      cloudflareDetection: { titleIncludes: ['Just a moment'], bodyIncludes: ['checking your browser'] },
+    });
+
+    expect(result.title).toBe('Just a moment...');
+  });
+
+  it('does not wait extra when cloudflareDetection is configured but no challenge matches', async () => {
+    mockPage.title.mockResolvedValue('Ordinary Page');
+    mockPage.evaluate.mockResolvedValue('nothing suspicious here');
+
+    const service = createScrapingService();
+    const result = await service.scrapePage('https://alpha.example.test/item/1', {
+      cloudflareDetection: { titleIncludes: ['Just a moment'] },
+    });
+
+    expect(result.title).toBe('Ordinary Page');
+  });
+});

--- a/src/__tests__/unit/engineServices/sessionService.test.ts
+++ b/src/__tests__/unit/engineServices/sessionService.test.ts
@@ -1,0 +1,67 @@
+import { jest } from '@jest/globals';
+import { createSessionService } from '../../../services/engineServices/sessionService';
+
+function buildFakeSessionManager() {
+  return {
+    getAllSessions: jest.fn(),
+    reportCookieFailure: jest.fn(),
+  };
+}
+
+describe('createSessionService', () => {
+  it('maps legacy session fields to the generic SessionInfo shape', () => {
+    const sessionManager = buildFakeSessionManager();
+    sessionManager.getAllSessions.mockReturnValue([
+      {
+        sessionId: 'sess-1',
+        isPaused: true,
+        consecutiveFailures: 3,
+        failedMfcIds: ['1', '2'],
+        inCooldown: false,
+        cooldownRemainingMs: 0,
+      },
+    ]);
+
+    const service = createSessionService(sessionManager as any);
+    const sessions = service.getAllSessions();
+
+    expect(sessions).toEqual([
+      {
+        sessionId: 'sess-1',
+        isPaused: true,
+        inCooldown: false,
+        failureCount: 3,
+        totalItems: 0,
+        processedItems: 0,
+      },
+    ]);
+  });
+
+  it('validateSession returns true only for a known sessionId', () => {
+    const sessionManager = buildFakeSessionManager();
+    sessionManager.getAllSessions.mockReturnValue([
+      { sessionId: 'known', isPaused: false, consecutiveFailures: 0, failedMfcIds: [], inCooldown: false, cooldownRemainingMs: 0 },
+    ]);
+
+    const service = createSessionService(sessionManager as any);
+
+    expect(service.validateSession('known')).toBe(true);
+    expect(service.validateSession('unknown')).toBe(false);
+  });
+
+  it('reportPause does not throw and does not require a mock session manager call', () => {
+    const sessionManager = buildFakeSessionManager();
+    const service = createSessionService(sessionManager as any);
+
+    expect(() => service.reportPause('sess-1', 'plugin-detected pause')).not.toThrow();
+  });
+
+  it('reportFailure forwards to the legacy reportCookieFailure', () => {
+    const sessionManager = buildFakeSessionManager();
+    const service = createSessionService(sessionManager as any);
+
+    service.reportFailure('sess-1', 'item-42', 'timeout');
+
+    expect(sessionManager.reportCookieFailure).toHaveBeenCalledWith('sess-1', 'item-42', 'plugin', 0);
+  });
+});

--- a/src/__tests__/unit/engineServices/webhookService.test.ts
+++ b/src/__tests__/unit/engineServices/webhookService.test.ts
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../../../services/webhookClient');
+
+import * as webhookClient from '../../../services/webhookClient';
+import { createWebhookService } from '../../../services/engineServices/webhookService';
+
+const mocked = webhookClient as jest.Mocked<typeof webhookClient>;
+
+describe('createWebhookService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards registerConfig to webhookClient.registerWebhookConfig', () => {
+    const service = createWebhookService();
+    const config = { webhookUrl: 'https://backend.test/hook', webhookSecret: 's3cret', sessionId: 'sess-1' };
+
+    service.registerConfig(config);
+
+    expect(mocked.registerWebhookConfig).toHaveBeenCalledWith(config);
+  });
+
+  it('forwards unregisterConfig to webhookClient.unregisterWebhookConfig', () => {
+    const service = createWebhookService();
+
+    service.unregisterConfig('sess-1');
+
+    expect(mocked.unregisterWebhookConfig).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('forwards notifyItemComplete and returns its resolved value', async () => {
+    mocked.notifyItemComplete.mockResolvedValue(true);
+    const service = createWebhookService();
+    const payload = { sessionId: 'sess-1', mfcId: '42', status: 'completed' as const };
+
+    const result = await service.notifyItemComplete(payload);
+
+    expect(mocked.notifyItemComplete).toHaveBeenCalledWith(payload);
+    expect(result).toBe(true);
+  });
+
+  it('forwards notifyPhaseChange and returns its resolved value', async () => {
+    mocked.notifyPhaseChange.mockResolvedValue(false);
+    const service = createWebhookService();
+    const payload = { sessionId: 'sess-1', phase: 'enriching' };
+
+    const result = await service.notifyPhaseChange(payload);
+
+    expect(mocked.notifyPhaseChange).toHaveBeenCalledWith(payload);
+    expect(result).toBe(false);
+  });
+
+  it('forwards notifyListsSync and returns its resolved value', async () => {
+    mocked.notifyListsSync.mockResolvedValue(true);
+    const service = createWebhookService();
+    const payload = { sessionId: 'sess-1', lists: [] };
+
+    const result = await service.notifyListsSync(payload);
+
+    expect(mocked.notifyListsSync).toHaveBeenCalledWith(payload);
+    expect(result).toBe(true);
+  });
+});

--- a/src/__tests__/unit/extractionRegistry.test.ts
+++ b/src/__tests__/unit/extractionRegistry.test.ts
@@ -1,0 +1,112 @@
+import { createExtractionRegistry } from '../../services/extractionRegistry';
+import { SiteConfig, ExtractionRuleset, ExtractedData, ValidationResult } from '../../services/pluginTypes';
+
+function buildSiteConfig(overrides: Partial<SiteConfig> = {}): SiteConfig {
+  return {
+    siteId: 'alpha',
+    name: 'Alpha Site',
+    domains: ['alpha.example.test', 'www.alpha.example.test'],
+    rateLimit: {
+      domain: 'alpha.example.test',
+      baseDelayMs: 1000,
+      minDelayMs: 500,
+      maxDelayMs: 5000,
+      backoffMultiplier: 1.5,
+      recoveryDivisor: 1.5,
+      successThreshold: 3,
+    },
+    requiresBrowser: false,
+    allowedCookies: [],
+    ...overrides,
+  };
+}
+
+function buildRuleset(siteId: string): ExtractionRuleset {
+  return {
+    siteId,
+    version: '1.0.0',
+    extract(html: string, url: string): ExtractedData {
+      return {
+        source: { site: siteId, itemId: '1', url, extractedAt: new Date(), rulesetVersion: '1.0.0' },
+        fields: { html },
+        warnings: [],
+      };
+    },
+    validate(): ValidationResult {
+      return { valid: true, errors: [], warnings: [] };
+    },
+  };
+}
+
+describe('ExtractionRegistry', () => {
+  it('resolves a site config by exact hostname', () => {
+    const registry = createExtractionRegistry();
+    registry.registerSite(buildSiteConfig());
+
+    const config = registry.getSiteConfigForUrl('https://alpha.example.test/item/1');
+    expect(config?.siteId).toBe('alpha');
+  });
+
+  it('resolves a site config for a registered subdomain-style host', () => {
+    const registry = createExtractionRegistry();
+    registry.registerSite(buildSiteConfig());
+
+    const config = registry.getSiteConfigForUrl('https://www.alpha.example.test/item/1');
+    expect(config?.siteId).toBe('alpha');
+  });
+
+  it('matches hostnames case-insensitively', () => {
+    const registry = createExtractionRegistry();
+    registry.registerSite(buildSiteConfig());
+
+    const config = registry.getSiteConfigForUrl('https://ALPHA.EXAMPLE.TEST/item/1');
+    expect(config?.siteId).toBe('alpha');
+  });
+
+  it('returns undefined for an unregistered hostname', () => {
+    const registry = createExtractionRegistry();
+    registry.registerSite(buildSiteConfig());
+
+    expect(registry.getSiteConfigForUrl('https://unregistered.example.test/item/1')).toBeUndefined();
+  });
+
+  it('resolves the ruleset registered for the same siteId as the matched hostname', () => {
+    const registry = createExtractionRegistry();
+    registry.registerSite(buildSiteConfig());
+    registry.registerRuleset(buildRuleset('alpha'));
+
+    const ruleset = registry.getRulesetForUrl('https://alpha.example.test/item/42');
+    expect(ruleset?.siteId).toBe('alpha');
+
+    const extracted = ruleset!.extract('<html></html>', 'https://alpha.example.test/item/42');
+    expect(extracted.source.site).toBe('alpha');
+  });
+
+  it('returns undefined from getRulesetForUrl when no site matches the hostname', () => {
+    const registry = createExtractionRegistry();
+    expect(registry.getRulesetForUrl('https://nowhere.example.test/x')).toBeUndefined();
+  });
+
+  it('keeps sites isolated by domain — one registration does not leak into another', () => {
+    const registry = createExtractionRegistry();
+    registry.registerSite(buildSiteConfig({ siteId: 'alpha', domains: ['alpha.example.test'] }));
+    registry.registerSite(
+      buildSiteConfig({
+        siteId: 'beta',
+        domains: ['beta.example.test'],
+        rateLimit: { ...buildSiteConfig().rateLimit, domain: 'beta.example.test' },
+      })
+    );
+    registry.registerRuleset(buildRuleset('alpha'));
+    registry.registerRuleset(buildRuleset('beta'));
+
+    expect(registry.getSiteConfigForUrl('https://beta.example.test/x')?.siteId).toBe('beta');
+    expect(registry.getRulesetForUrl('https://beta.example.test/x')?.siteId).toBe('beta');
+    expect(registry.getSiteConfigForUrl('https://alpha.example.test/x')?.siteId).toBe('alpha');
+  });
+
+  it('throws a clear error for a malformed URL rather than crashing silently', () => {
+    const registry = createExtractionRegistry();
+    expect(() => registry.getSiteConfigForUrl('not-a-url')).toThrow();
+  });
+});

--- a/src/__tests__/unit/pluginLoader.test.ts
+++ b/src/__tests__/unit/pluginLoader.test.ts
@@ -1,4 +1,6 @@
 import path from 'path';
+import { promises as fsPromises } from 'fs';
+import { jest } from '@jest/globals';
 import { discoverPlugins } from '../../services/pluginLoader';
 
 const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'plugins');
@@ -47,5 +49,38 @@ describe('discoverPlugins', () => {
   it('returns an empty array when node_modules has no candidate packages', async () => {
     const plugins = await discoverPlugins({ nodeModulesDir: path.join(__dirname, '..', 'fixtures') });
     expect(plugins).toEqual([]);
+  });
+
+  it('defaults to the real process node_modules directory when none is provided', async () => {
+    // Smoke test for the no-args path (defaultNodeModulesDir()) — the repo's
+    // real node_modules has no scraper-ruleset packages, so this just
+    // proves it scans without throwing and returns an array.
+    await expect(discoverPlugins()).resolves.toEqual(expect.any(Array));
+  });
+
+  it('skips a scoped package directory whose contents cannot be read, without failing the whole scan', async () => {
+    const realReaddir = fsPromises.readdir.bind(fsPromises);
+    const spy = jest.spyOn(fsPromises, 'readdir').mockImplementation(((dir: any, opts?: any) => {
+      if (typeof dir === 'string' && dir.includes('@mockscope')) {
+        return Promise.reject(new Error('EACCES simulated'));
+      }
+      return realReaddir(dir, opts);
+    }) as typeof fsPromises.readdir);
+
+    try {
+      const plugins = await discoverPlugins({ nodeModulesDir: FIXTURES_DIR });
+      expect(plugins.find(p => p.name === 'mock-scraper-ruleset')).toBeDefined();
+      expect(plugins.find(p => p.name === '@mockscope/scoped-ruleset')).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('skips a candidate whose entry file fails to import (e.g. missing main), without failing the whole scan', async () => {
+    const plugins = await discoverPlugins({ nodeModulesDir: FIXTURES_DIR });
+
+    expect(plugins.find(p => p.name === 'missing-entry-plugin')).toBeUndefined();
+    // Sibling valid plugins are still discovered.
+    expect(plugins.find(p => p.name === 'mock-scraper-ruleset')).toBeDefined();
   });
 });

--- a/src/__tests__/unit/pluginLoader.test.ts
+++ b/src/__tests__/unit/pluginLoader.test.ts
@@ -1,0 +1,51 @@
+import path from 'path';
+import { discoverPlugins } from '../../services/pluginLoader';
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'plugins');
+
+describe('discoverPlugins', () => {
+  it('discovers a well-formed plugin package advertising the scraper-ruleset keyword', async () => {
+    const plugins = await discoverPlugins({ nodeModulesDir: FIXTURES_DIR });
+
+    const mock = plugins.find(p => p.name === 'mock-scraper-ruleset');
+    expect(mock).toBeDefined();
+    expect(mock!.version).toBe('1.0.0');
+    expect(typeof mock!.register).toBe('function');
+    expect(typeof mock!.registerRoutes).toBe('function');
+    expect(typeof mock!.shutdown).toBe('function');
+  });
+
+  it('recurses into scoped (@scope/name) packages under node_modules', async () => {
+    const plugins = await discoverPlugins({ nodeModulesDir: FIXTURES_DIR });
+
+    const scoped = plugins.find(p => p.name === '@mockscope/scoped-ruleset');
+    expect(scoped).toBeDefined();
+    expect(scoped!.version).toBe('2.0.0');
+  });
+
+  it('rejects a package that has the keyword but does not implement the ScraperPlugin contract', async () => {
+    const plugins = await discoverPlugins({ nodeModulesDir: FIXTURES_DIR });
+
+    expect(plugins.find(p => p.name === 'broken-plugin')).toBeUndefined();
+  });
+
+  it('never imports packages that lack the scraper-ruleset keyword', async () => {
+    // not-a-ruleset/index.js throws synchronously if imported — a passing
+    // (non-throwing) discoverPlugins call proves it was filtered by
+    // package.json keyword before any dynamic import was attempted.
+    await expect(discoverPlugins({ nodeModulesDir: FIXTURES_DIR })).resolves.not.toThrow();
+
+    const plugins = await discoverPlugins({ nodeModulesDir: FIXTURES_DIR });
+    expect(plugins.find(p => p.name === 'not-a-ruleset')).toBeUndefined();
+  });
+
+  it('returns an empty array when the directory does not exist', async () => {
+    const plugins = await discoverPlugins({ nodeModulesDir: path.join(FIXTURES_DIR, 'does-not-exist') });
+    expect(plugins).toEqual([]);
+  });
+
+  it('returns an empty array when node_modules has no candidate packages', async () => {
+    const plugins = await discoverPlugins({ nodeModulesDir: path.join(__dirname, '..', 'fixtures') });
+    expect(plugins).toEqual([]);
+  });
+});

--- a/src/__tests__/unit/pluginTypes.test.ts
+++ b/src/__tests__/unit/pluginTypes.test.ts
@@ -1,0 +1,49 @@
+import { isScraperPlugin } from '../../services/pluginTypes';
+
+describe('isScraperPlugin', () => {
+  it('accepts an object with only the required fields (name/version/register)', () => {
+    expect(isScraperPlugin({ name: 'p', version: '1.0.0', register: async () => {} })).toBe(true);
+  });
+
+  it('accepts an object that also has valid optional registerRoutes/shutdown functions', () => {
+    expect(
+      isScraperPlugin({
+        name: 'p',
+        version: '1.0.0',
+        register: async () => {},
+        registerRoutes: () => {},
+        shutdown: async () => {},
+      })
+    ).toBe(true);
+  });
+
+  it.each([null, undefined, 'a string', 42, true])('rejects a non-object value: %p', value => {
+    expect(isScraperPlugin(value)).toBe(false);
+  });
+
+  it('rejects an object missing name', () => {
+    expect(isScraperPlugin({ version: '1.0.0', register: async () => {} })).toBe(false);
+  });
+
+  it('rejects an object missing version', () => {
+    expect(isScraperPlugin({ name: 'p', register: async () => {} })).toBe(false);
+  });
+
+  it('rejects an object missing register', () => {
+    expect(isScraperPlugin({ name: 'p', version: '1.0.0' })).toBe(false);
+  });
+
+  it('rejects an object where register is not a function', () => {
+    expect(isScraperPlugin({ name: 'p', version: '1.0.0', register: 'not-a-function' })).toBe(false);
+  });
+
+  it('rejects an object where registerRoutes is present but not a function', () => {
+    expect(
+      isScraperPlugin({ name: 'p', version: '1.0.0', register: async () => {}, registerRoutes: 'nope' })
+    ).toBe(false);
+  });
+
+  it('rejects an object where shutdown is present but not a function', () => {
+    expect(isScraperPlugin({ name: 'p', version: '1.0.0', register: async () => {}, shutdown: 'nope' })).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { scraperDebug } from './utils/logger.js';
 
 // Import browser pool functionality
 import { initializeBrowserPool, BrowserPool } from './services/genericScraper.js';
+import { bootstrapPlugins, shutdownPlugins } from './services/pluginBootstrap.js';
+import { ScraperPlugin } from './services/pluginTypes.js';
 
 dotenv.config();
 
@@ -77,24 +79,50 @@ app.use('/', scraperRoutes);
 // Sync routes for MFC collection synchronization
 app.use('/sync', syncRoutes);
 
-// Start server and initialize browser pool
-app.listen(PORT, async () => {
-  console.log(`[PAGE-SCRAPER] Server running on port ${PORT}`);
-  console.log(`[PAGE-SCRAPER] Health check: http://localhost:${PORT}/health`);
-  
-  // Initialize browser pool in background
-  console.log('[PAGE-SCRAPER] Initializing browser pool...');
-  try {
-    await initializeBrowserPool();
-    console.log('[PAGE-SCRAPER] Browser pool ready!');
-  } catch (error) {
-    console.error('[PAGE-SCRAPER] Failed to initialize browser pool:', error);
-  }
-});
+// Plugins loaded at boot (populated by startServer, read by gracefulShutdown)
+let loadedPlugins: ScraperPlugin[] = [];
 
-// Graceful shutdown - properly close browser pool to prevent file descriptor leaks
+// Discover + register plugins (mounting their routes) before accepting
+// connections, then start the server and initialize the browser pool.
+async function startServer(): Promise<void> {
+  try {
+    const { plugins } = await bootstrapPlugins(app);
+    loadedPlugins = plugins;
+    if (plugins.length > 0) {
+      console.log(`[PAGE-SCRAPER] Loaded ${plugins.length} plugin(s): ${plugins.map(p => `${p.name}@${p.version}`).join(', ')}`);
+    }
+  } catch (error) {
+    console.error('[PAGE-SCRAPER] Plugin bootstrap failed:', error);
+  }
+
+  app.listen(PORT, async () => {
+    console.log(`[PAGE-SCRAPER] Server running on port ${PORT}`);
+    console.log(`[PAGE-SCRAPER] Health check: http://localhost:${PORT}/health`);
+
+    // Initialize browser pool in background
+    console.log('[PAGE-SCRAPER] Initializing browser pool...');
+    try {
+      await initializeBrowserPool();
+      console.log('[PAGE-SCRAPER] Browser pool ready!');
+    } catch (error) {
+      console.error('[PAGE-SCRAPER] Failed to initialize browser pool:', error);
+    }
+  });
+}
+
+startServer();
+
+// Graceful shutdown - shut down plugins, then close browser pool to prevent file descriptor leaks
 async function gracefulShutdown(signal: string): Promise<void> {
   console.log(`[PAGE-SCRAPER] Received ${signal}, shutting down gracefully...`);
+
+  try {
+    console.log('[PAGE-SCRAPER] Shutting down plugins...');
+    await shutdownPlugins(loadedPlugins);
+    console.log('[PAGE-SCRAPER] Plugins shut down successfully');
+  } catch (error) {
+    console.error('[PAGE-SCRAPER] Error shutting down plugins:', error);
+  }
 
   try {
     console.log('[PAGE-SCRAPER] Closing browser pool...');

--- a/src/services/engineServices/index.ts
+++ b/src/services/engineServices/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Barrel: assembles the concrete EngineServices bundle handed to plugins via
+ * PluginContext.services.
+ */
+import { EngineServices } from '../pluginTypes.js';
+import { createScrapingService } from './scrapingService.js';
+import { createQueueService } from './queueService.js';
+import { createSessionService } from './sessionService.js';
+import { createWebhookService } from './webhookService.js';
+
+export { createRuntimeConfig, EnvRuntimeConfig } from './runtimeConfig.js';
+export { createPluginLogger } from './pluginLogger.js';
+export { createScrapingService } from './scrapingService.js';
+export { createQueueService } from './queueService.js';
+export { createSessionService } from './sessionService.js';
+export { createWebhookService } from './webhookService.js';
+
+export function buildEngineServices(): EngineServices {
+  return {
+    scraping: createScrapingService(),
+    queue: createQueueService(),
+    sessions: createSessionService(),
+    webhooks: createWebhookService(),
+  };
+}

--- a/src/services/engineServices/pluginLogger.ts
+++ b/src/services/engineServices/pluginLogger.ts
@@ -1,0 +1,24 @@
+/**
+ * PluginLogger adapter — wraps the engine's existing debug logger with a
+ * fixed namespace per plugin, so every log line a plugin emits is
+ * attributable (e.g. "[plugin:mock-scraper-ruleset] ...").
+ */
+import { logger } from '../../utils/logger.js';
+import { PluginLogger } from '../pluginTypes.js';
+
+export function createPluginLogger(namespace: string): PluginLogger {
+  return {
+    info(message: string, meta?: Record<string, unknown>): void {
+      logger.info(`[${namespace}] ${message}`, meta);
+    },
+    warn(message: string, meta?: Record<string, unknown>): void {
+      logger.warn(`[${namespace}] ${message}`, meta);
+    },
+    error(message: string, meta?: Record<string, unknown>): void {
+      logger.error(`[${namespace}] ${message}`, meta);
+    },
+    debug(message: string, meta?: Record<string, unknown>): void {
+      logger.debug(namespace, message, meta);
+    },
+  };
+}

--- a/src/services/engineServices/queueService.ts
+++ b/src/services/engineServices/queueService.ts
@@ -1,0 +1,53 @@
+/**
+ * QueueService adapter — thin wrapper around the existing ScrapeQueue
+ * singleton, mapping its {id, ...} results onto the generic
+ * {itemId, ...} contract shape. Accepts an injected queue for testability;
+ * defaults to the real singleton at runtime.
+ */
+import { getScrapeQueue } from '../scrapeQueue.js';
+import type { ScrapeQueue } from '../scrapeQueue.js';
+import { QueueService, EnqueueOptions, EnqueueResult } from '../pluginTypes.js';
+
+export type QueueServiceDeps = Pick<
+  ScrapeQueue,
+  'enqueue' | 'enqueueBulk' | 'getStats' | 'resumeSession' | 'cancelFailedItems' | 'cancelAllForSession' | 'clear'
+>;
+
+export function createQueueService(queue: QueueServiceDeps = getScrapeQueue()): QueueService {
+  return {
+    enqueue(itemId: string, options?: EnqueueOptions): EnqueueResult {
+      const result = queue.enqueue(itemId, options);
+      // Guard against unhandled rejection — plugins that don't await the
+      // scrape result (they get progress via webhooks instead) shouldn't
+      // crash the process when a scrape ultimately fails.
+      result.promise.catch(() => {});
+      return { itemId: result.id, deduplicated: result.deduplicated, position: result.position };
+    },
+
+    enqueueBulk(items: Array<{ itemId: string; options?: EnqueueOptions }>): EnqueueResult[] {
+      const results = queue.enqueueBulk(items.map(({ itemId, options }) => ({ mfcId: itemId, ...options })));
+      results.forEach(r => r.promise.catch(() => {}));
+      return results.map(r => ({ itemId: r.id, deduplicated: r.deduplicated, position: r.position }));
+    },
+
+    getStats() {
+      return queue.getStats();
+    },
+
+    resumeSession(sessionId: string): boolean {
+      return queue.resumeSession(sessionId);
+    },
+
+    cancelFailedItems(sessionId: string): number {
+      return queue.cancelFailedItems(sessionId);
+    },
+
+    cancelAllForSession(sessionId: string): number {
+      return queue.cancelAllForSession(sessionId);
+    },
+
+    reset(): void {
+      queue.clear();
+    },
+  };
+}

--- a/src/services/engineServices/runtimeConfig.ts
+++ b/src/services/engineServices/runtimeConfig.ts
@@ -1,0 +1,34 @@
+/**
+ * RuntimeConfig adapter — env-backed implementation of the generic
+ * RuntimeConfig contract. Dotted keys (e.g. "vndb.apiToken") map to
+ * uppercased, underscore-joined env vars (VNDB_APITOKEN). Values that parse
+ * as JSON (booleans, numbers, objects) are returned parsed; anything else is
+ * returned as the raw string.
+ */
+import { RuntimeConfig } from '../pluginTypes.js';
+
+function toEnvKey(key: string): string {
+  return key.toUpperCase().replace(/[.\-]/g, '_');
+}
+
+export class EnvRuntimeConfig implements RuntimeConfig {
+  get(key: string): unknown {
+    const raw = process.env[toEnvKey(key)];
+    if (raw === undefined) return undefined;
+
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  }
+
+  getFeatureFlag(site: string, feature: string): boolean {
+    const key = toEnvKey(`FEATURE_${site}_${feature}`);
+    return process.env[key] === 'true';
+  }
+}
+
+export function createRuntimeConfig(): RuntimeConfig {
+  return new EnvRuntimeConfig();
+}

--- a/src/services/engineServices/scrapingService.ts
+++ b/src/services/engineServices/scrapingService.ts
@@ -1,0 +1,123 @@
+/**
+ * ScrapingService adapter — generic page-fetch capability built on top of
+ * the existing BrowserPool (pooled + stealth browser lifecycle management).
+ * Deliberately does NOT reuse genericScraper.scrapeGeneric()/scrapeMFC(): those
+ * bake in MFC-specific selectors and schema-v3 extraction. This adapter only
+ * navigates and returns raw HTML — extraction is the plugin's job via its
+ * own ExtractionRuleset.
+ */
+import type { Browser, Page } from 'puppeteer';
+import { BrowserPool } from '../genericScraper.js';
+import { ScrapingService, ScrapePageOptions, ScrapePageResult, PageOptions } from '../pluginTypes.js';
+
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36';
+const NAV_TIMEOUT_MS = 20000;
+const MAX_WAIT_TIME_MS = 10000;
+const CHALLENGE_RECHECK_DELAY_MS = 1500;
+
+function capWaitTime(waitTime?: number): number {
+  if (!waitTime || waitTime < 0) return 0;
+  return Math.min(waitTime, MAX_WAIT_TIME_MS);
+}
+
+async function detectChallenge(
+  page: Page,
+  patterns: NonNullable<ScrapePageOptions['cloudflareDetection']>
+): Promise<boolean> {
+  const title = (await page.title()).toLowerCase();
+  const bodyText = ((await page.evaluate(() => document.body.innerText)) as string).toLowerCase();
+
+  const matchesAny = (list?: string[]) =>
+    (list || []).some(pattern => {
+      const needle = pattern.toLowerCase();
+      return title.includes(needle) || bodyText.includes(needle);
+    });
+
+  return matchesAny(patterns.titleIncludes) || matchesAny(patterns.bodyIncludes);
+}
+
+async function navigateAndCapture(page: Page, url: string, options: ScrapePageOptions = {}): Promise<ScrapePageResult> {
+  await page.setViewport({ width: 1280, height: 720 });
+  await page.setUserAgent(options.userAgent || DEFAULT_USER_AGENT);
+
+  if (options.cookies) {
+    const hostname = new URL(url).hostname;
+    const cookieArray = Object.entries(options.cookies)
+      .filter(([, value]) => value != null && value !== '')
+      .map(([name, value]) => ({ name, value, domain: `.${hostname.replace(/^www\./, '')}`, path: '/' }));
+    if (cookieArray.length > 0) {
+      await page.setCookie(...(cookieArray as Parameters<Page['setCookie']>));
+    }
+  }
+
+  const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT_MS });
+
+  const waitTime = capWaitTime(options.waitTime);
+  if (waitTime > 0) {
+    await new Promise(resolve => setTimeout(resolve, waitTime));
+  }
+
+  if (options.cloudflareDetection) {
+    const challenged = await detectChallenge(page, options.cloudflareDetection);
+    if (challenged) {
+      // Single bounded re-check wait. Plugins needing more elaborate
+      // challenge-clearing behavior can retry from their own workflow layer.
+      await new Promise(resolve => setTimeout(resolve, CHALLENGE_RECHECK_DELAY_MS));
+    }
+  }
+
+  const html = await page.content();
+  const title = await page.title();
+
+  return {
+    html,
+    url,
+    title,
+    statusCode: response?.status(),
+  };
+}
+
+export function createScrapingService(): ScrapingService {
+  async function withPage<T>(fn: (page: Page) => Promise<T>, options: PageOptions = {}): Promise<T> {
+    const stealth = options.stealth ?? false;
+    const browser: Browser = stealth ? await BrowserPool.getStealthBrowser() : await BrowserPool.getBrowser();
+    const context = await browser.createBrowserContext();
+
+    try {
+      const page: Page = await context.newPage();
+      if (options.viewport) {
+        await page.setViewport(options.viewport);
+      }
+      if (options.userAgent) {
+        await page.setUserAgent(options.userAgent);
+      }
+      return await fn(page);
+    } finally {
+      await context.close().catch(() => {});
+      if (!stealth) {
+        await BrowserPool.returnBrowser(browser);
+      }
+    }
+  }
+
+  async function withBrowser<T>(fn: (browser: Browser) => Promise<T>): Promise<T> {
+    const browser = await BrowserPool.getBrowser();
+    try {
+      return await fn(browser);
+    } finally {
+      await BrowserPool.returnBrowser(browser);
+    }
+  }
+
+  return {
+    scrapePage: (url: string, options?: ScrapePageOptions) =>
+      withPage(page => navigateAndCapture(page, url, options), { stealth: false }),
+
+    scrapePageStealth: (url: string, options?: ScrapePageOptions) =>
+      withPage(page => navigateAndCapture(page, url, options), { stealth: true }),
+
+    withBrowser,
+    withPage,
+  };
+}

--- a/src/services/engineServices/sessionService.ts
+++ b/src/services/engineServices/sessionService.ts
@@ -1,0 +1,44 @@
+/**
+ * SessionService adapter — thin wrapper around the existing SessionManager
+ * singleton. The legacy manager only tracks cookie-auth failure/pause state
+ * (no total/processed item counts), so those two SessionInfo fields are
+ * reserved at 0 for now; wiring them up is deferred until session tracking
+ * is generalized away from cookie-specific semantics (a later task, same as
+ * cutting genericScraper's MFC extraction over to the plugin).
+ */
+import { getSessionManager } from '../sessionManager.js';
+import type { SessionManager } from '../sessionManager.js';
+import { SessionService, SessionInfo } from '../pluginTypes.js';
+
+export type SessionServiceDeps = Pick<SessionManager, 'getAllSessions' | 'reportCookieFailure'>;
+
+export function createSessionService(sessionManager: SessionServiceDeps = getSessionManager()): SessionService {
+  return {
+    getAllSessions(): SessionInfo[] {
+      return sessionManager.getAllSessions().map(s => ({
+        sessionId: s.sessionId,
+        isPaused: s.isPaused,
+        inCooldown: s.inCooldown,
+        failureCount: s.consecutiveFailures,
+        totalItems: 0,
+        processedItems: 0,
+      }));
+    },
+
+    validateSession(sessionId: string): boolean {
+      return sessionManager.getAllSessions().some(s => s.sessionId === sessionId);
+    },
+
+    reportPause(sessionId: string, reason: string): void {
+      // The legacy SessionManager derives pauses internally from
+      // reportCookieFailure crossing a threshold; it has no API for an
+      // externally-detected pause. Log for visibility until that's unified.
+      console.warn(`[SESSION SERVICE] External pause report for session ${sessionId}: ${reason}`);
+    },
+
+    reportFailure(sessionId: string, itemId: string, error: string): void {
+      sessionManager.reportCookieFailure(sessionId, itemId, 'plugin', 0);
+      console.warn(`[SESSION SERVICE] Reported failure for session ${sessionId}, item ${itemId}: ${error}`);
+    },
+  };
+}

--- a/src/services/engineServices/webhookService.ts
+++ b/src/services/engineServices/webhookService.ts
@@ -1,0 +1,23 @@
+/**
+ * WebhookService adapter — thin pass-through to the existing webhookClient
+ * module. No mapping needed: webhookClient's config/payload shapes already
+ * match the generic contract exactly.
+ */
+import {
+  registerWebhookConfig,
+  unregisterWebhookConfig,
+  notifyItemComplete,
+  notifyPhaseChange,
+  notifyListsSync,
+} from '../webhookClient.js';
+import { WebhookService } from '../pluginTypes.js';
+
+export function createWebhookService(): WebhookService {
+  return {
+    registerConfig: registerWebhookConfig,
+    unregisterConfig: unregisterWebhookConfig,
+    notifyItemComplete,
+    notifyPhaseChange,
+    notifyListsSync,
+  };
+}

--- a/src/services/extractionRegistry.ts
+++ b/src/services/extractionRegistry.ts
@@ -1,0 +1,68 @@
+/**
+ * Extraction Registry
+ *
+ * The engine-side implementation of the ExtractionRegistry contract. Plugins
+ * call registerSite()/registerRuleset() during register(); the engine uses
+ * getSiteConfigForUrl()/getRulesetForUrl() to resolve a request's hostname to
+ * the plugin-provided site config and ruleset. Pure indexing/lookup — no
+ * knowledge of any specific site lives here.
+ */
+
+import {
+  ExtractionRegistry,
+  SiteConfig,
+  ExtractionRuleset,
+} from './pluginTypes.js';
+
+export class ExtractionRegistryImpl implements ExtractionRegistry {
+  private readonly sites = new Map<string, SiteConfig>();
+  private readonly rulesets = new Map<string, ExtractionRuleset>();
+  /** hostname (lowercased) -> siteId */
+  private readonly hostnameIndex = new Map<string, string>();
+
+  registerSite(config: SiteConfig): void {
+    this.sites.set(config.siteId, config);
+    for (const domain of config.domains) {
+      this.hostnameIndex.set(domain.toLowerCase(), config.siteId);
+    }
+  }
+
+  registerRuleset(ruleset: ExtractionRuleset): void {
+    this.rulesets.set(ruleset.siteId, ruleset);
+  }
+
+  getSiteConfigForUrl(url: string): SiteConfig | undefined {
+    const siteId = this.resolveSiteId(url);
+    return siteId ? this.sites.get(siteId) : undefined;
+  }
+
+  getRulesetForUrl(url: string): ExtractionRuleset | undefined {
+    const siteId = this.resolveSiteId(url);
+    return siteId ? this.rulesets.get(siteId) : undefined;
+  }
+
+  private resolveSiteId(url: string): string | undefined {
+    // Let URL's own validation error propagate — callers get a clear
+    // "Invalid URL" failure rather than a silently-undefined match.
+    const hostname = new URL(url).hostname.toLowerCase();
+
+    if (this.hostnameIndex.has(hostname)) {
+      return this.hostnameIndex.get(hostname);
+    }
+
+    // Fall back to registered-domain matching so an unlisted subdomain of a
+    // registered domain still resolves (e.g. "cdn.alpha.example.test"
+    // matching a registered "alpha.example.test").
+    for (const [domain, siteId] of this.hostnameIndex.entries()) {
+      if (hostname.endsWith(`.${domain}`)) {
+        return siteId;
+      }
+    }
+
+    return undefined;
+  }
+}
+
+export function createExtractionRegistry(): ExtractionRegistryImpl {
+  return new ExtractionRegistryImpl();
+}

--- a/src/services/pluginBootstrap.ts
+++ b/src/services/pluginBootstrap.ts
@@ -1,0 +1,81 @@
+/**
+ * Plugin Bootstrap
+ *
+ * Wires the generic plugin-loading seam together: discover candidate
+ * plugins, build the shared ExtractionRegistry + PluginContext, await
+ * register() per plugin, mount registerRoutes() onto the running Express
+ * app, and hand back the loaded plugin list so the caller (src/index.ts)
+ * can wire shutdown() into SIGTERM/SIGINT.
+ *
+ * A single misbehaving plugin (throws in register(), or fails the
+ * ScraperPlugin shape check upstream in pluginLoader) is logged and skipped
+ * rather than taking down the whole engine boot.
+ */
+import { Router, type Express } from 'express';
+import { discoverPlugins } from './pluginLoader.js';
+import { createExtractionRegistry, ExtractionRegistryImpl } from './extractionRegistry.js';
+import { buildEngineServices, createRuntimeConfig, createPluginLogger } from './engineServices/index.js';
+import { ScraperPlugin, PluginContext, ExpressRouter } from './pluginTypes.js';
+
+export interface BootstrapPluginsOptions {
+  /** Directory to scan for candidate plugin packages (forwarded to discoverPlugins). */
+  nodeModulesDir?: string;
+  /** Full override of plugin discovery — primarily for tests. */
+  discover?: () => Promise<ScraperPlugin[]>;
+}
+
+export interface BootstrapPluginsResult {
+  registry: ExtractionRegistryImpl;
+  plugins: ScraperPlugin[];
+}
+
+export async function bootstrapPlugins(app: Express, options: BootstrapPluginsOptions = {}): Promise<BootstrapPluginsResult> {
+  const registry = createExtractionRegistry();
+  const config = createRuntimeConfig();
+  const services = buildEngineServices();
+
+  const discover = options.discover ?? (() => discoverPlugins({ nodeModulesDir: options.nodeModulesDir }));
+  const candidates = await discover();
+
+  const loaded: ScraperPlugin[] = [];
+
+  for (const plugin of candidates) {
+    const logger = createPluginLogger(`plugin:${plugin.name}`);
+    const context: PluginContext = { logger, config, services };
+
+    try {
+      await plugin.register(registry, context);
+
+      if (plugin.registerRoutes) {
+        const router = Router();
+        plugin.registerRoutes(router as unknown as ExpressRouter);
+        app.use('/', router);
+      }
+
+      loaded.push(plugin);
+      console.log(`[PLUGIN BOOTSTRAP] Registered plugin ${plugin.name}@${plugin.version}`);
+    } catch (error) {
+      console.error(`[PLUGIN BOOTSTRAP] Failed to register plugin "${plugin.name}":`, error);
+    }
+  }
+
+  return { registry, plugins: loaded };
+}
+
+/**
+ * Call shutdown() on every loaded plugin. Failures are logged, not thrown —
+ * one plugin's broken shutdown hook shouldn't block the rest of graceful
+ * shutdown (browser pool close, process exit).
+ */
+export async function shutdownPlugins(plugins: ScraperPlugin[]): Promise<void> {
+  await Promise.all(
+    plugins.map(async plugin => {
+      if (!plugin.shutdown) return;
+      try {
+        await plugin.shutdown();
+      } catch (error) {
+        console.error(`[PLUGIN BOOTSTRAP] Error shutting down plugin "${plugin.name}":`, error);
+      }
+    })
+  );
+}

--- a/src/services/pluginLoader.ts
+++ b/src/services/pluginLoader.ts
@@ -1,0 +1,124 @@
+/**
+ * Plugin Loader
+ *
+ * Scans node_modules for packages that advertise the "scraper-ruleset"
+ * keyword in their package.json, dynamic-imports each candidate, and
+ * type-guards the result against the ScraperPlugin contract. Generic by
+ * design: no site names, no knowledge of any specific ruleset package.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { ScraperPlugin, isScraperPlugin } from './pluginTypes.js';
+
+const PLUGIN_KEYWORD = 'scraper-ruleset';
+
+export interface DiscoverPluginsOptions {
+  /** Directory to scan for candidate packages. Defaults to the process's node_modules. */
+  nodeModulesDir?: string;
+}
+
+interface CandidatePackageJson {
+  name?: string;
+  main?: string;
+  keywords?: string[];
+}
+
+function defaultNodeModulesDir(): string {
+  return path.resolve(process.cwd(), 'node_modules');
+}
+
+async function readPackageJson(dir: string): Promise<CandidatePackageJson | null> {
+  try {
+    const raw = await fs.readFile(path.join(dir, 'package.json'), 'utf-8');
+    return JSON.parse(raw) as CandidatePackageJson;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List every directory under node_modules that could be a package,
+ * expanding one level into @scope/* directories for scoped packages.
+ */
+async function listCandidateDirs(nodeModulesDir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(nodeModulesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const candidates: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    if (entry.name.startsWith('@')) {
+      const scopeDir = path.join(nodeModulesDir, entry.name);
+      let scopedEntries;
+      try {
+        scopedEntries = await fs.readdir(scopeDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const scoped of scopedEntries) {
+        if (scoped.isDirectory()) {
+          candidates.push(path.join(scopeDir, scoped.name));
+        }
+      }
+      continue;
+    }
+
+    candidates.push(path.join(nodeModulesDir, entry.name));
+  }
+
+  return candidates;
+}
+
+async function importPlugin(packageDir: string, pkg: CandidatePackageJson): Promise<ScraperPlugin | null> {
+  const entryFile = path.join(packageDir, pkg.main || 'index.js');
+
+  let mod: unknown;
+  try {
+    mod = await import(pathToFileURL(entryFile).href);
+  } catch (error) {
+    console.warn(`[PLUGIN LOADER] Failed to import candidate plugin at ${packageDir}:`, error);
+    return null;
+  }
+
+  const candidate = (mod as { default?: unknown })?.default ?? mod;
+  if (!isScraperPlugin(candidate)) {
+    console.warn(`[PLUGIN LOADER] Skipping ${packageDir}: does not implement the ScraperPlugin contract`);
+    return null;
+  }
+
+  return candidate;
+}
+
+/**
+ * Scan node_modules (or a provided directory) for packages whose
+ * package.json advertises the "scraper-ruleset" keyword, dynamic-import
+ * each candidate, and return only those that structurally satisfy the
+ * ScraperPlugin contract. Malformed or non-matching packages are skipped
+ * (logged, never thrown) so a single bad plugin can't take down the engine.
+ */
+export async function discoverPlugins(options: DiscoverPluginsOptions = {}): Promise<ScraperPlugin[]> {
+  const nodeModulesDir = options.nodeModulesDir ?? defaultNodeModulesDir();
+  const candidateDirs = await listCandidateDirs(nodeModulesDir);
+
+  const plugins: ScraperPlugin[] = [];
+
+  for (const dir of candidateDirs) {
+    const pkg = await readPackageJson(dir);
+    if (!pkg || !pkg.keywords?.includes(PLUGIN_KEYWORD)) continue;
+
+    const plugin = await importPlugin(dir, pkg);
+    if (plugin) {
+      plugins.push(plugin);
+    }
+  }
+
+  return plugins;
+}

--- a/src/services/pluginTypes.ts
+++ b/src/services/pluginTypes.ts
@@ -1,0 +1,263 @@
+/**
+ * Plugin contract — local mirror of the ScraperPlugin contract.
+ *
+ * The engine intentionally does NOT depend on the private
+ * @figurecollecting/scraper-rulesets package (credential-free, publicly
+ * shippable). These types are a structural mirror of that contract so any
+ * package implementing the shapes below can register itself with the engine
+ * at runtime, without the engine importing anything private.
+ */
+
+export interface ScraperPlugin {
+  name: string;
+  version: string;
+  register(registry: ExtractionRegistry, context: PluginContext): Promise<void>;
+  registerRoutes?(router: ExpressRouter): void;
+  shutdown?(): Promise<void>;
+}
+
+export interface ExtractionRegistry {
+  registerSite(config: SiteConfig): void;
+  registerRuleset(ruleset: ExtractionRuleset): void;
+}
+
+export interface PluginContext {
+  logger: PluginLogger;
+  config: RuntimeConfig;
+  services: EngineServices;
+}
+
+// ============================================================================
+// Engine Services — provided by the scraper engine via PluginContext.services
+// ============================================================================
+
+export interface EngineServices {
+  scraping: ScrapingService;
+  queue: QueueService;
+  sessions: SessionService;
+  webhooks: WebhookService;
+}
+
+export interface ScrapePageOptions {
+  waitTime?: number;
+  userAgent?: string;
+  cookies?: Record<string, string>;
+  cloudflareDetection?: {
+    titleIncludes?: string[];
+    bodyIncludes?: string[];
+  };
+}
+
+export interface ScrapePageResult {
+  html: string;
+  url: string;
+  title: string;
+  statusCode?: number;
+}
+
+export interface PageOptions {
+  stealth?: boolean;
+  viewport?: { width: number; height: number };
+  userAgent?: string;
+}
+
+export interface ScrapingService {
+  scrapePage(url: string, options?: ScrapePageOptions): Promise<ScrapePageResult>;
+  scrapePageStealth(url: string, options?: ScrapePageOptions): Promise<ScrapePageResult>;
+  withBrowser<T>(fn: (browser: any) => Promise<T>): Promise<T>;
+  withPage<T>(fn: (page: any) => Promise<T>, options?: PageOptions): Promise<T>;
+}
+
+export type QueuePriority = 'HOT' | 'WARM' | 'COLD';
+export type ItemStatus = 'owned' | 'ordered' | 'wished';
+
+export interface EnqueueOptions {
+  priority?: QueuePriority;
+  status?: ItemStatus;
+  cookies?: Record<string, string>;
+  sessionId?: string;
+  userId?: string;
+}
+
+export interface EnqueueResult {
+  itemId: string;
+  deduplicated: boolean;
+  position?: number;
+}
+
+export interface QueueStats {
+  hot: number;
+  warm: number;
+  cold: number;
+  total: number;
+  processing: number;
+  completed: number;
+  failed: number;
+  rateLimited: boolean;
+  currentDelay: number;
+}
+
+export interface QueueService {
+  enqueue(itemId: string, options?: EnqueueOptions): EnqueueResult;
+  enqueueBulk(items: Array<{ itemId: string; options?: EnqueueOptions }>): EnqueueResult[];
+  getStats(): QueueStats;
+  resumeSession(sessionId: string): boolean;
+  cancelFailedItems(sessionId: string): number;
+  cancelAllForSession(sessionId: string): number;
+  reset?(): void;
+}
+
+export interface SessionInfo {
+  sessionId: string;
+  isPaused: boolean;
+  inCooldown: boolean;
+  failureCount: number;
+  totalItems: number;
+  processedItems: number;
+}
+
+export interface SessionService {
+  getAllSessions(): SessionInfo[];
+  validateSession(sessionId: string): boolean;
+  reportPause(sessionId: string, reason: string): void;
+  reportFailure(sessionId: string, itemId: string, error: string): void;
+}
+
+export interface WebhookConfig {
+  webhookUrl: string;
+  webhookSecret: string;
+  sessionId: string;
+}
+
+export interface PhaseChangePayload {
+  sessionId: string;
+  phase: string;
+  message?: string;
+  items?: Array<{
+    mfcId: string;
+    name?: string;
+    collectionStatus: string;
+    isNsfw?: boolean;
+    mfcActivityOrder?: number;
+    isOrphan?: boolean;
+  }>;
+}
+
+export interface ListsSyncPayload {
+  sessionId: string;
+  lists: Array<{
+    mfcId: number;
+    name: string;
+    teaser?: string;
+    description?: string;
+    privacy: string;
+    iconUrl?: string;
+    itemCount: number;
+    itemMfcIds?: number[];
+    itemDetails?: Array<{ mfcId: number; name?: string; imageUrl?: string }>;
+    mfcCreatedAt?: string;
+  }>;
+}
+
+export interface ItemCompletePayload {
+  sessionId: string;
+  mfcId: string;
+  status: 'pending' | 'processing' | 'completed' | 'failed' | 'skipped';
+  error?: string;
+  scrapedData?: Record<string, unknown>;
+}
+
+export interface WebhookService {
+  registerConfig(config: WebhookConfig): void;
+  unregisterConfig(sessionId: string): void;
+  notifyItemComplete(payload: ItemCompletePayload): Promise<boolean>;
+  notifyPhaseChange(payload: PhaseChangePayload): Promise<boolean>;
+  notifyListsSync(payload: ListsSyncPayload): Promise<boolean>;
+}
+
+// ============================================================================
+// Site Configuration & Extraction
+// ============================================================================
+
+export interface SiteConfig {
+  siteId: string;
+  name: string;
+  domains: string[];
+  rateLimit: DomainRateLimit;
+  requiresBrowser: boolean;
+  allowedCookies: string[];
+}
+
+export interface DomainRateLimit {
+  domain: string;
+  baseDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  backoffMultiplier: number;
+  recoveryDivisor: number;
+  successThreshold: number;
+}
+
+export interface ExtractionRuleset {
+  siteId: string;
+  version: string;
+  extract(html: string, url: string): ExtractedData;
+  validate(data: ExtractedData): ValidationResult;
+}
+
+export interface ExtractedData {
+  source: {
+    site: string;
+    itemId: string;
+    url: string;
+    extractedAt: Date;
+    rulesetVersion: string;
+  };
+  fields: Record<string, unknown>;
+  warnings: string[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface RuntimeConfig {
+  get(key: string): unknown;
+  getFeatureFlag(site: string, feature: string): boolean;
+}
+
+export interface PluginLogger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+  debug(message: string, meta?: Record<string, unknown>): void;
+}
+
+// Express Router type (lightweight, avoids importing express in the contract)
+export interface ExpressRouter {
+  get(path: string, ...handlers: Function[]): void;
+  post(path: string, ...handlers: Function[]): void;
+  put(path: string, ...handlers: Function[]): void;
+  delete(path: string, ...handlers: Function[]): void;
+  use(path: string, ...handlers: Function[]): void;
+}
+
+/**
+ * Type guard: validates an unknown module export has the minimum shape of a
+ * ScraperPlugin (name/version/register required; registerRoutes/shutdown
+ * optional). Used by the plugin loader to reject malformed packages instead
+ * of crashing the engine at boot.
+ */
+export function isScraperPlugin(value: unknown): value is ScraperPlugin {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.name === 'string' &&
+    typeof candidate.version === 'string' &&
+    typeof candidate.register === 'function' &&
+    (candidate.registerRoutes === undefined || typeof candidate.registerRoutes === 'function') &&
+    (candidate.shutdown === undefined || typeof candidate.shutdown === 'function')
+  );
+}


### PR DESCRIPTION
Generic ScraperPlugin discovery + hostname ExtractionRegistry + EngineServices adapters + bootstrap, tested against a mock plugin. NO private-package dep, NO site-specific code in the engine. 853 tests, tsc clean.