### PR TITLE
Bump fc-shared to 1.5.1; drop redundant axios override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@figurecollecting/fc-shared": "^1.3.0",
+        "@figurecollecting/fc-shared": "^1.5.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.79.0",
         "@opentelemetry/core": "^2.10.0",
@@ -1049,13 +1049,13 @@
       }
     },
     "node_modules/@figurecollecting/fc-shared": {
-      "version": "1.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/fc-shared/1.3.0/0fc7bbaada8d37b687aca810971ae803e1ae1dbe",
-      "integrity": "sha512-FFuFMFKiw1cPdgocxTnKvN74d6NVkk88jJev9Zbr55L8uHQ63GMktbnUg7/vuGQhBYDBi+K222/k34eqpdx8Vw==",
+      "version": "1.5.1",
+      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/fc-shared/1.5.1/6b2055063a7d647e86daa4f0a654623b4d086f42",
+      "integrity": "sha512-BC1V3x5n1CmOQzmLUEbHMzV7Gvc/dUmOwwkjE4Rq9GLaQyngpazIXmdbUopp8nQxzkVS8Xi5mAe64FK3uaBz0w==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "axios": "^1.16.1",
+        "axios": "^1.18.1",
         "zustand": "^5.0.14"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@figurecollecting/fc-shared": "^1.3.0",
+    "@figurecollecting/fc-shared": "^1.5.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.79.0",
     "@opentelemetry/core": "^2.10.0",
@@ -41,7 +41,6 @@
     "puppeteer-extra-plugin-stealth": "^2.11.2"
   },
   "overrides": {
-    "axios": "^1.18.1",
     "qs": "^6.14.1",
     "rimraf": "^6.1.2",
     "basic-ftp": "^5.3.1",


### PR DESCRIPTION
fc-shared 1.5.1 depends on axios ^1.18.1 natively, so the local `overrides.axios` pin (added when fc-shared 1.3.0 dragged in vulnerable axios 1.16.x) is redundant. This moves the axios remediation to its source and retires the local override.

- `@figurecollecting/fc-shared` ^1.3.0 -> ^1.5.1 (resolves 1.5.1)
- Removed `axios` from `overrides` (all other overrides kept)
- axios still resolves to 1.18.1 — now via fc-shared's own range; zero 1.16.x/1.17.x in the lockfile

Verification: 858 tests passed / 40 suites (matches baseline), `typecheck` + `typecheck:tests` clean.