### PR TITLE
Add spine ingest emitter; cut queue over to plugin extraction when configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,15 @@ MFC_ALLOWED_COOKIES=PHPSESSID,sesUID,sesDID,cf_clearance
 # Example: http://fc-backend:5050
 # BACKEND_URL=http://fc-backend:5050
 
+# Aggregation Spine Ingest (optional, default OFF)
+# Base URL of the fc-aggregation SpineIngest gRPC server (h2c/HTTP2).
+# When set AND a plugin ruleset matches an item's URL, the scrape queue takes
+# the new path: raw page fetch -> plugin extraction -> gRPC emit to the spine
+# (no webhook leg). Unset = legacy scrapeMFC+webhook path for everything.
+# INGEST_BASE_URL=http://fc-aggregation:50051
+# Per-call deadline in milliseconds for spine ingest RPCs (default: 30000)
+# INGEST_TIMEOUT_MS=30000
+
 # Debug Logging (optional)
 # Enable debug output for specific namespaces
 # DEBUG=scraper:*

--- a/README.md
+++ b/README.md
@@ -634,6 +634,12 @@ See `.env.example` for complete configuration template.
   - Use when plugins are injected at runtime (e.g. a mounted volume in a container) instead of being installed as dependencies
   - Example: `/plugins/node_modules`
   - An explicit `nodeModulesDir` option passed to the plugin bootstrap takes precedence
+- `INGEST_BASE_URL`: Base URL of the fc-aggregation SpineIngest gRPC server (h2c/HTTP2)
+  - Example: `http://fc-aggregation:50051`
+  - When set AND a plugin ruleset matches an item's URL, the scrape queue takes the new ingest path: raw page fetch → plugin extraction → gRPC emit to the aggregation spine (no webhook leg on that path)
+  - Unset (default): the new path is disabled and every item uses the legacy scrape+webhook path
+- `INGEST_TIMEOUT_MS`: Per-call deadline in milliseconds for spine ingest RPCs
+  - Default: `30000`
 
 **MFC Cookie Security:**
 - `MFC_ALLOWED_COOKIES`: Whitelist of cookie names allowed during authenticated MFC scraping

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
       "version": "2.3.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@bufbuild/protobuf": "^2.13.0",
+        "@connectrpc/connect": "^2.1.2",
+        "@connectrpc/connect-node": "^2.1.2",
         "@figurecollecting/fc-shared": "^1.5.1",
+        "@figurecollecting/ingest-contract": "^0.1.0",
         "@figurecollecting/scraper-plugin-contract": "file:packages/plugin-contract",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.79.0",
@@ -549,6 +553,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1061,6 +1093,15 @@
       },
       "peerDependencies": {
         "react": ">=18.0.0"
+      }
+    },
+    "node_modules/@figurecollecting/ingest-contract": {
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@figurecollecting/ingest-contract/0.1.0/dc1aca8172862e55d730cf241708a520ea7091b7",
+      "integrity": "sha512-RHK6g0V7Y49q0w5EiWqeWdP2DAluY3uvsWSDe94mwJpv3oBJtARvTbWmyRlaSpEGnkj6R36WHR9j4AwM7RCsfA==",
+      "license": "UNLICENSED",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.13.0"
       }
     },
     "node_modules/@figurecollecting/scraper-plugin-contract": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "^2.13.0",
+    "@connectrpc/connect": "^2.1.2",
+    "@connectrpc/connect-node": "^2.1.2",
     "@figurecollecting/fc-shared": "^1.5.1",
+    "@figurecollecting/ingest-contract": "^0.1.0",
     "@figurecollecting/scraper-plugin-contract": "file:packages/plugin-contract",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.79.0",

--- a/src/__tests__/unit/ingestEmitter.test.ts
+++ b/src/__tests__/unit/ingestEmitter.test.ts
@@ -1,0 +1,281 @@
+/**
+ * IngestEmitter tests — wire-mapping fidelity + retry classification against
+ * an IN-PROCESS SpineIngest server (connectNodeAdapter on node:http2, real
+ * gRPC over an ephemeral localhost port). Nothing is mocked at the transport
+ * boundary: what the stub service captures is exactly what the spine's real
+ * server would decode.
+ *
+ * Fidelity contract under test (mirrors @figurecollecting/ingest-contract):
+ *   - fields_json is the EXACT JSON text of the fields object
+ *   - extracted_at passes through byte-identical (raw token, never parsed)
+ *   - warnings travel verbatim
+ *   - optional source fields (url, rulesetVersion) are ABSENT when absent
+ * Retry contract:
+ *   - Unavailable  -> bounded exponential backoff (3 tries total)
+ *   - InvalidArgument -> NEVER retried (producer bug, loud log)
+ *   - Internal     -> at most ONE delayed retry, loud log
+ *   - anything else (e.g. DeadlineExceeded) -> no retry
+ *   - SUCCESS = RPC resolved OK, even when stats report zero inserts
+ */
+import * as http2 from 'node:http2';
+import type { AddressInfo } from 'node:net';
+import { Code, ConnectError, type ConnectRouter } from '@connectrpc/connect';
+import { connectNodeAdapter } from '@connectrpc/connect-node';
+import { create } from '@bufbuild/protobuf';
+import {
+  SpineIngest,
+  WriteStatsSchema,
+  type ExtractedData as WireExtractedData,
+  type WriteStats,
+} from '@figurecollecting/ingest-contract';
+import type { ExtractedData } from '@figurecollecting/scraper-plugin-contract';
+import { IngestEmitter, createIngestEmitterFromEnv } from '../../services/ingestEmitter';
+
+type StubImpl = (req: WireExtractedData) => Promise<WriteStats> | WriteStats;
+
+const okStats = (): WriteStats =>
+  create(WriteStatsSchema, { sourceId: '11111111-2222-3333-4444-555555555555' });
+
+interface StubServer {
+  baseUrl: string;
+  captured: WireExtractedData[];
+  callCount: () => number;
+  close: () => Promise<void>;
+}
+
+/** In-process SpineIngest stub: real h2c server, ephemeral port. */
+async function startStub(impl: StubImpl): Promise<StubServer> {
+  const captured: WireExtractedData[] = [];
+  let calls = 0;
+
+  const routes = (router: ConnectRouter) => {
+    router.service(SpineIngest, {
+      ingest: async (req: WireExtractedData) => {
+        calls++;
+        captured.push(req);
+        return impl(req);
+      },
+    });
+  };
+
+  const server = http2.createServer(connectNodeAdapter({ routes }));
+  const sessions: http2.ServerHttp2Session[] = [];
+  server.on('session', s => sessions.push(s));
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    captured,
+    callCount: () => calls,
+    close: async () => {
+      for (const s of sessions) s.destroy();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    },
+  };
+}
+
+const codeOf = async (p: Promise<unknown>): Promise<Code | 'OK'> => {
+  try {
+    await p;
+    return 'OK';
+  } catch (e) {
+    return ConnectError.from(e).code;
+  }
+};
+
+describe('IngestEmitter', () => {
+  let stub: StubServer | null = null;
+
+  afterEach(async () => {
+    if (stub) {
+      await stub.close();
+      stub = null;
+    }
+  });
+
+  const makeEmitter = (baseUrl: string, overrides: Record<string, unknown> = {}) =>
+    new IngestEmitter({ baseUrl, timeoutMs: 5000, retryDelayMs: 1, ...overrides });
+
+  describe('wire mapping fidelity', () => {
+    it('maps source 1:1, fields as exact JSON text, and warnings verbatim', async () => {
+      stub = await startStub(() => okStats());
+      const emitter = makeEmitter(stub.baseUrl);
+
+      const fields = {
+        name: 'Kitagawa Marin',
+        jan: '4530956107891',
+        // precision-bearing raw token beyond float64 — must survive as string
+        productCode: '9007199254740993',
+        releases: [{ date: '2026-06-01', price: '25,000' }],
+      };
+      const extracted: ExtractedData = {
+        source: {
+          site: 'mfc',
+          itemId: '1450976',
+          url: 'https://myfigurecollection.net/item/1450976',
+          extractedAt: '2026-06-15T00:00:00.123456Z',
+          rulesetVersion: 'mfc@1.2',
+        },
+        fields,
+        warnings: ['producer saw layout drift', 'µs precision noted'],
+      };
+
+      await emitter.send(extracted);
+
+      expect(stub.captured).toHaveLength(1);
+      const wire = stub.captured[0];
+      expect(wire.source?.site).toBe('mfc');
+      expect(wire.source?.itemId).toBe('1450976');
+      expect(wire.source?.url).toBe('https://myfigurecollection.net/item/1450976');
+      expect(wire.source?.rulesetVersion).toBe('mfc@1.2');
+      // fields_json is the EXACT JSON text of ONE JSON object
+      expect(wire.fieldsJson).toBe(JSON.stringify(fields));
+      // warnings pass through verbatim
+      expect([...wire.warnings]).toEqual(['producer saw layout drift', 'µs precision noted']);
+    });
+
+    it('passes extractedAt through byte-identical, even a weird-but-PG-valid token', async () => {
+      stub = await startStub(() => okStats());
+      const emitter = makeEmitter(stub.baseUrl);
+
+      await emitter.send({
+        source: { site: 'mfc', itemId: '1', extractedAt: '20260605T090000Z' },
+        fields: {},
+        warnings: [],
+      });
+
+      // raw string token: never parsed, never reformatted
+      expect(stub.captured[0].source?.extractedAt).toBe('20260605T090000Z');
+    });
+
+    it('leaves optional url and rulesetVersion ABSENT on the wire when absent', async () => {
+      stub = await startStub(() => okStats());
+      const emitter = makeEmitter(stub.baseUrl);
+
+      await emitter.send({
+        source: { site: 'amiami', itemId: 'FIGURE-999', extractedAt: '2026-07-24T00:00:00.000Z' },
+        fields: { name: 'x' },
+        warnings: [],
+      });
+
+      expect(stub.captured[0].source?.url).toBeUndefined();
+      expect(stub.captured[0].source?.rulesetVersion).toBeUndefined();
+    });
+
+    it('treats an all-deduped WriteStats (inserted=0) as SUCCESS and returns it', async () => {
+      // post-commit retry legitimately returns deduped counts — that is success
+      stub = await startStub(() =>
+        create(WriteStatsSchema, {
+          sourceId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          claims: { emitted: 12, inserted: 0, deduped: 12, quarantined: 0, dropped: 0 },
+        })
+      );
+      const emitter = makeEmitter(stub.baseUrl);
+
+      const stats = await emitter.send({
+        source: { site: 'mfc', itemId: '2', extractedAt: '2026-07-24T00:00:00.000Z' },
+        fields: { name: 'dupe' },
+        warnings: [],
+      });
+
+      expect(stats.claims?.inserted).toBe(0);
+      expect(stats.claims?.deduped).toBe(12);
+      // productId absent (unstorable anchor) is a valid success shape
+      expect(stats.productId).toBeUndefined();
+      expect(stub.callCount()).toBe(1);
+    });
+  });
+
+  describe('retry classification', () => {
+    const sample: ExtractedData = {
+      source: { site: 'mfc', itemId: '3', extractedAt: '2026-07-24T00:00:00.000Z' },
+      fields: { name: 'retry probe' },
+      warnings: [],
+    };
+
+    it('retries UNAVAILABLE with backoff and succeeds on a later attempt', async () => {
+      let failures = 2;
+      stub = await startStub(() => {
+        if (failures-- > 0) throw new ConnectError('spine unavailable', Code.Unavailable);
+        return okStats();
+      });
+      const emitter = makeEmitter(stub.baseUrl);
+
+      const stats = await emitter.send(sample);
+      expect(stats.sourceId).toBe('11111111-2222-3333-4444-555555555555');
+      expect(stub.callCount()).toBe(3);
+    });
+
+    it('gives up on UNAVAILABLE after 3 total tries', async () => {
+      stub = await startStub(() => {
+        throw new ConnectError('spine unavailable', Code.Unavailable);
+      });
+      const emitter = makeEmitter(stub.baseUrl);
+
+      await expect(codeOf(emitter.send(sample))).resolves.toBe(Code.Unavailable);
+      expect(stub.callCount()).toBe(3);
+    });
+
+    it('NEVER retries INVALID_ARGUMENT and logs it loudly (producer bug)', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      stub = await startStub(() => {
+        throw new ConnectError('fields_json is not valid JSON text', Code.InvalidArgument);
+      });
+      const emitter = makeEmitter(stub.baseUrl);
+
+      await expect(codeOf(emitter.send(sample))).resolves.toBe(Code.InvalidArgument);
+      expect(stub.callCount()).toBe(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('producer bug'));
+    });
+
+    it('retries INTERNAL at most once, then fails', async () => {
+      stub = await startStub(() => {
+        throw new ConnectError('ingest failed: broken', Code.Internal);
+      });
+      const emitter = makeEmitter(stub.baseUrl);
+
+      await expect(codeOf(emitter.send(sample))).resolves.toBe(Code.Internal);
+      expect(stub.callCount()).toBe(2);
+    });
+
+    it('recovers when INTERNAL clears on the single delayed retry', async () => {
+      let first = true;
+      stub = await startStub(() => {
+        if (first) {
+          first = false;
+          throw new ConnectError('ingest failed: transient', Code.Internal);
+        }
+        return okStats();
+      });
+      const emitter = makeEmitter(stub.baseUrl);
+
+      const stats = await emitter.send(sample);
+      expect(stats.sourceId).toBe('11111111-2222-3333-4444-555555555555');
+      expect(stub.callCount()).toBe(2);
+    });
+
+    it('applies the per-call timeout and does NOT retry deadline expiry', async () => {
+      stub = await startStub(async () => {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        return okStats();
+      });
+      const emitter = makeEmitter(stub.baseUrl, { timeoutMs: 100 });
+
+      await expect(codeOf(emitter.send(sample))).resolves.toBe(Code.DeadlineExceeded);
+      expect(stub.callCount()).toBe(1);
+    });
+  });
+
+  describe('createIngestEmitterFromEnv', () => {
+    it('returns null when INGEST_BASE_URL is unset (new path disabled)', () => {
+      expect(createIngestEmitterFromEnv({})).toBeNull();
+      expect(createIngestEmitterFromEnv({ INGEST_BASE_URL: '' })).toBeNull();
+    });
+
+    it('builds an emitter when INGEST_BASE_URL is set', () => {
+      const emitter = createIngestEmitterFromEnv({ INGEST_BASE_URL: 'http://spine.internal:50051' });
+      expect(emitter).toBeInstanceOf(IngestEmitter);
+    });
+  });
+});

--- a/src/__tests__/unit/scrapeQueueIngest.test.ts
+++ b/src/__tests__/unit/scrapeQueueIngest.test.ts
@@ -1,0 +1,286 @@
+/**
+ * ScrapeQueue ingest cutover tests — when an IngestEmitter is configured
+ * (INGEST_BASE_URL) AND the plugin registry resolves a ruleset for the item's
+ * URL, the queue takes the NEW path: raw page fetch (engine's scraping
+ * service) -> ruleset.extract() -> ingestEmitter.send(). Clean cut: NO
+ * webhook leg on that path. When the emitter is absent OR no ruleset matches,
+ * the legacy scrapeMFC+webhook path runs untouched.
+ *
+ * The fixture ruleset mirrors src/__tests__/fixtures/plugins/
+ * mock-scraper-ruleset (same shape a real plugin registers), pointed at the
+ * queue's myfigurecollection.net URLs so registry lookup resolves.
+ */
+
+// Mock scrapeMFC to control legacy-path outcomes
+const mockScrapeMFC = jest.fn();
+
+// Persistent mock objects that survive clearAllMocks
+const mockNotifyItemSuccess = jest.fn().mockResolvedValue(true);
+const mockNotifyItemFailed = jest.fn().mockResolvedValue(true);
+const mockNotifyItemSkipped = jest.fn().mockResolvedValue(true);
+
+jest.mock('../../services/genericScraper', () => ({
+  scrapeMFC: (...args: any[]) => mockScrapeMFC(...args),
+  BrowserPool: {
+    getStealthBrowser: jest.fn(),
+    getBrowser: jest.fn(),
+    returnBrowser: jest.fn(),
+    getPoolSize: jest.fn().mockReturnValue(2),
+    getPoolCapacity: jest.fn().mockReturnValue(3),
+    reset: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/webhookClient', () => ({
+  notifyItemSuccess: (...args: any[]) => mockNotifyItemSuccess(...args),
+  notifyItemFailed: (...args: any[]) => mockNotifyItemFailed(...args),
+  notifyItemSkipped: (...args: any[]) => mockNotifyItemSkipped(...args),
+}));
+
+import type { ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+import { ScrapeQueue, resetScrapeQueue } from '../../services/scrapeQueue';
+import { createExtractionRegistry, ExtractionRegistryImpl } from '../../services/extractionRegistry';
+
+const FIXTURE_HTML = '<html><body><h1 class="title">Kitagawa Marin</h1></body></html>';
+
+/** Registry with the fixture site registered against the queue's MFC URLs. */
+function makeRegistry(ruleset: ExtractionRuleset): ExtractionRegistryImpl {
+  const registry = createExtractionRegistry();
+  registry.registerSite({
+    siteId: ruleset.siteId,
+    name: 'Mock MFC',
+    domains: ['myfigurecollection.net'],
+    rateLimit: {
+      domain: 'myfigurecollection.net',
+      baseDelayMs: 1000,
+      minDelayMs: 500,
+      maxDelayMs: 5000,
+      backoffMultiplier: 1.5,
+      recoveryDivisor: 1.5,
+      successThreshold: 3,
+    },
+    requiresBrowser: false,
+    allowedCookies: [],
+  });
+  registry.registerRuleset(ruleset);
+  return registry;
+}
+
+/** Fixture ruleset (same shape as fixtures/plugins/mock-scraper-ruleset). */
+function makeRuleset(extract?: jest.Mock): ExtractionRuleset & { extract: jest.Mock } {
+  const extractFn =
+    extract ??
+    jest.fn((html: string, url: string) => ({
+      source: {
+        site: 'mock-mfc',
+        itemId: '12345',
+        url,
+        extractedAt: '2026-07-24T00:00:00.000Z',
+        rulesetVersion: '1.0.0',
+      },
+      fields: { name: 'Kitagawa Marin', jan: '4530956107891' },
+      warnings: [],
+    }));
+  return {
+    siteId: 'mock-mfc',
+    version: '1.0.0',
+    extract: extractFn,
+    validate: () => ({ valid: true, errors: [], warnings: [] }),
+  };
+}
+
+function makeScrapingStub() {
+  return {
+    scrapePage: jest.fn().mockResolvedValue({
+      html: FIXTURE_HTML,
+      url: 'https://myfigurecollection.net/item/12345',
+      title: 'Item',
+      statusCode: 200,
+    }),
+    scrapePageStealth: jest.fn().mockResolvedValue({
+      html: FIXTURE_HTML,
+      url: 'https://myfigurecollection.net/item/12345',
+      title: 'Item',
+      statusCode: 200,
+    }),
+  };
+}
+
+describe('ScrapeQueue - ingest cutover', () => {
+  let queue: ScrapeQueue;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers({ advanceTimers: true });
+    resetScrapeQueue();
+    mockScrapeMFC.mockReset();
+    mockNotifyItemSuccess.mockResolvedValue(true);
+    mockNotifyItemFailed.mockResolvedValue(true);
+    mockNotifyItemSkipped.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    if (queue) {
+      queue.stop();
+      queue.clear();
+    }
+    resetScrapeQueue();
+    jest.useRealTimers();
+  });
+
+  // Helper to advance timers and flush microtask queue multiple times
+  async function advanceAndFlush(ms: number, iterations: number = 3) {
+    for (let i = 0; i < iterations; i++) {
+      jest.advanceTimersByTime(ms / iterations);
+      await jest.advanceTimersByTimeAsync(50);
+    }
+  }
+
+  it('takes the ingest path when emitter configured and ruleset matches: fetch -> extract -> emit, NO webhook, NO scrapeMFC', async () => {
+    const ruleset = makeRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const result = queue.enqueue('12345', { priority: 'WARM', sessionId: 'session1' });
+    await advanceAndFlush(500);
+    const data = await result.promise;
+
+    // engine fetched the raw page; extraction was the plugin's job
+    expect(scraping.scrapePage).toHaveBeenCalledWith('https://myfigurecollection.net/item/12345');
+    expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, 'https://myfigurecollection.net/item/12345');
+    // the extraction went to the spine, verbatim
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0][0];
+    expect(sent.source.site).toBe('mock-mfc');
+    expect(sent.source.extractedAt).toBe('2026-07-24T00:00:00.000Z');
+    expect(sent.fields).toEqual({ name: 'Kitagawa Marin', jan: '4530956107891' });
+    // clean cut: no legacy scrape, no webhook leg on the new path
+    expect(mockScrapeMFC).not.toHaveBeenCalled();
+    expect(mockNotifyItemSuccess).not.toHaveBeenCalled();
+    // waiting callers still resolve (with the extracted field bag)
+    expect(data).toEqual({ name: 'Kitagawa Marin', jan: '4530956107891' });
+    expect(queue.getStats().completed).toBe(1);
+  });
+
+  it('uses the stealth fetch when the item carries cookies', async () => {
+    const ruleset = makeRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const cookies = { PHPSESSID: 'abc' };
+    const result = queue.enqueue('12345', { priority: 'WARM', sessionId: 'session1', cookies });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    expect(scraping.scrapePageStealth).toHaveBeenCalledWith(
+      'https://myfigurecollection.net/item/12345',
+      { cookies }
+    );
+    expect(scraping.scrapePage).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the legacy scrapeMFC+webhook path when no emitter is configured', async () => {
+    const ruleset = makeRuleset();
+    const scraping = makeScrapingStub();
+    mockScrapeMFC.mockResolvedValue({ name: 'Legacy Figure' });
+
+    queue = new ScrapeQueue(false);
+    // registry present, but INGEST_BASE_URL unset -> no emitter -> legacy path
+    queue.setPluginRegistry(makeRegistry(ruleset));
+    queue.setScrapingService(scraping);
+
+    const result = queue.enqueue('12345', { priority: 'WARM', sessionId: 'session1' });
+    await advanceAndFlush(500);
+    const data = await result.promise;
+
+    expect(mockScrapeMFC).toHaveBeenCalledWith('https://myfigurecollection.net/item/12345', undefined);
+    expect(ruleset.extract).not.toHaveBeenCalled();
+    expect(scraping.scrapePage).not.toHaveBeenCalled();
+    expect(mockNotifyItemSuccess).toHaveBeenCalledWith('session1', '12345', expect.any(Object));
+    expect(data).toEqual({ name: 'Legacy Figure' });
+  });
+
+  it('keeps the legacy path when the emitter is configured but no ruleset matches the URL', async () => {
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+    mockScrapeMFC.mockResolvedValue({ name: 'Legacy Figure' });
+
+    queue = new ScrapeQueue(false);
+    // registry has NO site registered for myfigurecollection.net
+    queue.setPluginRegistry(createExtractionRegistry());
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const result = queue.enqueue('12345', { priority: 'WARM', sessionId: 'session1' });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    expect(mockScrapeMFC).toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+    expect(scraping.scrapePage).not.toHaveBeenCalled();
+    expect(mockNotifyItemSuccess).toHaveBeenCalled();
+  });
+
+  it('fails the item through existing failure handling when the emitter gives up (never a silent drop)', async () => {
+    const ruleset = makeRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockRejectedValue(new Error('spine unavailable after retries'));
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const result = queue.enqueue('12345', { priority: 'WARM', maxRetries: 0 });
+    const promiseRef = result.promise.catch((e: Error) => e);
+
+    await advanceAndFlush(500);
+    await advanceAndFlush(5000);
+
+    const error = await promiseRef;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Scrape failed');
+    expect(queue.getStats().failed).toBe(1);
+    expect(mockScrapeMFC).not.toHaveBeenCalled();
+  });
+
+  it('fails the item and logs the error when extraction throws', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ruleset = makeRuleset(
+      jest.fn(() => {
+        throw new Error('selector drift: .title vanished');
+      })
+    );
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const result = queue.enqueue('12345', { priority: 'WARM', maxRetries: 0 });
+    const promiseRef = result.promise.catch((e: Error) => e);
+
+    await advanceAndFlush(500);
+    await advanceAndFlush(5000);
+
+    const error = await promiseRef;
+    expect(error).toBeInstanceOf(Error);
+    expect(queue.getStats().failed).toBe(1);
+    // nothing was emitted for a failed extraction
+    expect(send).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Extraction failed'));
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { scraperDebug } from './utils/logger.js';
 // Import browser pool functionality
 import { initializeBrowserPool, BrowserPool } from './services/genericScraper.js';
 import { bootstrapPlugins, shutdownPlugins } from './services/pluginBootstrap.js';
+import { getScrapeQueue } from './services/scrapeQueue.js';
 import { ScraperPlugin } from '@figurecollecting/scraper-plugin-contract';
 
 dotenv.config();
@@ -86,8 +87,12 @@ let loadedPlugins: ScraperPlugin[] = [];
 // connections, then start the server and initialize the browser pool.
 async function startServer(): Promise<void> {
   try {
-    const { plugins } = await bootstrapPlugins(app);
+    const { registry, plugins } = await bootstrapPlugins(app);
     loadedPlugins = plugins;
+    // Thread the plugin registry into the scrape queue so items whose URLs
+    // resolve to a plugin ruleset take the ingest path (when INGEST_BASE_URL
+    // is configured) instead of the legacy scrapeMFC+webhook path.
+    getScrapeQueue().setPluginRegistry(registry);
     if (plugins.length > 0) {
       console.log(`[PAGE-SCRAPER] Loaded ${plugins.length} plugin(s): ${plugins.map(p => `${p.name}@${p.version}`).join(', ')}`);
     }

--- a/src/services/ingestEmitter.ts
+++ b/src/services/ingestEmitter.ts
@@ -1,0 +1,163 @@
+/**
+ * Ingest Emitter — engine-side gRPC client for the fc-aggregation spine
+ * (ingest.v1.SpineIngest/Ingest). ENGINE PLUMBING ONLY: plugins never see
+ * this module — it is deliberately NOT part of EngineServices or the plugin
+ * contract. The queue hands it a plugin-produced ExtractedData; it maps that
+ * 1:1 onto the wire and emits.
+ *
+ * FIDELITY (hard contract, mirrors the proto's doctrine):
+ *   - fields_json = JSON.stringify(fields): the JSON TEXT of one object;
+ *     string tokens pass byte-exact, never folded through float64.
+ *   - extractedAt is a RAW STRING passthrough — never parsed or reformatted
+ *     (PG-valid-but-JS-unparseable spellings must flow verbatim).
+ *   - warnings travel verbatim; optional source fields stay ABSENT when
+ *     absent.
+ *
+ * TRANSPORT: createGrpcTransport is h2c-hardwired HTTP/2, matching the
+ * spine server (node:http2 cleartext behind the mesh). Never swap this for
+ * createConnectTransport with httpVersion '1.1' — the server speaks gRPC
+ * over h2 only.
+ *
+ * RETRY (SUCCESS = the RPC resolved OK — never key success on
+ * stats.inserted > 0; a post-commit retry legitimately returns all-deduped
+ * counts, and identical re-ingest is idempotent so at-least-once retry is
+ * safe):
+ *   - UNAVAILABLE      -> bounded exponential backoff, 3 tries total
+ *   - INVALID_ARGUMENT -> NEVER retried: a producer bug, logged loudly
+ *   - INTERNAL         -> at most one delayed retry, logged loudly
+ *   - anything else    -> no retry
+ */
+import { Code, ConnectError, createClient, type Client } from '@connectrpc/connect';
+import { createGrpcTransport } from '@connectrpc/connect-node';
+import { create } from '@bufbuild/protobuf';
+import {
+  SpineIngest,
+  ExtractedDataSchema,
+  type ExtractedData as WireExtractedData,
+  type WriteStats,
+} from '@figurecollecting/ingest-contract';
+import type { ExtractedData } from '@figurecollecting/scraper-plugin-contract';
+import { sanitizeForLog } from '../utils/security.js';
+
+/** Default per-call deadline. The server has no deadline of its own. */
+export const DEFAULT_INGEST_TIMEOUT_MS = 30_000;
+
+/** Total tries (first call + retries) for UNAVAILABLE. */
+const UNAVAILABLE_MAX_TRIES = 3;
+/** Total tries for INTERNAL: the first call plus exactly one delayed retry. */
+const INTERNAL_MAX_TRIES = 2;
+
+export interface IngestEmitterOptions {
+  /** Spine ingest server base URL, e.g. http://fc-aggregation:50051 */
+  baseUrl: string;
+  /** Per-call deadline in ms (default 30s). */
+  timeoutMs?: number;
+  /** Base delay for exponential backoff between retries (default 1s). */
+  retryDelayMs?: number;
+}
+
+export class IngestEmitter {
+  private readonly client: Client<typeof SpineIngest>;
+  private readonly timeoutMs: number;
+  private readonly retryDelayMs: number;
+
+  constructor(options: IngestEmitterOptions) {
+    // h2c-hardwired HTTP/2 — matches the spine's node:http2 cleartext server.
+    const transport = createGrpcTransport({ baseUrl: options.baseUrl });
+    this.client = createClient(SpineIngest, transport);
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_INGEST_TIMEOUT_MS;
+    this.retryDelayMs = options.retryDelayMs ?? 1_000;
+  }
+
+  /**
+   * Emit one extraction to the spine. Resolves with the server's WriteStats
+   * accounting (any OK response is success); rejects with the final
+   * ConnectError once the retry policy is exhausted.
+   */
+  async send(extracted: ExtractedData): Promise<WriteStats> {
+    const message = toWire(extracted);
+    const label = `${extracted.source.site}:${extracted.source.itemId}`;
+
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.client.ingest(message, { timeoutMs: this.timeoutMs });
+      } catch (error) {
+        const connectError = ConnectError.from(error);
+        if (!this.shouldRetry(connectError, attempt, label)) {
+          throw connectError;
+        }
+        const delay = this.retryDelayMs * 2 ** (attempt - 1);
+        console.warn(
+          `[INGEST EMITTER] ${Code[connectError.code]} from spine for ${label} (attempt ${attempt}), retrying in ${delay}ms: ${sanitizeForLog(connectError.rawMessage)}`
+        );
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  private shouldRetry(error: ConnectError, attempt: number, label: string): boolean {
+    switch (error.code) {
+      case Code.Unavailable:
+        if (attempt < UNAVAILABLE_MAX_TRIES) return true;
+        console.error(
+          `[INGEST EMITTER] Spine UNAVAILABLE for ${label} after ${attempt} tries, giving up: ${sanitizeForLog(error.rawMessage)}`
+        );
+        return false;
+      case Code.Internal:
+        if (attempt < INTERNAL_MAX_TRIES) {
+          console.error(
+            `[INGEST EMITTER] INTERNAL from spine for ${label} — server-side fault, retrying ONCE: ${sanitizeForLog(error.rawMessage)}`
+          );
+          return true;
+        }
+        console.error(
+          `[INGEST EMITTER] INTERNAL from spine for ${label} persisted after retry, giving up: ${sanitizeForLog(error.rawMessage)}`
+        );
+        return false;
+      case Code.InvalidArgument:
+        console.error(
+          `[INGEST EMITTER] INVALID_ARGUMENT from spine for ${label} — producer bug, NOT retrying: ${sanitizeForLog(error.rawMessage)}`
+        );
+        return false;
+      default:
+        console.error(
+          `[INGEST EMITTER] ${Code[error.code]} from spine for ${label}, not retrying: ${sanitizeForLog(error.rawMessage)}`
+        );
+        return false;
+    }
+  }
+}
+
+/**
+ * Build the emitter from INGEST_BASE_URL (naming mirrors BACKEND_URL /
+ * WEBHOOK_BASE_URL). Unset or empty = the new ingest path is DISABLED and
+ * the queue keeps its legacy behavior.
+ */
+export function createIngestEmitterFromEnv(env: NodeJS.ProcessEnv = process.env): IngestEmitter | null {
+  const baseUrl = env.INGEST_BASE_URL;
+  if (!baseUrl) return null;
+
+  const timeoutMs = env.INGEST_TIMEOUT_MS ? Number(env.INGEST_TIMEOUT_MS) : undefined;
+  return new IngestEmitter({
+    baseUrl,
+    ...(timeoutMs !== undefined && Number.isFinite(timeoutMs) ? { timeoutMs } : {}),
+  });
+}
+
+/** Map plugin ExtractedData 1:1 onto the ingest wire (fidelity: see header). */
+function toWire(extracted: ExtractedData): WireExtractedData {
+  const { site, itemId, url, extractedAt, rulesetVersion } = extracted.source;
+  return create(ExtractedDataSchema, {
+    source: {
+      site,
+      itemId,
+      // RAW STRING passthrough — never parse or reformat the token.
+      extractedAt,
+      ...(url !== undefined ? { url } : {}),
+      ...(rulesetVersion !== undefined ? { rulesetVersion } : {}),
+    },
+    // The JSON TEXT of ONE JSON object — exact serialization of the field bag.
+    fieldsJson: JSON.stringify(extracted.fields),
+    warnings: [...extracted.warnings],
+  });
+}

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -19,6 +19,13 @@ import { sanitizeForLog } from '../utils/security.js';
 import { getSessionManager, resetSessionManager, SessionManager, SessionPausedEvent } from './sessionManager.js';
 import { notifyItemSuccess, notifyItemFailed, notifyItemSkipped } from './webhookClient.js';
 import { enrichmentLogger } from '../utils/logger.js';
+import { createScrapingService } from './engineServices/scrapingService.js';
+import { createIngestEmitterFromEnv } from './ingestEmitter.js';
+import type {
+  ExtractionRuleset,
+  ExtractedData as PluginExtractedData,
+  ScrapingService,
+} from '@figurecollecting/scraper-plugin-contract';
 
 // ============================================================================
 // Types and Interfaces
@@ -106,6 +113,25 @@ export interface EnqueueResult {
   /** Promise that resolves when scraping completes */
   promise: Promise<ScrapedData>;
 }
+
+/**
+ * Narrow view of the plugin extraction registry the queue needs to decide
+ * whether an item's URL has a plugin-provided ruleset (ingest cutover seam).
+ */
+export interface RulesetResolver {
+  getRulesetForUrl(url: string): ExtractionRuleset | undefined;
+}
+
+/**
+ * Narrow view of the spine ingest emitter. Engine plumbing ONLY — plugins
+ * never see the emitter (it is not part of EngineServices or the contract).
+ */
+export interface IngestSender {
+  send(extracted: PluginExtractedData): Promise<unknown>;
+}
+
+/** Raw page-fetch capability the ingest path uses (extraction is the plugin's job). */
+type RawPageFetcher = Pick<ScrapingService, 'scrapePage' | 'scrapePageStealth'>;
 
 // ============================================================================
 // Rate Limiting Configuration
@@ -228,12 +254,24 @@ export class ScrapeQueue {
   // Cooldown wait timer - prevents multiple concurrent timers when all items blocked
   private cooldownWaitTimerId: NodeJS.Timeout | null = null;
 
+  // Ingest cutover seams (engine plumbing, injected — see setters below).
+  // When an emitter is configured (INGEST_BASE_URL) AND the registry resolves
+  // a ruleset for the item's URL, processing takes the NEW path: raw page
+  // fetch -> ruleset.extract() -> spine emit. NO webhook leg on that path.
+  // Otherwise the legacy scrapeMFC+webhook path runs untouched.
+  private pluginRegistry: RulesetResolver | null = null;
+  private ingestEmitter: IngestSender | null = null;
+  private rawPageFetcher: RawPageFetcher | null = null;
+
   constructor(testMode?: boolean) {
     // Auto-detect test environment if not explicitly set
     this.testMode = testMode ?? (
       process.env.NODE_ENV === 'test' ||
       process.env.JEST_WORKER_ID !== undefined
     );
+
+    // New ingest path is enabled by INGEST_BASE_URL; unset = null = disabled.
+    this.ingestEmitter = createIngestEmitterFromEnv();
 
     // Get or create session manager
     this.sessionManager = getSessionManager();
@@ -244,6 +282,30 @@ export class ScrapeQueue {
     });
 
     console.log(`[SCRAPE QUEUE] Initialized (testMode: ${this.testMode})`);
+  }
+
+  /**
+   * Inject the plugin extraction registry (threaded from bootstrapPlugins in
+   * src/index.ts). Without it, or without an emitter, items keep the legacy path.
+   */
+  setPluginRegistry(registry: RulesetResolver | null): void {
+    this.pluginRegistry = registry;
+  }
+
+  /**
+   * Override the spine ingest emitter (tests / DI). The constructor default
+   * comes from INGEST_BASE_URL via createIngestEmitterFromEnv().
+   */
+  setIngestEmitter(emitter: IngestSender | null): void {
+    this.ingestEmitter = emitter;
+  }
+
+  /**
+   * Override the raw page-fetch service used by the ingest path (tests / DI).
+   * Defaults lazily to the same engine scraping service plugins get.
+   */
+  setScrapingService(service: RawPageFetcher | null): void {
+    this.rawPageFetcher = service;
   }
 
   /**
@@ -775,11 +837,18 @@ export class ScrapeQueue {
     console.log(`[SCRAPE QUEUE] Processing MFC ${item.mfcId} (${item.priority}, attempt ${item.retryCount + 1}/${item.maxRetries + 1}, delay=${this.currentDelay}ms, pool=${poolAvailable}/${BrowserPool.getPoolCapacity()})`);
 
     try {
-      // Perform the scrape
-      const result = await scrapeMFC(item.url, item.cookies);
+      // Ingest cutover: emitter configured AND a plugin ruleset matches the
+      // URL -> new path (extract + spine emit, no webhook). Otherwise legacy.
+      const ruleset = this.ingestEmitter ? this.lookupRuleset(item.url) : undefined;
 
-      // Success!
-      this.handleSuccess(item, result);
+      if (this.ingestEmitter && ruleset) {
+        const fields = await this.processViaIngest(item, ruleset);
+        this.handleSuccess(item, fields, { skipWebhook: true });
+      } else {
+        // Legacy path: MFC-specific scrape + webhook callbacks
+        const result = await scrapeMFC(item.url, item.cookies);
+        this.handleSuccess(item, result);
+      }
 
     } catch (error: any) {
       // Handle failure
@@ -792,6 +861,57 @@ export class ScrapeQueue {
     if (!this.cooldownWaitTimerId) {
       setTimeout(() => this.processNext(), this.currentDelay);
     }
+  }
+
+  /**
+   * Resolve a plugin ruleset for a URL. A lookup failure (e.g. unparseable
+   * URL) is treated as "no match" so the legacy path still gets its chance.
+   */
+  private lookupRuleset(url: string): ExtractionRuleset | undefined {
+    if (!this.pluginRegistry) return undefined;
+    try {
+      return this.pluginRegistry.getRulesetForUrl(url);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private getRawPageFetcher(): RawPageFetcher {
+    if (!this.rawPageFetcher) {
+      // Same raw page-fetch machinery plugins get via EngineServices — the
+      // engine only fetches; extraction is the plugin's job.
+      this.rawPageFetcher = createScrapingService();
+    }
+    return this.rawPageFetcher;
+  }
+
+  /**
+   * NEW ingest path: fetch raw HTML, hand it to the plugin's ruleset for
+   * extraction, and emit the result to the aggregation spine. Clean cut —
+   * no webhook leg here. Throws on fetch, extraction, or emit failure so
+   * the item flows through the queue's existing failure handling (never a
+   * silent drop). Returns the extracted field bag so waiting callers'
+   * promises still resolve.
+   */
+  private async processViaIngest(item: QueueItem, ruleset: ExtractionRuleset): Promise<ScrapedData> {
+    const fetcher = this.getRawPageFetcher();
+    const page = item.cookies
+      ? await fetcher.scrapePageStealth(item.url, { cookies: item.cookies })
+      : await fetcher.scrapePage(item.url);
+
+    let extracted: PluginExtractedData;
+    try {
+      extracted = ruleset.extract(page.html, item.url);
+    } catch (error: any) {
+      console.error(
+        `[SCRAPE QUEUE] Extraction failed for ${item.url} (ruleset ${ruleset.siteId}@${ruleset.version}): ${sanitizeForLog(error?.message ?? String(error))}`
+      );
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+
+    await this.ingestEmitter!.send(extracted);
+
+    return extracted.fields as ScrapedData;
   }
 
   /**
@@ -865,7 +985,7 @@ export class ScrapeQueue {
     return false;
   }
 
-  private handleSuccess(item: QueueItem, result: ScrapedData): void {
+  private handleSuccess(item: QueueItem, result: ScrapedData, opts: { skipWebhook?: boolean } = {}): void {
     // Track success
     this.completedCount++;
     this.consecutiveSuccesses++;
@@ -890,11 +1010,14 @@ export class ScrapeQueue {
     if (item.sessionId) {
       this.sessionManager.reportSuccess(item.sessionId);
 
-      // Notify backend via webhook (non-blocking)
-      notifyItemSuccess(item.sessionId, item.mfcId, result as Record<string, unknown>).catch(() => {
-        // Webhook failures are non-fatal, just log
-        console.warn(`[SCRAPE QUEUE] Webhook notification failed for MFC ${item.mfcId}`);
-      });
+      // Notify backend via webhook (non-blocking). The ingest path skips
+      // this leg entirely — it emits to the spine ONLY (clean cut).
+      if (!opts.skipWebhook) {
+        notifyItemSuccess(item.sessionId, item.mfcId, result as Record<string, unknown>).catch(() => {
+          // Webhook failures are non-fatal, just log
+          console.warn(`[SCRAPE QUEUE] Webhook notification failed for MFC ${item.mfcId}`);
+        });
+      }
     }
 
     // Reduce delay if consistently succeeding


### PR DESCRIPTION
## Summary

1B-2 + 1B-3: engine-side spine ingest client, and the scrape queue cutover to plugin extraction + gRPC emit when configured.

### Ingest emitter (`src/services/ingestEmitter.ts`)
- gRPC client for `ingest.v1.SpineIngest/Ingest` via `createGrpcTransport` (h2c-hardwired HTTP/2, matching the spine server).
- Engine plumbing only: NOT part of EngineServices or the plugin contract — plugins never see it.
- Wire fidelity (hard contract): `fields_json = JSON.stringify(fields)` (exact JSON text of one object), `extractedAt` raw-string passthrough (never parsed/reformatted), warnings verbatim, optional source fields absent-when-absent.
- Per-call deadline (`INGEST_TIMEOUT_MS`, default 30s) — the server has no deadline of its own.
- Retry policy: UNAVAILABLE → bounded exponential backoff (3 tries total); INVALID_ARGUMENT → never retried (producer bug, loud log); INTERNAL → at most one delayed retry; anything else → no retry. Success = RPC resolved OK (an all-deduped WriteStats is success — identical re-ingest is idempotent).

### Queue cutover (`src/services/scrapeQueue.ts`, `src/index.ts`)
- `bootstrapPlugins`' registry is now threaded into the queue (was discarded).
- When `INGEST_BASE_URL` is set AND `registry.getRulesetForUrl(url)` resolves: raw page fetch (same engine scraping service plugins get; stealth when the item carries cookies) → `ruleset.extract(html, url)` → `ingestEmitter.send(extracted)`. No webhook leg on this path.
- `INGEST_BASE_URL` unset OR no ruleset match → legacy `scrapeMFC`+webhook path untouched.
- Failure semantics: emitter failure after retries and extraction throws both flow through the queue's existing failure handling (retry classification, promise rejection, stats) — never a silent drop.

### Config & docs
- `INGEST_BASE_URL` (unset = new path disabled) and `INGEST_TIMEOUT_MS` documented in README and `.env.example`.
- New deps: `@connectrpc/connect(-node)@^2.1.2`, `@bufbuild/protobuf@^2.13.0`, `@figurecollecting/ingest-contract@^0.1.0`.

## Testing

TDD throughout (RED shown before each implementation step):
- **Emitter (12 tests)** against an in-process SpineIngest server (`connectNodeAdapter` on `node:http2`, ephemeral port — real gRPC over the wire): exact `fields_json` text, byte-identical `extractedAt` passthrough incl. `20260605T090000Z`, verbatim warnings, absent optionals, absent `productId` handled, all-deduped success, and full retry-classification matrix (UNAVAILABLE×3, INVALID_ARGUMENT×1, INTERNAL×2, deadline no-retry).
- **Queue cutover (6 tests)**: ingest path chosen (extract+emit called, webhook and scrapeMFC NOT called), stealth fetch with cookies, legacy path when emitter unset, legacy path when no ruleset matches, emitter failure → item failure, extraction throw → item failure with error logged.
- Full suite: 42 suites, 887 passed + 3 todo (baseline 869+3; +18 = exactly the new tests). `typecheck` and `typecheck:tests` clean.
