### PR TITLE
Fix plugin loader CJS default-export interop; add plugin dir env override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ PORT=3080
 # Token for admin-only endpoints like /reset-pool (non-production only)
 # ADMIN_TOKEN=your-admin-token-here
 
+# Plugin Directory (optional)
+# Directory scanned for ruleset plugin packages at boot. Defaults to the
+# service's own node_modules. Point this at a mounted volume to inject
+# plugins at runtime without installing them as dependencies.
+# PLUGIN_DIR=/plugins/node_modules
+
 # MFC Cookie Security (required for authenticated scraping)
 # Whitelist of cookie names allowed when scraping MFC with authentication
 # These cookies are filtered from user-provided session data for security

--- a/README.md
+++ b/README.md
@@ -629,6 +629,11 @@ See `.env.example` for complete configuration template.
 - `ADMIN_TOKEN`: Authentication token for admin endpoints
   - Required for `/reset-pool` endpoint in non-production environments
   - Simple string token for basic protection
+- `PLUGIN_DIR`: Directory scanned for ruleset plugin packages at boot
+  - Default: the service's own `node_modules`
+  - Use when plugins are injected at runtime (e.g. a mounted volume in a container) instead of being installed as dependencies
+  - Example: `/plugins/node_modules`
+  - An explicit `nodeModulesDir` option passed to the plugin bootstrap takes precedence
 
 **MFC Cookie Security:**
 - `MFC_ALLOWED_COOKIES`: Whitelist of cookie names allowed during authenticated MFC scraping

--- a/src/__tests__/fixtures/plugins/cjs-default-export-ruleset/index.js
+++ b/src/__tests__/fixtures/plugins/cjs-default-export-ruleset/index.js
@@ -1,0 +1,37 @@
+/**
+ * Fixture: a plugin compiled the way tsc emits `export default plugin` to
+ * CommonJS — `exports.default = plugin` plus named exports and the
+ * `__esModule` marker. This is the exact shape of the real published ruleset
+ * artifact. Node's ESM import of a CJS module wraps the ENTIRE
+ * `module.exports` as the namespace's `default`, so the plugin object lands
+ * at `mod.default.default` — the loader must unwrap that second level.
+ */
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.shutdown = exports.registerRoutes = exports.register = void 0;
+
+const register = async (registry, context) => {
+  context.logger.info('cjs default-export plugin registered');
+};
+exports.register = register;
+
+const registerRoutes = router => {
+  router.get('/cjs-default/ping', (req, res) => {
+    res.json({ ok: true, plugin: 'cjs-default-export-ruleset' });
+  });
+};
+exports.registerRoutes = registerRoutes;
+
+const shutdown = async () => {
+  // no-op
+};
+exports.shutdown = shutdown;
+
+const plugin = {
+  name: 'cjs-default-export-ruleset',
+  version: '3.0.0',
+  register,
+  registerRoutes,
+  shutdown,
+};
+exports.default = plugin;

--- a/src/__tests__/fixtures/plugins/cjs-default-export-ruleset/package.json
+++ b/src/__tests__/fixtures/plugins/cjs-default-export-ruleset/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cjs-default-export-ruleset",
+  "version": "3.0.0",
+  "main": "index.js",
+  "keywords": ["scraper-ruleset"]
+}

--- a/src/__tests__/integration/pluginBootstrap.test.ts
+++ b/src/__tests__/integration/pluginBootstrap.test.ts
@@ -150,3 +150,52 @@ describe('bootstrapPlugins', () => {
     await expect(shutdownPlugins([minimalPlugin])).resolves.not.toThrow();
   });
 });
+
+describe('bootstrapPlugins PLUGIN_DIR environment override', () => {
+  const ORIGINAL_PLUGIN_DIR = process.env.PLUGIN_DIR;
+
+  afterEach(() => {
+    if (ORIGINAL_PLUGIN_DIR === undefined) {
+      delete process.env.PLUGIN_DIR;
+    } else {
+      process.env.PLUGIN_DIR = ORIGINAL_PLUGIN_DIR;
+    }
+  });
+
+  it('scans the directory named by PLUGIN_DIR when no nodeModulesDir option is given', async () => {
+    process.env.PLUGIN_DIR = FIXTURES_DIR;
+    const app = buildApp();
+
+    const { plugins } = await bootstrapPlugins(app);
+
+    expect(plugins.map(p => p.name)).toContain('mock-scraper-ruleset');
+  });
+
+  it('falls back to default discovery (process node_modules) when PLUGIN_DIR is unset', async () => {
+    delete process.env.PLUGIN_DIR;
+    const app = buildApp();
+
+    const { plugins } = await bootstrapPlugins(app);
+
+    // The repo's real node_modules contains no scraper-ruleset packages.
+    expect(plugins.map(p => p.name)).not.toContain('mock-scraper-ruleset');
+  });
+
+  it('treats an empty PLUGIN_DIR as unset', async () => {
+    process.env.PLUGIN_DIR = '';
+    const app = buildApp();
+
+    const { plugins } = await bootstrapPlugins(app);
+
+    expect(plugins.map(p => p.name)).not.toContain('mock-scraper-ruleset');
+  });
+
+  it('lets an explicit nodeModulesDir option take precedence over PLUGIN_DIR', async () => {
+    process.env.PLUGIN_DIR = path.join(FIXTURES_DIR, 'does-not-exist');
+    const app = buildApp();
+
+    const { plugins } = await bootstrapPlugins(app, { nodeModulesDir: FIXTURES_DIR });
+
+    expect(plugins.map(p => p.name)).toContain('mock-scraper-ruleset');
+  });
+});

--- a/src/__tests__/unit/pluginLoader.test.ts
+++ b/src/__tests__/unit/pluginLoader.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { promises as fsPromises } from 'fs';
 import { jest } from '@jest/globals';
-import { discoverPlugins } from '../../services/pluginLoader';
+import { discoverPlugins, resolvePluginExport } from '../../services/pluginLoader';
 
 const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'plugins');
 
@@ -23,6 +23,23 @@ describe('discoverPlugins', () => {
     const scoped = plugins.find(p => p.name === '@mockscope/scoped-ruleset');
     expect(scoped).toBeDefined();
     expect(scoped!.version).toBe('2.0.0');
+  });
+
+  it('loads a plugin compiled the tsc way: exports.default = plugin with __esModule marker (real artifact shape)', async () => {
+    // Regression guard for the real published artifact shape. NOTE: under
+    // ts-jest's CommonJS downlevel, import() becomes require()+__importStar,
+    // which honors __esModule and masks the native-ESM double-`default`
+    // wrapping — so the faithful red/green for the interop bug lives in the
+    // resolvePluginExport tests below (exact namespace shapes) and in the
+    // real-runtime probe against the built dist.
+    const plugins = await discoverPlugins({ nodeModulesDir: FIXTURES_DIR });
+
+    const cjsDefault = plugins.find(p => p.name === 'cjs-default-export-ruleset');
+    expect(cjsDefault).toBeDefined();
+    expect(cjsDefault!.version).toBe('3.0.0');
+    expect(typeof cjsDefault!.register).toBe('function');
+    expect(typeof cjsDefault!.registerRoutes).toBe('function');
+    expect(typeof cjsDefault!.shutdown).toBe('function');
   });
 
   it('rejects a package that has the keyword but does not implement the ScraperPlugin contract', async () => {
@@ -82,5 +99,54 @@ describe('discoverPlugins', () => {
     expect(plugins.find(p => p.name === 'missing-entry-plugin')).toBeUndefined();
     // Sibling valid plugins are still discovered.
     expect(plugins.find(p => p.name === 'mock-scraper-ruleset')).toBeDefined();
+  });
+});
+
+describe('resolvePluginExport', () => {
+  const plugin = {
+    name: 'shape-test-ruleset',
+    version: '9.9.9',
+    register: async () => {},
+  };
+
+  it('resolves a native ESM default export (namespace.default = plugin)', () => {
+    const namespace = { default: plugin };
+    expect(resolvePluginExport(namespace)).toBe(plugin);
+  });
+
+  it('resolves CJS module.exports = plugin imported as ESM (namespace.default = plugin, lexer-hoisted names)', () => {
+    const namespace = { default: plugin, name: plugin.name, register: plugin.register };
+    expect(resolvePluginExport(namespace)).toBe(plugin);
+  });
+
+  it('resolves the tsc-compiled CJS default export: plugin at namespace.default.default (real artifact shape)', () => {
+    // Node's ESM import() of a CJS module exposes the ENTIRE module.exports
+    // as the namespace's `default`. For a tsc-compiled `export default plugin`
+    // (exports.default = plugin + __esModule marker + named exports), the
+    // plugin object therefore lands at namespace.default.default.
+    const cjsModuleExports = Object.defineProperty(
+      { register: plugin.register, default: plugin },
+      '__esModule',
+      { value: true }
+    );
+    const namespace = { __esModule: true, default: cjsModuleExports, register: plugin.register };
+    expect(resolvePluginExport(namespace)).toBe(plugin);
+  });
+
+  it('resolves a bare plugin object (require-style module.exports seen directly)', () => {
+    expect(resolvePluginExport(plugin)).toBe(plugin);
+  });
+
+  it('does not unwrap more than one extra level (bounded, no unbounded descent)', () => {
+    const triplyNested = { default: { default: { default: plugin } } };
+    expect(resolvePluginExport(triplyNested)).toBeNull();
+  });
+
+  it('returns null for non-plugin values', () => {
+    expect(resolvePluginExport(null)).toBeNull();
+    expect(resolvePluginExport(undefined)).toBeNull();
+    expect(resolvePluginExport('nope')).toBeNull();
+    expect(resolvePluginExport({})).toBeNull();
+    expect(resolvePluginExport({ default: { name: 'x' } })).toBeNull();
   });
 });

--- a/src/services/pluginBootstrap.ts
+++ b/src/services/pluginBootstrap.ts
@@ -18,7 +18,13 @@ import { buildEngineServices, createRuntimeConfig, createPluginLogger } from './
 import { ScraperPlugin, PluginContext, ExpressRouter } from './pluginTypes.js';
 
 export interface BootstrapPluginsOptions {
-  /** Directory to scan for candidate plugin packages (forwarded to discoverPlugins). */
+  /**
+   * Directory to scan for candidate plugin packages (forwarded to
+   * discoverPlugins). Falls back to the PLUGIN_DIR environment variable when
+   * not provided, then to the process's own node_modules — so runtime-injected
+   * plugins (e.g. a mounted volume in a container) can live outside
+   * process.cwd()/node_modules.
+   */
   nodeModulesDir?: string;
   /** Full override of plugin discovery — primarily for tests. */
   discover?: () => Promise<ScraperPlugin[]>;
@@ -34,7 +40,8 @@ export async function bootstrapPlugins(app: Express, options: BootstrapPluginsOp
   const config = createRuntimeConfig();
   const services = buildEngineServices();
 
-  const discover = options.discover ?? (() => discoverPlugins({ nodeModulesDir: options.nodeModulesDir }));
+  const nodeModulesDir = options.nodeModulesDir ?? (process.env.PLUGIN_DIR || undefined);
+  const discover = options.discover ?? (() => discoverPlugins({ nodeModulesDir }));
   const candidates = await discover();
 
   const loaded: ScraperPlugin[] = [];

--- a/src/services/pluginLoader.ts
+++ b/src/services/pluginLoader.ts
@@ -77,6 +77,34 @@ async function listCandidateDirs(nodeModulesDir: string): Promise<string[]> {
   return candidates;
 }
 
+/**
+ * Resolve the ScraperPlugin object out of a dynamically imported module,
+ * tolerating every interop shape a plugin package can compile to:
+ *
+ * - native ESM `export default plugin`        -> mod.default
+ * - CJS `module.exports = plugin`             -> mod.default (Node wraps the
+ *   whole module.exports as the namespace's `default`)
+ * - CJS `exports.default = plugin` (tsc emit  -> mod.default.default (the
+ *   of `export default plugin`)                  namespace's `default` is the
+ *                                                entire exports bag, so the
+ *                                                plugin sits one level deeper)
+ *
+ * The second unwrap is bounded: exactly one extra level, only when the first
+ * candidate fails the type guard and exposes an object `default` property.
+ */
+export function resolvePluginExport(mod: unknown): ScraperPlugin | null {
+  let candidate: unknown = (mod as { default?: unknown })?.default ?? mod;
+
+  if (!isScraperPlugin(candidate) && candidate !== null && typeof candidate === 'object') {
+    const inner = (candidate as { default?: unknown }).default;
+    if (inner !== null && typeof inner === 'object') {
+      candidate = inner;
+    }
+  }
+
+  return isScraperPlugin(candidate) ? candidate : null;
+}
+
 async function importPlugin(packageDir: string, pkg: CandidatePackageJson): Promise<ScraperPlugin | null> {
   const entryFile = path.join(packageDir, pkg.main || 'index.js');
 
@@ -88,13 +116,13 @@ async function importPlugin(packageDir: string, pkg: CandidatePackageJson): Prom
     return null;
   }
 
-  const candidate = (mod as { default?: unknown })?.default ?? mod;
-  if (!isScraperPlugin(candidate)) {
+  const plugin = resolvePluginExport(mod);
+  if (!plugin) {
     console.warn(`[PLUGIN LOADER] Skipping ${packageDir}: does not implement the ScraperPlugin contract`);
     return null;
   }
 
-  return candidate;
+  return plugin;
 }
 
 /**


### PR DESCRIPTION
## Bug: CJS default-export interop (double `default`)

`pluginLoader.ts` unwrapped a dynamically imported plugin module exactly once (`mod.default ?? mod`). The real published plugin (`@figurecollecting/scraper-rulesets@0.1.0`) compiles to CJS the tsc way: `exports.default = plugin` plus named exports and the `__esModule` marker. Node's ESM `import()` of a CJS module wraps the **entire** `module.exports` as the namespace's `default`, so the plugin object actually lives at `mod.default.default`. The single unwrap landed on the exports bag (whose `name`/`version` are undefined) and `isScraperPlugin` silently rejected the real plugin at boot.

Both suites were green anyway because ts-jest's CommonJS downlevel turns `import()` into `require()` + `__importStar`, which honors `__esModule` and masks the native-ESM wrapping — the seam had never been exercised with the real artifact shape under real runtime semantics.

## Fix

- Extract `resolvePluginExport(mod)`: after the first unwrap, if the candidate fails the `ScraperPlugin` type guard and exposes an object `default` property, unwrap exactly one more level (bounded — no unbounded descent). All three plugin shapes load: CJS `module.exports = plugin`, CJS `exports.default = plugin` (tsc emit), native ESM `export default plugin`.
- New on-disk fixture `cjs-default-export-ruleset` shaped exactly like the real compiled artifact (synthetic — no ruleset code), plus unit tests for `resolvePluginExport` fed the exact namespace shapes Node produces.

## PLUGIN_DIR env override (runtime-injected plugins)

`bootstrapPlugins` now falls back to the `PLUGIN_DIR` environment variable when no `nodeModulesDir` option is passed (explicit option wins; empty env treated as unset), so containerized deployments can mount plugins in a volume instead of `process.cwd()/node_modules`. Documented in README and `.env.example`.

## TDD evidence

- RED (real runtime, pre-fix): built dist + probe over the fixture dir and over the real packed artifact — `[PLUGIN LOADER] Skipping .../@figurecollecting/scraper-rulesets: does not implement the ScraperPlugin contract`, 0 plugins discovered.
- RED (jest): 6 new `resolvePluginExport` tests failed pre-implementation; `PLUGIN_DIR` test failed pre-plumb (`Received array: []`).
- GREEN: unit+integration suites pass; full suite **40 suites, 869 passed + 3 todo, 0 failed**; `typecheck` and `typecheck:tests` clean.
- Coverage: `pluginLoader.ts` 100% line / 93.75% branch, `pluginBootstrap.ts` 100% / 100%.

## Real-artifact proof (post-fix, real Node ESM)

`npm pack` of the private rulesets repo, installed into a temp dir, `PLUGIN_DIR` pointed at it, `bootstrapPlugins(app)` with no options:

```
[PLUGIN BOOTSTRAP] Registered plugin @figurecollecting/scraper-rulesets@0.1.0
[ENV PROBE] loaded 1 plugin(s): @figurecollecting/scraper-rulesets@0.1.0
```

All 15 site configurations registered. The interop bug is dead against the true artifact, not just the fixture.
