### PR TITLE
Align plugin ExtractedData with ingest wire: extractedAt ISO string, url/rulesetVersion optional

### DIFF
--- a/src/__tests__/unit/extractionRegistry.test.ts
+++ b/src/__tests__/unit/extractionRegistry.test.ts
@@ -27,7 +27,7 @@ function buildRuleset(siteId: string): ExtractionRuleset {
     version: '1.0.0',
     extract(html: string, url: string): ExtractedData {
       return {
-        source: { site: siteId, itemId: '1', url, extractedAt: new Date(), rulesetVersion: '1.0.0' },
+        source: { site: siteId, itemId: '1', url, extractedAt: new Date().toISOString(), rulesetVersion: '1.0.0' },
         fields: { html },
         warnings: [],
       };

--- a/src/services/pluginTypes.ts
+++ b/src/services/pluginTypes.ts
@@ -205,13 +205,19 @@ export interface ExtractionRuleset {
   validate(data: ExtractedData): ValidationResult;
 }
 
+/**
+ * Uniform extraction result. `source` serializes 1:1 onto the aggregation
+ * ingest wire: `extractedAt` MUST be an ISO-8601 UTC string (it becomes the
+ * `as_of` timestamp on every downstream claim row — produce it with
+ * `new Date().toISOString()`, never a Date object).
+ */
 export interface ExtractedData {
   source: {
     site: string;
     itemId: string;
-    url: string;
-    extractedAt: Date;
-    rulesetVersion: string;
+    url?: string;
+    extractedAt: string;
+    rulesetVersion?: string;
   };
   fields: Record<string, unknown>;
   warnings: string[];


### PR DESCRIPTION
Aligns the plugin `ExtractedData` contract with the downstream ingest wire format so plugin output serializes 1:1 onto it.

- `source.extractedAt`: `Date` → ISO-8601 UTC `string` — it becomes the record's `as_of`, and a `Date`/relative token would not round-trip deterministically on the wire.
- `source.url`, `source.rulesetVersion`: now optional.

Scope is the contract type plus one test fixture. Typecheck clean; full suite green.
