### PR TITLE
Bump base image to ubuntu 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
-# BASE STAGE - Secure Ubuntu 24.04 + Node 24.18.0 LTS + Chrome 151.0.7922.47
+# BASE STAGE - Secure Ubuntu 26.04 + Node 24.18.0 LTS + Chrome 151.0.7922.47
 # =============================================================================
-FROM ubuntu:24.04 AS base
+FROM ubuntu:26.04 AS base
 
 # Cache-bust ARG to invalidate Docker layers when dependencies change
 ARG CACHE_BUST=2026-07-24-node-24.18.0-chrome-151.0.7922.47-cve-fix


### PR DESCRIPTION
Bumps the container base image ubuntu:24.04 -> 26.04 (supersedes dependabot #160), plus a fix dependabot's own PR lacks: the stale "Ubuntu 24.04" text in the base-stage header comment.

All 28 Puppeteer/X11 apt packages still resolve on 26.04 under the same names (including libasound2t64, the t64 rename that carried forward from 24.04). The authoritative check is this PR's own CI, which builds the full production image on 26.04 - including the patch-package postinstall and the Chrome 151 download from #215 - and runs the image vulnerability scans.

No other Dockerfile changes required.
