### PR TITLE
Extract plugin contract into @figurecollecting/scraper-plugin-contract package

### DIFF
--- a/.github/workflows/publish-plugin-contract.yml
+++ b/.github/workflows/publish-plugin-contract.yml
@@ -1,0 +1,58 @@
+name: Publish Plugin Contract
+
+# Publishes @figurecollecting/scraper-plugin-contract to GitHub Packages (npm)
+# when the package changes on develop, using the ephemeral GITHUB_TOKEN (no
+# standing PAT). npm versions are immutable, so a push that does not bump
+# packages/plugin-contract/package.json is skipped instead of failing.
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'packages/plugin-contract/**'
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        working-directory: packages/plugin-contract
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@figurecollecting'
+
+      - name: Install build tooling
+        run: npm install --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Check whether version is already published
+        id: version-check
+        run: |
+          VERSION="$(node -pe "require('./package.json').version")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          if npm view "@figurecollecting/scraper-plugin-contract@${VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already on the registry; skipping publish."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        if: steps.version-check.outputs.published == 'false'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 
 # Build outputs
 /dist
+/packages/plugin-contract/dist
+*.tgz
 
 # Environment variables
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,8 @@ FROM base AS development
 COPY package*.json .npmrc ./
 # patches/ must be present before npm install so the patch-package postinstall applies
 COPY patches ./patches
+# plugin-contract manifest must be present so the file: dependency resolves at npm install
+COPY packages/plugin-contract/package.json ./packages/plugin-contract/
 
 # Install all dependencies (Puppeteer won't download Chrome due to ENV vars)
 RUN npm config set fetch-timeout 300000 && npm config set fetch-retry-maxtimeout 300000
@@ -125,6 +127,8 @@ FROM base AS builder
 COPY package*.json .npmrc ./
 # patches/ must be present before npm install so the patch-package postinstall applies
 COPY patches ./patches
+# plugin-contract manifest must be present so the file: dependency resolves at npm install
+COPY packages/plugin-contract/package.json ./packages/plugin-contract/
 
 # Install all dependencies for build
 RUN npm config set fetch-timeout 300000 && npm config set fetch-retry-maxtimeout 300000
@@ -151,6 +155,8 @@ FROM base AS production
 COPY package*.json .npmrc ./
 # patches/ must be present before npm install so the patch-package postinstall applies
 COPY patches ./patches
+# plugin-contract manifest must be present so the file: dependency resolves at npm install
+COPY packages/plugin-contract/package.json ./packages/plugin-contract/
 
 # Install only production dependencies
 RUN npm config set fetch-timeout 300000 && npm config set fetch-retry-maxtimeout 300000
@@ -164,6 +170,7 @@ RUN rm -rf /root/.cache/puppeteer \
 
 # Copy built application from builder
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/packages/plugin-contract/dist ./packages/plugin-contract/dist
 
 # Create non-root user for security
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -55,6 +55,7 @@ module.exports = {
   // MUST stay first — moduleNameMapper is evaluated top-to-bottom.
   moduleNameMapper: {
     '^puppeteer$': '<rootDir>/src/__tests__/__mocks__/puppeteer.ts',
+    '^@figurecollecting/scraper-plugin-contract$': '<rootDir>/packages/plugin-contract/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@figurecollecting/fc-shared": "^1.5.1",
+        "@figurecollecting/scraper-plugin-contract": "file:packages/plugin-contract",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.79.0",
         "@opentelemetry/core": "^2.10.0",
@@ -1061,6 +1062,10 @@
       "peerDependencies": {
         "react": ">=18.0.0"
       }
+    },
+    "node_modules/@figurecollecting/scraper-plugin-contract": {
+      "resolved": "packages/plugin-contract",
+      "link": true
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
@@ -11772,6 +11777,14 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "packages/plugin-contract": {
+      "name": "@figurecollecting/scraper-plugin-contract",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^6.0.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:contract && tsc",
+    "build:contract": "tsc -p packages/plugin-contract",
     "start": "node --import ./dist/tracing.js dist/index.js",
     "dev": "tsx watch --env-file=.env src/index.ts",
     "lint": "echo 'No linter configured'",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "npm run build:contract && tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
     "test": "jest --config jest.config.cjs --testPathIgnorePatterns='inter-service'",
     "test:unit": "jest --config jest.config.cjs src/__tests__/unit",
@@ -23,6 +24,7 @@
   },
   "dependencies": {
     "@figurecollecting/fc-shared": "^1.5.1",
+    "@figurecollecting/scraper-plugin-contract": "file:packages/plugin-contract",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.79.0",
     "@opentelemetry/core": "^2.10.0",

--- a/packages/plugin-contract/README.md
+++ b/packages/plugin-contract/README.md
@@ -1,0 +1,21 @@
+# @figurecollecting/scraper-plugin-contract
+
+Single source of truth for the contract between the scraper engine and its
+ruleset plugin packages: the `ScraperPlugin` interface family (registry,
+context, engine services, site config, extraction types) plus the
+`isScraperPlugin` runtime guard the plugin loader uses to validate modules.
+
+The engine consumes this package in-repo via a `file:` dependency; plugin
+packages consume the published version from GitHub Packages:
+
+```
+npm install @figurecollecting/scraper-plugin-contract
+```
+
+with an `.npmrc` scoping `@figurecollecting` to `https://npm.pkg.github.com`.
+
+The package is types-plus-one-guard only — no engine runtime code. It compiles
+to CommonJS with type declarations, so it is importable from both CJS and ESM
+consumers. Publishing happens from CI (`publish-plugin-contract.yml`) when the
+package changes on `develop`; npm versions are immutable, so bump `version`
+here to release.

--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@figurecollecting/scraper-plugin-contract",
+  "version": "0.1.0",
+  "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FigureCollecting/scraper.git",
+    "directory": "packages/plugin-contract"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "keywords": [
+    "scraper",
+    "plugin",
+    "contract",
+    "types"
+  ],
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -1,11 +1,12 @@
 /**
- * Plugin contract — local mirror of the ScraperPlugin contract.
+ * Plugin contract — single source of truth for the ScraperPlugin contract.
  *
- * The engine intentionally does NOT depend on the private
- * @figurecollecting/scraper-rulesets package (credential-free, publicly
- * shippable). These types are a structural mirror of that contract so any
- * package implementing the shapes below can register itself with the engine
- * at runtime, without the engine importing anything private.
+ * Published as @figurecollecting/scraper-plugin-contract and consumed by both
+ * the scraper engine and ruleset plugin packages, so the two sides can never
+ * drift. The engine intentionally does NOT depend on any private ruleset
+ * package (credential-free, publicly shippable): any package implementing the
+ * shapes below can register itself with the engine at runtime, without the
+ * engine importing anything private.
  */
 
 export interface ScraperPlugin {

--- a/packages/plugin-contract/tsconfig.json
+++ b/packages/plugin-contract/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/src/__tests__/integration/pluginBootstrap.test.ts
+++ b/src/__tests__/integration/pluginBootstrap.test.ts
@@ -8,7 +8,7 @@ import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 import { bootstrapPlugins, shutdownPlugins } from '../../services/pluginBootstrap';
-import { ScraperPlugin, ExtractionRegistry, PluginContext, ExpressRouter } from '../../services/pluginTypes';
+import { ScraperPlugin, ExtractionRegistry, PluginContext, ExpressRouter } from '@figurecollecting/scraper-plugin-contract';
 
 const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'plugins');
 

--- a/src/__tests__/unit/extractionRegistry.test.ts
+++ b/src/__tests__/unit/extractionRegistry.test.ts
@@ -1,5 +1,5 @@
 import { createExtractionRegistry } from '../../services/extractionRegistry';
-import { SiteConfig, ExtractionRuleset, ExtractedData, ValidationResult } from '../../services/pluginTypes';
+import { SiteConfig, ExtractionRuleset, ExtractedData, ValidationResult } from '@figurecollecting/scraper-plugin-contract';
 
 function buildSiteConfig(overrides: Partial<SiteConfig> = {}): SiteConfig {
   return {

--- a/src/__tests__/unit/pluginTypes.test.ts
+++ b/src/__tests__/unit/pluginTypes.test.ts
@@ -1,4 +1,4 @@
-import { isScraperPlugin } from '../../services/pluginTypes';
+import { isScraperPlugin } from '@figurecollecting/scraper-plugin-contract';
 
 describe('isScraperPlugin', () => {
   it('accepts an object with only the required fields (name/version/register)', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { scraperDebug } from './utils/logger.js';
 // Import browser pool functionality
 import { initializeBrowserPool, BrowserPool } from './services/genericScraper.js';
 import { bootstrapPlugins, shutdownPlugins } from './services/pluginBootstrap.js';
-import { ScraperPlugin } from './services/pluginTypes.js';
+import { ScraperPlugin } from '@figurecollecting/scraper-plugin-contract';
 
 dotenv.config();
 

--- a/src/services/engineServices/index.ts
+++ b/src/services/engineServices/index.ts
@@ -2,7 +2,7 @@
  * Barrel: assembles the concrete EngineServices bundle handed to plugins via
  * PluginContext.services.
  */
-import { EngineServices } from '../pluginTypes.js';
+import { EngineServices } from '@figurecollecting/scraper-plugin-contract';
 import { createScrapingService } from './scrapingService.js';
 import { createQueueService } from './queueService.js';
 import { createSessionService } from './sessionService.js';

--- a/src/services/engineServices/pluginLogger.ts
+++ b/src/services/engineServices/pluginLogger.ts
@@ -4,7 +4,7 @@
  * attributable (e.g. "[plugin:mock-scraper-ruleset] ...").
  */
 import { logger } from '../../utils/logger.js';
-import { PluginLogger } from '../pluginTypes.js';
+import { PluginLogger } from '@figurecollecting/scraper-plugin-contract';
 
 export function createPluginLogger(namespace: string): PluginLogger {
   return {

--- a/src/services/engineServices/queueService.ts
+++ b/src/services/engineServices/queueService.ts
@@ -6,7 +6,7 @@
  */
 import { getScrapeQueue } from '../scrapeQueue.js';
 import type { ScrapeQueue } from '../scrapeQueue.js';
-import { QueueService, EnqueueOptions, EnqueueResult } from '../pluginTypes.js';
+import { QueueService, EnqueueOptions, EnqueueResult } from '@figurecollecting/scraper-plugin-contract';
 
 export type QueueServiceDeps = Pick<
   ScrapeQueue,

--- a/src/services/engineServices/runtimeConfig.ts
+++ b/src/services/engineServices/runtimeConfig.ts
@@ -5,7 +5,7 @@
  * as JSON (booleans, numbers, objects) are returned parsed; anything else is
  * returned as the raw string.
  */
-import { RuntimeConfig } from '../pluginTypes.js';
+import { RuntimeConfig } from '@figurecollecting/scraper-plugin-contract';
 
 function toEnvKey(key: string): string {
   return key.toUpperCase().replace(/[.\-]/g, '_');

--- a/src/services/engineServices/scrapingService.ts
+++ b/src/services/engineServices/scrapingService.ts
@@ -8,7 +8,7 @@
  */
 import type { Browser, Page } from 'puppeteer';
 import { BrowserPool } from '../genericScraper.js';
-import { ScrapingService, ScrapePageOptions, ScrapePageResult, PageOptions } from '../pluginTypes.js';
+import { ScrapingService, ScrapePageOptions, ScrapePageResult, PageOptions } from '@figurecollecting/scraper-plugin-contract';
 
 const DEFAULT_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36';

--- a/src/services/engineServices/sessionService.ts
+++ b/src/services/engineServices/sessionService.ts
@@ -8,7 +8,7 @@
  */
 import { getSessionManager } from '../sessionManager.js';
 import type { SessionManager } from '../sessionManager.js';
-import { SessionService, SessionInfo } from '../pluginTypes.js';
+import { SessionService, SessionInfo } from '@figurecollecting/scraper-plugin-contract';
 
 export type SessionServiceDeps = Pick<SessionManager, 'getAllSessions' | 'reportCookieFailure'>;
 

--- a/src/services/engineServices/webhookService.ts
+++ b/src/services/engineServices/webhookService.ts
@@ -10,7 +10,7 @@ import {
   notifyPhaseChange,
   notifyListsSync,
 } from '../webhookClient.js';
-import { WebhookService } from '../pluginTypes.js';
+import { WebhookService } from '@figurecollecting/scraper-plugin-contract';
 
 export function createWebhookService(): WebhookService {
   return {

--- a/src/services/extractionRegistry.ts
+++ b/src/services/extractionRegistry.ts
@@ -12,7 +12,7 @@ import {
   ExtractionRegistry,
   SiteConfig,
   ExtractionRuleset,
-} from './pluginTypes.js';
+} from '@figurecollecting/scraper-plugin-contract';
 
 export class ExtractionRegistryImpl implements ExtractionRegistry {
   private readonly sites = new Map<string, SiteConfig>();

--- a/src/services/pluginBootstrap.ts
+++ b/src/services/pluginBootstrap.ts
@@ -15,7 +15,7 @@ import { Router, type Express } from 'express';
 import { discoverPlugins } from './pluginLoader.js';
 import { createExtractionRegistry, ExtractionRegistryImpl } from './extractionRegistry.js';
 import { buildEngineServices, createRuntimeConfig, createPluginLogger } from './engineServices/index.js';
-import { ScraperPlugin, PluginContext, ExpressRouter } from './pluginTypes.js';
+import { ScraperPlugin, PluginContext, ExpressRouter } from '@figurecollecting/scraper-plugin-contract';
 
 export interface BootstrapPluginsOptions {
   /**

--- a/src/services/pluginLoader.ts
+++ b/src/services/pluginLoader.ts
@@ -10,7 +10,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { ScraperPlugin, isScraperPlugin } from './pluginTypes.js';
+import { ScraperPlugin, isScraperPlugin } from '@figurecollecting/scraper-plugin-contract';
 
 const PLUGIN_KEYWORD = 'scraper-ruleset';
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -15,7 +15,11 @@
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": false,
     "skipLibCheck": true,
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "rootDir": ".",
+    "paths": {
+      "@figurecollecting/scraper-plugin-contract": ["./packages/plugin-contract/src/index.ts"]
+    }
   },
   "include": [
     "src/**/__tests__/**/*",


### PR DESCRIPTION
## Problem

The plugin contract existed as two hand-maintained mirrors: the engine's `src/services/pluginTypes.ts` (whose header admitted it mirrors the private ruleset repo's `src/types.ts`) and the private copy itself. They already drifted once (`Date` vs ISO string on `extractedAt`, fixed in #214). This makes the contract a single published source of truth.

## What changed

- **New package `packages/plugin-contract/`** → `@figurecollecting/scraper-plugin-contract@0.1.0`: the contract interfaces plus the `isScraperPlugin` guard, moved verbatim from `src/services/pluginTypes.ts` (git tracks it as a rename; only the header comment changed). No engine runtime code. Compiles to CJS + `.d.ts`, so it is importable from both CJS and ESM consumers.
- **Engine consumes the package name**: all 14 import sites now use `@figurecollecting/scraper-plugin-contract`; `pluginTypes.ts` is deleted. The definitions exist in exactly one place.
- **Resolution mechanics** — a real `file:packages/plugin-contract` dependency rather than a tsconfig `paths`-only mapping, because `isScraperPlugin` is a *value* import in `pluginLoader.ts`: the bare specifier survives into `dist/` and must resolve at Node runtime (verified: emitted `dist/services/pluginLoader.js` imports the package name and loads through the npm symlink). A `paths` mapping into `packages/` would also break `rootDir: ./src` on emit.
  - `build`/`typecheck` chain a fast `build:contract` step (`tsc -p packages/plugin-contract`).
  - Tests never need the package built: jest `moduleNameMapper` + tsconfig.test.json `paths` resolve the package **source** (`rootDir` widened to `.` in the test config only, which never emits).
  - Dockerfile: the package manifest is copied before `npm install` in all three install stages so the `file:` dep resolves; production copies the built contract `dist/` from the builder stage.
- **Publish workflow** `.github/workflows/publish-plugin-contract.yml`: on push to `develop` touching `packages/plugin-contract/**` (or manual dispatch), builds and publishes to `npm.pkg.github.com` with the ephemeral `GITHUB_TOKEN` (`packages: write`). Skips (instead of failing) when the version is already on the registry, since npm versions are immutable.

The private ruleset repo's switch from its mirrored `src/types.ts` to this published package is a follow-up after first publish; nothing there is touched here.

## Verification

- Full suite: **40 suites passed, 869 passed + 3 todo** — identical to the pre-change baseline, zero regression.
- `npm run typecheck` and `npm run typecheck:tests` both clean.
- `npm run build` green; emitted `dist/services/pluginLoader.js` imports the bare package specifier and `node` dynamic-import of it succeeds (runtime resolution proven, not assumed).
- `npm pack` in `packages/plugin-contract` from a clean state (no `dist/`) self-builds via `prepack`; tarball = `dist/index.js`, `dist/index.d.ts`, `package.json`, `README.md` (3.2 kB).
