### PR TITLE
Use npm ci in Dockerfile to install exact lockfile versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,11 @@ RUN rm -rf /root/.cache/puppeteer \
     && rm -rf node_modules/puppeteer/.local-chromium \
     && rm -rf node_modules/puppeteer-core/.local-chromium
 
+# Remove the global npm/npx CLI: npm bundles its own transitive deps (e.g. brace-expansion)
+# that scanners flag in the shipped image, though they run only at install time. The runtime
+# launches via `node dist/...` (see CMD), so npm is not needed in the final image.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
 # Copy built application from builder
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/packages/plugin-contract/dist ./packages/plugin-contract/dist
@@ -188,4 +193,4 @@ EXPOSE 3050
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3050/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
-CMD ["npm", "start"]
+CMD ["node", "--import", "./dist/tracing.js", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ COPY packages/plugin-contract/package.json ./packages/plugin-contract/
 # Install all dependencies (Puppeteer won't download Chrome due to ENV vars)
 RUN npm config set fetch-timeout 300000 && npm config set fetch-retry-maxtimeout 300000
 RUN --mount=type=secret,id=node_auth_token \
-    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" timeout 600 npm install --no-audit --no-fund
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" timeout 600 npm ci --no-audit --no-fund
 
 # Remove any Chrome that might have been downloaded by Puppeteer
 RUN rm -rf /root/.cache/puppeteer \
@@ -133,7 +133,7 @@ COPY packages/plugin-contract/package.json ./packages/plugin-contract/
 # Install all dependencies for build
 RUN npm config set fetch-timeout 300000 && npm config set fetch-retry-maxtimeout 300000
 RUN --mount=type=secret,id=node_auth_token \
-    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" timeout 600 npm install --no-audit --no-fund
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" timeout 600 npm ci --no-audit --no-fund
 
 # Remove any Chrome that might have been downloaded by Puppeteer
 RUN rm -rf /root/.cache/puppeteer \
@@ -161,7 +161,7 @@ COPY packages/plugin-contract/package.json ./packages/plugin-contract/
 # Install only production dependencies
 RUN npm config set fetch-timeout 300000 && npm config set fetch-retry-maxtimeout 300000
 RUN --mount=type=secret,id=node_auth_token \
-    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" timeout 600 npm install --no-audit --no-fund --omit=dev
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" timeout 600 npm ci --no-audit --no-fund --omit=dev
 
 # Remove any Chrome that might have been downloaded by Puppeteer
 RUN rm -rf /root/.cache/puppeteer \


### PR DESCRIPTION
## Problem

`pr-security-scan` (grype) fails with HIGH `GHSA-mh99-v99m-4gvg` (brace-expansion) from two distinct sources:

1. **App tree, install-time reintroduction.** The three dependency-install stages used `npm install`, which **re-resolves** the tree instead of honoring `package-lock.json`. The committed lockfile is clean (brace-expansion pins to the patched 2.0.2 / 1.1.16 / 5.0.8), but re-resolution pulled a vulnerable brace-expansion into a transitive path.
2. **npm's own bundle.** `npm install -g npm@latest` (base stage) installs a global npm whose bundled deps include a vulnerable brace-expansion under `/usr/local/lib/node_modules/npm/**`. grype scans the whole image filesystem and flags it even though npm's bundle runs only at package-install time, never at app runtime.

## Fix

**Commit 1 — install exactly from the lockfile.** Switch the development, builder, and production dependency installs from `npm install` to `npm ci`, so the image installs the audited lockfile exactly. This closes the reintroduction class permanently. `npm install -g npm@latest` (global tool bootstrap) is unchanged. All flags preserved: `--no-audit --no-fund`, the `NODE_AUTH_TOKEN` BuildKit secret mount, the `timeout 600` wrapper, and `--omit=dev` on production.

**Commit 2 — remove npm from the shipped production image (remediate, not suppress).** After `npm ci --omit=dev` runs (npm is still needed for that step), the production stage now removes the global npm/npx CLI (`/usr/local/lib/node_modules/npm`, `/usr/local/bin/npm`, `/usr/local/bin/npx`), so the vulnerable npm bundle is not present in the final image. The production runtime launches directly via `node --import ./dist/tracing.js dist/index.js` (previously `npm start`, which merely spawned that same node command) — this is what lets npm be dropped, and it also gives the container proper SIGTERM/SIGINT forwarding. base/development/builder stages retain npm.

## Verification

- `npm ci --dry-run` against the committed lockfile resolves with no sync error (874 packages). A real `npm ci` in a context mirroring the Docker pre-`COPY . .` state installs the exact patched tree — brace-expansion 2.0.2 / 1.1.16 / 5.0.8, zero vulnerable versions — with postinstall (patch-package) running as before.
- Only runtime reference to npm in `src/` is `process.env.npm_package_version` (has a `|| 'dev'` fallback), so removing npm does not break the app. Nothing spawns/execs npm or npx at runtime.
- Image build, `node dist/...` startup, and `pr-security-scan` are validated by this PR's own CI.