### PR TITLE
Bump TypeScript to 6.0.3 (with node10 deprecation shim)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "tsx": "^4.23.1",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -11184,9 +11184,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
     "tsx": "^4.23.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
Bumps the TypeScript devDependency 5.9.3 -> 6.0.3 (supersedes dependabot #185), plus the one change dependabot's own PR lacks: an ignoreDeprecations "6.0" line in tsconfig.test.json. Under TS6, the test config's moduleResolution "node10" (which ts-jest's CommonJS transform relies on) emits TS5107 as an error; the shim silences it until the proper migration.

Verified against current develop (post-#215): typecheck, typecheck:tests, and build all clean; full suite 858/40, zero regression. No src/tests code changes needed - ts-jest/ts-node/tsx already declare TS-under-7 peer ranges.

Follow-up (not blocking): before TS 7.0, tsconfig.test.json must migrate off node10 resolution properly - ignoreDeprecations only buys the runway.
