### PR TITLE
Emit ingest over Connect HTTP/1.1 so Linkerd meshes the hop

### DIFF
--- a/src/__tests__/unit/ingestEmitter.test.ts
+++ b/src/__tests__/unit/ingestEmitter.test.ts
@@ -1,9 +1,10 @@
 /**
  * IngestEmitter tests — wire-mapping fidelity + retry classification against
- * an IN-PROCESS SpineIngest server (connectNodeAdapter on node:http2, real
- * gRPC over an ephemeral localhost port). Nothing is mocked at the transport
- * boundary: what the stub service captures is exactly what the spine's real
- * server would decode.
+ * an IN-PROCESS SpineIngest server (connectNodeAdapter on node:http, real
+ * Connect-over-HTTP/1.1 on an ephemeral localhost port — the same cleartext
+ * HTTP/1.1 the production spine serves, so Linkerd can mesh it). Nothing is
+ * mocked at the transport boundary: what the stub service captures is exactly
+ * what the spine's real server would decode.
  *
  * Fidelity contract under test (mirrors @figurecollecting/ingest-contract):
  *   - fields_json is the EXACT JSON text of the fields object
@@ -17,8 +18,8 @@
  *   - anything else (e.g. DeadlineExceeded) -> no retry
  *   - SUCCESS = RPC resolved OK, even when stats report zero inserts
  */
-import * as http2 from 'node:http2';
-import type { AddressInfo } from 'node:net';
+import * as http from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
 import { Code, ConnectError, type ConnectRouter } from '@connectrpc/connect';
 import { connectNodeAdapter } from '@connectrpc/connect-node';
 import { create } from '@bufbuild/protobuf';
@@ -43,7 +44,7 @@ interface StubServer {
   close: () => Promise<void>;
 }
 
-/** In-process SpineIngest stub: real h2c server, ephemeral port. */
+/** In-process SpineIngest stub: real HTTP/1.1 server, ephemeral port. */
 async function startStub(impl: StubImpl): Promise<StubServer> {
   const captured: WireExtractedData[] = [];
   let calls = 0;
@@ -58,9 +59,18 @@ async function startStub(impl: StubImpl): Promise<StubServer> {
     });
   };
 
-  const server = http2.createServer(connectNodeAdapter({ routes }));
-  const sessions: http2.ServerHttp2Session[] = [];
-  server.on('session', s => sessions.push(s));
+  // Plain node:http server — the same cleartext HTTP/1.1 the production spine
+  // (main.ts) serves, and what the emitter's Connect/HTTP/1.1 transport speaks.
+  // (A cleartext http2 server, even with allowHTTP1, cannot serve an h1 client:
+  // it sends the h2 SETTINGS preface immediately.) Connect keeps the socket
+  // alive, so teardown tracks raw connections and destroys them — otherwise
+  // server.close() would hang on an idle keep-alive socket.
+  const server = http.createServer(connectNodeAdapter({ routes }));
+  const sockets = new Set<Socket>();
+  server.on('connection', socket => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
   await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
   const port = (server.address() as AddressInfo).port;
 
@@ -69,7 +79,7 @@ async function startStub(impl: StubImpl): Promise<StubServer> {
     captured,
     callCount: () => calls,
     close: async () => {
-      for (const s of sessions) s.destroy();
+      for (const socket of sockets) socket.destroy();
       await new Promise<void>(resolve => server.close(() => resolve()));
     },
   };

--- a/src/services/ingestEmitter.ts
+++ b/src/services/ingestEmitter.ts
@@ -13,10 +13,12 @@
  *   - warnings travel verbatim; optional source fields stay ABSENT when
  *     absent.
  *
- * TRANSPORT: createGrpcTransport is h2c-hardwired HTTP/2, matching the
- * spine server (node:http2 cleartext behind the mesh). Never swap this for
- * createConnectTransport with httpVersion '1.1' — the server speaks gRPC
- * over h2 only.
+ * TRANSPORT: createConnectTransport with httpVersion '1.1' — the Connect
+ * protocol over plain HTTP/1.1. The spine ingest server serves cleartext
+ * HTTP/1.1, and Linkerd meshes HTTP/1.1 natively (mTLS, no opaque-port
+ * workaround), whereas it mishandles the cleartext-h2c stream on this hop.
+ * Do NOT revert to createGrpcTransport (h2c) — that is the stream the mesh
+ * cannot carry.
  *
  * RETRY (SUCCESS = the RPC resolved OK — never key success on
  * stats.inserted > 0; a post-commit retry legitimately returns all-deduped
@@ -28,7 +30,7 @@
  *   - anything else    -> no retry
  */
 import { Code, ConnectError, createClient, type Client } from '@connectrpc/connect';
-import { createGrpcTransport } from '@connectrpc/connect-node';
+import { createConnectTransport } from '@connectrpc/connect-node';
 import { create } from '@bufbuild/protobuf';
 import {
   SpineIngest,
@@ -62,8 +64,9 @@ export class IngestEmitter {
   private readonly retryDelayMs: number;
 
   constructor(options: IngestEmitterOptions) {
-    // h2c-hardwired HTTP/2 — matches the spine's node:http2 cleartext server.
-    const transport = createGrpcTransport({ baseUrl: options.baseUrl });
+    // Connect over HTTP/1.1 — Linkerd meshes h1 natively (mTLS); the spine
+    // ingest server serves cleartext HTTP/1.1. See the TRANSPORT note in the header.
+    const transport = createConnectTransport({ baseUrl: options.baseUrl, httpVersion: '1.1' });
     this.client = createClient(SpineIngest, transport);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_INGEST_TIMEOUT_MS;
     this.retryDelayMs = options.retryDelayMs ?? 1_000;


### PR DESCRIPTION
## What

Switch the ingest emitter transport from `createGrpcTransport` (h2c, HTTP/2) to `createConnectTransport({ httpVersion: '1.1' })` (Connect over cleartext HTTP/1.1), so Linkerd meshes the scraper→ingest hop natively with mTLS.

Only the transport constructor changes. Message mapping (`fields_json` = `JSON.stringify(fields)`, raw `extractedAt` passthrough, absent optional source fields), retry classification (UNAVAILABLE/INTERNAL/INVALID_ARGUMENT/deadline), and `timeoutMs` are all unchanged.

## Why

The hop currently runs on a temporary plaintext mesh-bypass because Linkerd edge-26 cannot carry the cleartext-h2c stream. Connect-over-HTTP/1.1 is meshed natively by Linkerd (mTLS, L7) — restoring mTLS with no certificates and no opaque-port workaround. Paired with the fc-aggregation PR that serves the endpoint over HTTP/1.1 and the fc-infra PR that removes the bypass and re-enables `deny`.

## Test harness change

`ingestEmitter.test.ts` stands up a **real** SpineIngest server (no transport mocking). The stub moves from a cleartext `http2.createServer` (h2c) to `http.createServer` — matching the emitter's new HTTP/1.1 client and the production spine. Connect keeps the socket alive, so teardown tracks raw `connection` sockets and destroys them (an HTTP/1.1 socket has no http2 `session`, and `server.close()` would otherwise hang on an idle keep-alive socket).

(A cleartext `http2.createServer` with `allowHTTP1` cannot serve an h1 client — it emits the h2 SETTINGS preface immediately — which is why the stub is plain `node:http`.)

## Verification

- `npm test` → **30 suites, 453 passed + 3 todo, 0 failed** (zero regression).
- `ingestEmitter.test.ts` → 12/12 (fidelity + retry, real HTTP/1.1 wire).
- `npx tsc --noEmit` (after `npm run build:contract`) → clean.

## Deploy

Author-only. New engine image + re-pin + mesh apply are a follow-up Ross window after the three coordinated PRs (this, fc-aggregation, fc-infra) merge.
