### PR TITLE
Add ingest trigger route: enqueue URL scrapes into the plugin-extraction pipeline

### DIFF
--- a/src/__tests__/integration/ingestRoutes.test.ts
+++ b/src/__tests__/integration/ingestRoutes.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Ingest trigger route tests — POST /ingest/scrape {url} is the HTTP surface
+ * that drives the queue's EXISTING ingest path (registry-resolve -> raw fetch
+ * -> ruleset.extract -> ingestEmitter.send). The route only validates and
+ * enqueues; fetch/extraction/emit/retry semantics all stay in the queue.
+ *
+ * Answer shape:
+ *   400 - missing / malformed url
+ *   503 - ingest not configured (no emitter; INGEST_BASE_URL unset)
+ *   422 - no plugin ruleset matches the URL
+ *   202 - enqueued (itemId, deduplicated, position)
+ *
+ * Fixtures mirror scrapeQueueIngest.test.ts (#221) so the wiring test proves
+ * the enqueued item flows the same tested ingest path.
+ */
+
+// Persistent mock objects that survive clearAllMocks
+const mockNotifyItemSuccess = jest.fn().mockResolvedValue(true);
+const mockNotifyItemFailed = jest.fn().mockResolvedValue(true);
+const mockNotifyItemSkipped = jest.fn().mockResolvedValue(true);
+
+jest.mock('../../services/genericScraper', () => ({
+  BrowserPool: {
+    getStealthBrowser: jest.fn(),
+    getBrowser: jest.fn(),
+    returnBrowser: jest.fn(),
+    getPoolSize: jest.fn().mockReturnValue(2),
+    getPoolCapacity: jest.fn().mockReturnValue(3),
+    reset: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/webhookClient', () => ({
+  notifyItemSuccess: (...args: any[]) => mockNotifyItemSuccess(...args),
+  notifyItemFailed: (...args: any[]) => mockNotifyItemFailed(...args),
+  notifyItemSkipped: (...args: any[]) => mockNotifyItemSkipped(...args),
+}));
+
+import request from 'supertest';
+import express from 'express';
+import type { ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+import { createIngestRouter } from '../../routes/ingest';
+import { ScrapeQueue, resetScrapeQueue } from '../../services/scrapeQueue';
+import { createExtractionRegistry, ExtractionRegistryImpl } from '../../services/extractionRegistry';
+
+const FIXTURE_HTML = '<html><body><h1 class="title">Kitagawa Marin</h1></body></html>';
+const FIXTURE_URL = 'https://figures.example.test/item/777';
+
+/** Registry with the fixture site registered for the trigger URL's domain. */
+function makeRegistry(ruleset: ExtractionRuleset, domain = 'figures.example.test'): ExtractionRegistryImpl {
+  const registry = createExtractionRegistry();
+  registry.registerSite({
+    siteId: ruleset.siteId,
+    name: 'Mock Site',
+    domains: [domain],
+    rateLimit: {
+      domain,
+      baseDelayMs: 1000,
+      minDelayMs: 500,
+      maxDelayMs: 5000,
+      backoffMultiplier: 1.5,
+      recoveryDivisor: 1.5,
+      successThreshold: 3,
+    },
+    requiresBrowser: false,
+    allowedCookies: [],
+  });
+  registry.registerRuleset(ruleset);
+  return registry;
+}
+
+/** Fixture ruleset (same shape as fixtures/plugins/mock-scraper-ruleset). */
+function makeRuleset(): ExtractionRuleset & { extract: jest.Mock } {
+  const extractFn = jest.fn((html: string, url: string) => ({
+    source: {
+      site: 'mock-site',
+      itemId: '777',
+      url,
+      extractedAt: '2026-07-25T00:00:00.000Z',
+      rulesetVersion: '1.0.0',
+    },
+    fields: { name: 'Kitagawa Marin', jan: '4530956107891' },
+    warnings: [],
+  }));
+  return {
+    siteId: 'mock-site',
+    version: '1.0.0',
+    extract: extractFn,
+    validate: () => ({ valid: true, errors: [], warnings: [] }),
+  };
+}
+
+function makeScrapingStub() {
+  return {
+    scrapePage: jest.fn().mockResolvedValue({
+      html: FIXTURE_HTML,
+      url: FIXTURE_URL,
+      title: 'Item',
+      statusCode: 200,
+    }),
+    scrapePageStealth: jest.fn().mockResolvedValue({
+      html: FIXTURE_HTML,
+      url: FIXTURE_URL,
+      title: 'Item',
+      statusCode: 200,
+    }),
+  };
+}
+
+/** Poll (real timers) until the condition holds or the deadline passes. */
+async function waitFor(condition: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error('waitFor: condition not met before timeout');
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+}
+
+function makeApp(queue: ScrapeQueue): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createIngestRouter(() => queue));
+  return app;
+}
+
+describe('POST /ingest/scrape', () => {
+  let queue: ScrapeQueue;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetScrapeQueue();
+  });
+
+  afterEach(() => {
+    if (queue) {
+      queue.stop();
+      queue.clear();
+    }
+    resetScrapeQueue();
+  });
+
+  describe('validation', () => {
+    beforeEach(() => {
+      // Fully configured queue: validation failures must trip BEFORE config checks
+      queue = new ScrapeQueue(true);
+      queue.setPluginRegistry(makeRegistry(makeRuleset()));
+      queue.setIngestEmitter({ send: jest.fn().mockResolvedValue({ sourceId: 'src-1' }) });
+    });
+
+    it('returns 400 when url is missing', async () => {
+      const response = await request(makeApp(queue)).post('/ingest/scrape').send({}).expect(400);
+
+      expect(response.body).toEqual({ success: false, message: 'URL is required' });
+      expect(queue.getStats().total).toBe(0);
+    });
+
+    it('returns 400 when the request has no JSON body at all', async () => {
+      const response = await request(makeApp(queue)).post('/ingest/scrape').expect(400);
+
+      expect(response.body).toEqual({ success: false, message: 'URL is required' });
+      expect(queue.getStats().total).toBe(0);
+    });
+
+    it('returns 400 when url is not a valid URL', async () => {
+      const response = await request(makeApp(queue))
+        .post('/ingest/scrape')
+        .send({ url: 'not-a-url' })
+        .expect(400);
+
+      expect(response.body).toEqual({ success: false, message: 'Invalid URL format' });
+      expect(queue.getStats().total).toBe(0);
+    });
+  });
+
+  describe('configuration and ruleset checks', () => {
+    it('returns 503 when no ingest emitter is configured (INGEST_BASE_URL unset)', async () => {
+      queue = new ScrapeQueue(true);
+      queue.setPluginRegistry(makeRegistry(makeRuleset()));
+      queue.setIngestEmitter(null);
+
+      const response = await request(makeApp(queue))
+        .post('/ingest/scrape')
+        .send({ url: FIXTURE_URL })
+        .expect(503);
+
+      expect(response.body).toEqual({
+        success: false,
+        message: 'Ingest not configured (INGEST_BASE_URL unset)',
+      });
+      expect(queue.getStats().total).toBe(0);
+    });
+
+    it('returns 422 when no plugin ruleset matches the URL', async () => {
+      queue = new ScrapeQueue(true);
+      // registry present but empty: nothing matches the URL's domain
+      queue.setPluginRegistry(createExtractionRegistry());
+      queue.setIngestEmitter({ send: jest.fn().mockResolvedValue({ sourceId: 'src-1' }) });
+
+      const response = await request(makeApp(queue))
+        .post('/ingest/scrape')
+        .send({ url: FIXTURE_URL })
+        .expect(422);
+
+      expect(response.body).toEqual({
+        success: false,
+        message: 'No plugin ruleset matches this URL',
+      });
+      expect(queue.getStats().total).toBe(0);
+    });
+  });
+
+  describe('happy path', () => {
+    beforeEach(() => {
+      queue = new ScrapeQueue(true); // test mode: enqueue without auto-processing
+      queue.setPluginRegistry(makeRegistry(makeRuleset()));
+      queue.setIngestEmitter({ send: jest.fn().mockResolvedValue({ sourceId: 'src-1' }) });
+    });
+
+    it('enqueues the URL (key = url, options.url = url) and answers 202', async () => {
+      const enqueueSpy = jest.spyOn(queue, 'enqueue');
+
+      const response = await request(makeApp(queue))
+        .post('/ingest/scrape')
+        .send({ url: FIXTURE_URL })
+        .expect(202);
+
+      expect(enqueueSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueSpy).toHaveBeenCalledWith(FIXTURE_URL, { url: FIXTURE_URL });
+      expect(response.body).toEqual({
+        success: true,
+        itemId: expect.any(String),
+        deduplicated: false,
+        position: expect.any(Number),
+      });
+      expect(queue.isPending(FIXTURE_URL)).toBe(true);
+    });
+
+    it('deduplicates a repeat trigger for the same URL', async () => {
+      const app = makeApp(queue);
+      const first = await request(app).post('/ingest/scrape').send({ url: FIXTURE_URL }).expect(202);
+      const second = await request(app).post('/ingest/scrape').send({ url: FIXTURE_URL }).expect(202);
+
+      expect(first.body.deduplicated).toBe(false);
+      expect(second.body.deduplicated).toBe(true);
+      expect(second.body.itemId).toBe(first.body.itemId);
+      expect(queue.getStats().total).toBe(1);
+    });
+  });
+
+  describe('wiring: enqueued item flows the ingest path', () => {
+    it('drives fetch -> ruleset.extract -> ingestEmitter.send for the triggered URL', async () => {
+      const ruleset = makeRuleset();
+      const scraping = makeScrapingStub();
+      const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+      queue = new ScrapeQueue(false); // real processing loop
+      queue.setPluginRegistry(makeRegistry(ruleset));
+      queue.setIngestEmitter({ send });
+      queue.setScrapingService(scraping);
+
+      await request(makeApp(queue)).post('/ingest/scrape').send({ url: FIXTURE_URL }).expect(202);
+
+      await waitFor(() => send.mock.calls.length > 0);
+
+      // engine fetched the raw page; extraction was the plugin's job
+      expect(scraping.scrapePage).toHaveBeenCalledWith(FIXTURE_URL);
+      expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, FIXTURE_URL);
+      // the extraction went to the spine, verbatim
+      const sent = send.mock.calls[0][0];
+      expect(sent.source.site).toBe('mock-site');
+      expect(sent.fields).toEqual({ name: 'Kitagawa Marin', jan: '4530956107891' });
+      // outcome observable via queue accounting (and completion log lines)
+      await waitFor(() => queue.getStats().completed === 1);
+      expect(queue.getStats().failed).toBe(0);
+    });
+
+    it('logs a failure line when the triggered item permanently fails (smoke observability)', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const ruleset = makeRuleset();
+      const scraping = makeScrapingStub();
+      // NOT_FOUND classifies as not_found -> non-retryable -> permanent failure
+      const send = jest.fn().mockRejectedValue(new Error('NOT_FOUND: item vanished'));
+
+      queue = new ScrapeQueue(false);
+      queue.setPluginRegistry(makeRegistry(ruleset));
+      queue.setIngestEmitter({ send });
+      queue.setScrapingService(scraping);
+
+      await request(makeApp(queue)).post('/ingest/scrape').send({ url: FIXTURE_URL }).expect(202);
+
+      await waitFor(() => queue.getStats().failed === 1);
+      await waitFor(() =>
+        errorSpy.mock.calls.some(call =>
+          String(call[0]).includes('[INGEST API] Ingest scrape failed for')
+        )
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[INGEST API] Ingest scrape failed for https://figures.example.test/item/777')
+      );
+    });
+  });
+});

--- a/src/__tests__/integration/ingestRoutes.test.ts
+++ b/src/__tests__/integration/ingestRoutes.test.ts
@@ -247,6 +247,24 @@ describe('POST /ingest/scrape', () => {
       expect(second.body.itemId).toBe(first.body.itemId);
       expect(queue.getStats().total).toBe(1);
     });
+
+    it('never lets a CRLF-bearing URL forge multi-line log entries (log injection)', async () => {
+      // WHATWG URL parsing STRIPS tab/CR/LF, so this passes new URL()
+      // validation while the original string (logged, used as dedup key,
+      // embedded in the item id) still carries the raw control chars.
+      const crlfUrl = 'https://figures.example.test/item/7\r\nFORGED admin login OK\r\n77';
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      const app = makeApp(queue);
+      await request(app).post('/ingest/scrape').send({ url: crlfUrl }).expect(202);
+      // repeat trigger: exercises the dedup/coalesce log lines too
+      await request(app).post('/ingest/scrape').send({ url: crlfUrl }).expect(202);
+
+      expect(logSpy).toHaveBeenCalled();
+      for (const call of logSpy.mock.calls) {
+        expect(String(call[0])).not.toMatch(/[\r\n]/);
+      }
+    });
   });
 
   describe('wiring: enqueued item flows the ingest path', () => {

--- a/src/__tests__/unit/scrapeQueueIngest.test.ts
+++ b/src/__tests__/unit/scrapeQueueIngest.test.ts
@@ -41,14 +41,14 @@ import { createExtractionRegistry, ExtractionRegistryImpl } from '../../services
 const FIXTURE_HTML = '<html><body><h1 class="title">Kitagawa Marin</h1></body></html>';
 
 /** Registry with the fixture site registered against the queue's MFC URLs. */
-function makeRegistry(ruleset: ExtractionRuleset): ExtractionRegistryImpl {
+function makeRegistry(ruleset: ExtractionRuleset, domain = 'myfigurecollection.net'): ExtractionRegistryImpl {
   const registry = createExtractionRegistry();
   registry.registerSite({
     siteId: ruleset.siteId,
     name: 'Mock MFC',
-    domains: ['myfigurecollection.net'],
+    domains: [domain],
     rateLimit: {
-      domain: 'myfigurecollection.net',
+      domain,
       baseDelayMs: 1000,
       minDelayMs: 500,
       maxDelayMs: 5000,
@@ -160,6 +160,27 @@ describe('ScrapeQueue - ingest cutover', () => {
     // waiting callers still resolve (with the extracted field bag)
     expect(data).toEqual({ name: 'Kitagawa Marin', jan: '4530956107891' });
     expect(queue.getStats().completed).toBe(1);
+  });
+
+  it('scrapes the caller-supplied url option instead of building an MFC URL from the key', async () => {
+    const ruleset = makeRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'figures.example.test'));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    // Trigger-route shape: the URL itself is the dedup key AND the target.
+    const url = 'https://figures.example.test/item/777';
+    const result = queue.enqueue(url, { url });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    expect(scraping.scrapePage).toHaveBeenCalledWith(url);
+    expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, url);
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('uses the stealth fetch when the item carries cookies', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import { createRequire } from 'module';
 import scraperRoutes from './routes/scraper.js';
+import ingestRoutes from './routes/ingest.js';
 import { scraperDebug } from './utils/logger.js';
 
 // Import browser pool functionality
@@ -75,6 +76,10 @@ app.get('/version', (req, res) => {
 
 // Scraper routes (no /api prefix for consistency)
 app.use('/', scraperRoutes);
+
+// Ingest trigger route: POST /ingest/scrape enqueues a URL into the queue's
+// plugin-extraction ingest path (registry -> fetch -> extract -> spine emit)
+app.use('/', ingestRoutes);
 
 // Plugins loaded at boot (populated by startServer, read by gracefulShutdown)
 let loadedPlugins: ScraperPlugin[] = [];

--- a/src/routes/ingest.ts
+++ b/src/routes/ingest.ts
@@ -60,17 +60,19 @@ export function createIngestRouter(getQueue: () => ScrapeQueue = getScrapeQueue)
 
     const result = queue.enqueue(url, { url });
 
-    console.log(`[INGEST API] ${result.deduplicated ? 'Coalesced' : 'Enqueued'} ingest scrape for ${sanitizeForLog(url)} (item ${result.id}, position ${result.position})`); // lgtm[js/log-injection]
+    // result.id embeds the URL (it is the dedup key), so it is user-tainted
+    // and must be sanitized wherever it is logged; position is a number.
+    console.log(`[INGEST API] ${result.deduplicated ? 'Coalesced' : 'Enqueued'} ingest scrape for ${sanitizeForLog(url)} (item ${sanitizeForLog(result.id)}, position ${result.position})`); // lgtm[js/log-injection]
 
     // Outcome observability for smoke runs: the queue and emitter already log
     // processing detail; these lines tie completion/failure back to the
     // trigger by item id + URL.
     result.promise
       .then(() => {
-        console.log(`[INGEST API] Ingest scrape completed for ${sanitizeForLog(url)} (item ${result.id})`); // lgtm[js/log-injection]
+        console.log(`[INGEST API] Ingest scrape completed for ${sanitizeForLog(url)} (item ${sanitizeForLog(result.id)})`); // lgtm[js/log-injection]
       })
       .catch((error: Error) => {
-        console.error(`[INGEST API] Ingest scrape failed for ${sanitizeForLog(url)} (item ${result.id}): ${sanitizeForLog(error.message)}`); // lgtm[js/log-injection]
+        console.error(`[INGEST API] Ingest scrape failed for ${sanitizeForLog(url)} (item ${sanitizeForLog(result.id)}): ${sanitizeForLog(error.message)}`); // lgtm[js/log-injection]
       });
 
     return res.status(202).json({

--- a/src/routes/ingest.ts
+++ b/src/routes/ingest.ts
@@ -1,0 +1,87 @@
+/**
+ * Ingest trigger route — the HTTP surface for the queue's ingest path.
+ *
+ * POST /ingest/scrape {url} validates the URL, confirms the ingest path is
+ * usable (emitter configured + a plugin ruleset matches), and enqueues the
+ * URL into the scrape queue. Everything downstream — raw page fetch, plugin
+ * extraction, spine emit, retry/failure semantics — is the queue's existing,
+ * tested processViaIngest machinery; nothing is duplicated here.
+ *
+ * The URL itself is the queue's dedup key: repeat triggers for the same URL
+ * coalesce onto the pending item (deduplicated: true, same itemId).
+ */
+
+import express, { type Router } from 'express';
+import { getScrapeQueue, type ScrapeQueue } from '../services/scrapeQueue.js';
+import { sanitizeForLog } from '../utils/security.js';
+
+/**
+ * Build the router. The queue is resolved lazily per request (default: the
+ * singleton) so the route always sees the registry/emitter that index.ts
+ * threads in during plugin bootstrap.
+ */
+export function createIngestRouter(getQueue: () => ScrapeQueue = getScrapeQueue): Router {
+  const router = express.Router();
+
+  router.post('/ingest/scrape', (req, res) => {
+    const { url } = req.body ?? {};
+
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({
+        success: false,
+        message: 'URL is required',
+      });
+    }
+
+    try {
+      new URL(url);
+    } catch {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid URL format',
+      });
+    }
+
+    const queue = getQueue();
+
+    if (!queue.isIngestConfigured()) {
+      return res.status(503).json({
+        success: false,
+        message: 'Ingest not configured (INGEST_BASE_URL unset)',
+      });
+    }
+
+    if (!queue.hasRulesetForUrl(url)) {
+      return res.status(422).json({
+        success: false,
+        message: 'No plugin ruleset matches this URL',
+      });
+    }
+
+    const result = queue.enqueue(url, { url });
+
+    console.log(`[INGEST API] ${result.deduplicated ? 'Coalesced' : 'Enqueued'} ingest scrape for ${sanitizeForLog(url)} (item ${result.id}, position ${result.position})`); // lgtm[js/log-injection]
+
+    // Outcome observability for smoke runs: the queue and emitter already log
+    // processing detail; these lines tie completion/failure back to the
+    // trigger by item id + URL.
+    result.promise
+      .then(() => {
+        console.log(`[INGEST API] Ingest scrape completed for ${sanitizeForLog(url)} (item ${result.id})`); // lgtm[js/log-injection]
+      })
+      .catch((error: Error) => {
+        console.error(`[INGEST API] Ingest scrape failed for ${sanitizeForLog(url)} (item ${result.id}): ${sanitizeForLog(error.message)}`); // lgtm[js/log-injection]
+      });
+
+    return res.status(202).json({
+      success: true,
+      itemId: result.id,
+      deduplicated: result.deduplicated,
+      position: result.position,
+    });
+  });
+
+  return router;
+}
+
+export default createIngestRouter();

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -106,6 +106,12 @@ export interface EnqueueOptions {
   sessionId?: string;
   userId?: string;
   maxRetries?: number;
+  /**
+   * Explicit URL to scrape. When absent the key is treated as an MFC item ID
+   * and the item URL is built from it (legacy shape). Trigger routes pass the
+   * URL itself as both key and option — no faked MFC fields.
+   */
+  url?: string;
 }
 
 export interface EnqueueResult {
@@ -424,8 +430,10 @@ export class ScrapeQueue {
   /**
    * Add an item to the scrape queue
    *
-   * @param mfcId - MFC item ID to scrape
-   * @param options - Enqueue options (priority, cookies, etc.)
+   * @param mfcId - Dedup key: an MFC item ID (legacy shape) or, when
+   *   options.url is supplied, any caller-chosen key (trigger routes use the
+   *   URL itself)
+   * @param options - Enqueue options (priority, cookies, url, etc.)
    * @returns EnqueueResult with promise that resolves when scraping completes
    */
   enqueue(mfcId: string, options: EnqueueOptions = {}): EnqueueResult {
@@ -438,8 +446,8 @@ export class ScrapeQueue {
       maxRetries = RATE_LIMIT.DEFAULT_MAX_RETRIES,
     } = options;
 
-    // Build URL from MFC ID
-    const url = `https://myfigurecollection.net/item/${mfcId}`;
+    // Caller-supplied URL wins; otherwise build the MFC item URL from the key
+    const url = options.url ?? `https://myfigurecollection.net/item/${mfcId}`;
 
     // Check for deduplication
     const existingItem = this.pendingItems.get(mfcId);

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -496,7 +496,8 @@ export class ScrapeQueue {
       // Prevent unhandled rejection crash when items are cancelled
       promise.catch(() => {});
 
-      console.log(`[SCRAPE QUEUE] Deduplicated request for MFC ${mfcId} (${existingItem.waitingUserIds.length} users waiting)`);
+      // mfcId can be a caller-supplied URL (trigger route) — sanitize for log
+      console.log(`[SCRAPE QUEUE] Deduplicated request for MFC ${sanitizeForLog(mfcId)} (${existingItem.waitingUserIds.length} users waiting)`); // lgtm[js/log-injection]
 
       return {
         id: existingItem.id,
@@ -546,7 +547,8 @@ export class ScrapeQueue {
     const itemStatus = status || 'wished';
     this.statusQueued[itemStatus]++;
 
-    console.log(`[SCRAPE QUEUE] Enqueued MFC ${mfcId} at priority ${effectivePriority} (queue size: ${this.getStats().total})`);
+    // mfcId can be a caller-supplied URL (trigger route) — sanitize for log
+    console.log(`[SCRAPE QUEUE] Enqueued MFC ${sanitizeForLog(mfcId)} at priority ${effectivePriority} (queue size: ${this.getStats().total})`); // lgtm[js/log-injection]
 
     // Start processing if not already running (skip in test mode)
     if (!this.testMode) {

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -428,6 +428,23 @@ export class ScrapeQueue {
   // ==========================================================================
 
   /**
+   * Whether the spine ingest path is configured (an emitter is present).
+   * Trigger routes use this to answer "ingest not configured" up front
+   * instead of enqueueing items doomed to fail extraction_unavailable.
+   */
+  isIngestConfigured(): boolean {
+    return this.ingestEmitter !== null;
+  }
+
+  /**
+   * Whether the plugin registry resolves an extraction ruleset for this URL
+   * (same lookup the processing loop uses; lookup errors count as no match).
+   */
+  hasRulesetForUrl(url: string): boolean {
+    return this.lookupRuleset(url) !== undefined;
+  }
+
+  /**
    * Add an item to the scrape queue
    *
    * @param mfcId - Dedup key: an MFC item ID (legacy shape) or, when


### PR DESCRIPTION
## Gap

The C3 cutover (#222) removed syncOrchestrator — the only caller of `scrapeQueue.enqueue` — leaving the queue's ingest path (registry-resolve -> raw fetch -> ruleset.extract -> ingestEmitter.send, #221) fully wired but with no HTTP trigger. First production smoke had no way to drive an ingest scrape.

## Change

- **`POST /ingest/scrape {url}`** (`src/routes/ingest.ts`):
  - `400` missing / malformed URL
  - `503` when no ingest emitter is configured (`INGEST_BASE_URL` unset) — a clear error, never a silent no-op
  - `422` when no plugin ruleset matches the URL
  - `202 {itemId, deduplicated, position}` on enqueue; repeat triggers for the same URL coalesce onto the pending item
- The route only validates and enqueues. Fetch, plugin extraction, spine emit, and retry/failure semantics all stay in the queue's existing `processViaIngest` machinery — nothing is duplicated.
- **`EnqueueOptions.url`**: trigger items carry their real URL (which is also the dedup key) instead of faking MFC ids; the legacy key -> MFC-URL construction is unchanged for existing callers.
- Small read accessors on `ScrapeQueue` (`isIngestConfigured`, `hasRulesetForUrl`) let the route answer config shortfalls up front instead of enqueueing items doomed to `extraction_unavailable`.
- `[INGEST API]` completion/failure log lines tie outcomes back to the trigger (item id + URL) for smoke observation.

## Testing

- 9 new route tests (validation, config/ruleset checks, happy path + dedup, wiring through fetch -> extract -> emit with the #221 fixtures, failure logging) and 1 new queue unit test; red -> green per group.
- Full suite: 30 suites, 452 passed + 3 todo, zero regression. `typecheck` and `typecheck:tests` clean.
- `src/routes/ingest.ts` coverage: 100% lines / branches / functions.
