### PR TITLE
CaptureSink: wire+dom capture at the fetch path (raw-capture pipeline, phase 1)

### DIFF
--- a/src/__tests__/unit/browserContextTeardown.test.ts
+++ b/src/__tests__/unit/browserContextTeardown.test.ts
@@ -32,6 +32,9 @@ describe('BrowserContext teardown & leak accounting', () => {
       setUserAgent: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
       setCookie: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
       close: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      // capture hook (merged from develop) attaches a 'response' listener; no-op stubs
+      on: jest.fn<(...a: any[]) => any>(),
+      off: jest.fn<(...a: any[]) => any>(),
     } as unknown as jest.Mocked<Page>;
 
     mockContext = makeContext(() => Promise.resolve());

--- a/src/__tests__/unit/captureSink.test.ts
+++ b/src/__tests__/unit/captureSink.test.ts
@@ -1,0 +1,116 @@
+import { jest } from '@jest/globals';
+import { createHash } from 'node:crypto';
+import type { Page, Browser, HTTPResponse } from 'puppeteer';
+import { BrowserPool } from '../../services/genericScraper';
+import { createScrapingService } from '../../services/engineServices/scrapingService';
+import { buildRawCapture, CollectingCaptureSink } from '../../services/captureSink';
+
+const sha = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+describe('buildRawCapture', () => {
+  it('computes the sha256 content address of the uncompressed bytes', () => {
+    const bytes = Buffer.from('<html>hi</html>', 'utf8');
+    const c = buildRawCapture({ url: 'https://x/1', lane: 'wire', bytes, fetchedAt: '2026-07-30T00:00:00Z' });
+    expect(c.sha256).toBe(sha(bytes));
+    expect(c.lane).toBe('wire');
+    expect(c.fetchedAt).toBe('2026-07-30T00:00:00Z');
+  });
+
+  it('omits finalUrl when it equals url, includes it when it differs', () => {
+    const bytes = Buffer.from('x');
+    expect(buildRawCapture({ url: 'https://x/1', finalUrl: 'https://x/1', lane: 'dom', bytes }).finalUrl).toBeUndefined();
+    expect(buildRawCapture({ url: 'https://x/1', finalUrl: 'https://x/2', lane: 'dom', bytes }).finalUrl).toBe('https://x/2');
+  });
+
+  it('defaults fetchedAt to an ISO instant when omitted', () => {
+    const c = buildRawCapture({ url: 'https://x/1', lane: 'dom', bytes: Buffer.from('x') });
+    expect(() => new Date(c.fetchedAt).toISOString()).not.toThrow();
+    expect(c.fetchedAt).toBe(new Date(c.fetchedAt).toISOString());
+  });
+});
+
+describe('scrapingService capture hook', () => {
+  let mockPage: jest.Mocked<Page>;
+  let mockContext: any;
+  let mockBrowser: jest.Mocked<Browser>;
+  let responseHandler: ((r: HTTPResponse) => unknown) | undefined;
+  let simulate: HTTPResponse[] = [];
+  const mainFrame = { id: 'main' };
+
+  const wireBytes = Buffer.from('<html>WIRE pre-JS</html>', 'utf8');
+  const domHtml = '<html><body>DOM post-JS</body></html>';
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await BrowserPool.reset();
+    (BrowserPool as any).stealthBrowser = null;
+    responseHandler = undefined;
+    simulate = [];
+
+    mockPage = {
+      // fire simulated responses DURING navigation, as a real browser does
+      goto: jest.fn<(...a: any[]) => any>().mockImplementation(async () => {
+        for (const r of simulate) if (responseHandler) await responseHandler(r);
+        return { status: () => 200, url: () => 'https://alpha.test/item/1' };
+      }),
+      title: jest.fn<(...a: any[]) => any>().mockResolvedValue('T'),
+      content: jest.fn<(...a: any[]) => any>().mockResolvedValue(domHtml),
+      evaluate: jest.fn<(...a: any[]) => any>().mockResolvedValue('body'),
+      setViewport: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      setUserAgent: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      setCookie: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      mainFrame: jest.fn(() => mainFrame),
+      on: jest.fn((evt: string, h: any) => { if (evt === 'response') responseHandler = h; }),
+      off: jest.fn(),
+      close: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Page>;
+
+    mockContext = { newPage: jest.fn<(...a: any[]) => any>().mockResolvedValue(mockPage), close: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined) };
+    mockBrowser = { createBrowserContext: jest.fn<(...a: any[]) => any>().mockResolvedValue(mockContext), connected: true } as unknown as jest.Mocked<Browser>;
+    jest.spyOn(BrowserPool, 'getBrowser').mockResolvedValue(mockBrowser);
+    jest.spyOn(BrowserPool, 'returnBrowser').mockResolvedValue(undefined as any);
+  });
+
+  it('emits a wire capture (main-document response bytes) and a dom capture', async () => {
+    const sink = new CollectingCaptureSink();
+    const service = createScrapingService(sink);
+
+    simulate = [{
+      request: () => ({ resourceType: () => 'document' }),
+      frame: () => mainFrame,
+      buffer: async () => wireBytes,
+      status: () => 200,
+      headers: () => ({ 'content-type': 'text/html; charset=utf-8' }),
+      url: () => 'https://alpha.test/item/1',
+    } as unknown as HTTPResponse];
+    const result = await service.scrapePage('https://alpha.test/item/1');
+
+    // scraping result unchanged
+    expect(result.html).toBe(domHtml);
+
+    const wire = sink.captures.find(c => c.lane === 'wire');
+    const dom = sink.captures.find(c => c.lane === 'dom');
+    expect(wire).toBeDefined();
+    expect(wire!.sha256).toBe(sha(wireBytes));
+    expect(wire!.statusCode).toBe(200);
+    expect(wire!.contentType).toContain('text/html');
+    expect(dom).toBeDefined();
+    expect(dom!.sha256).toBe(sha(Buffer.from(domHtml, 'utf8')));
+    // wire and dom differ (pre-JS vs post-JS) — the whole point of two lanes
+    expect(wire!.sha256).not.toBe(dom!.sha256);
+  });
+
+  it('ignores non-document and cross-frame responses for the wire lane', async () => {
+    const sink = new CollectingCaptureSink();
+    const service = createScrapingService(sink);
+    simulate = [{
+      request: () => ({ resourceType: () => 'image' }),
+      frame: () => mainFrame,
+      buffer: async () => Buffer.from('IMGDATA'),
+      status: () => 200, headers: () => ({}), url: () => 'https://alpha.test/img.png',
+    } as unknown as HTTPResponse];
+    await service.scrapePage('https://alpha.test/item/1');
+    expect(sink.captures.find(c => c.lane === 'wire')).toBeUndefined();
+    expect(sink.captures.find(c => c.lane === 'dom')).toBeDefined();
+  });
+});

--- a/src/__tests__/unit/engineServices/scrapingService.test.ts
+++ b/src/__tests__/unit/engineServices/scrapingService.test.ts
@@ -22,6 +22,10 @@ describe('createScrapingService', () => {
       setViewport: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
       setUserAgent: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
       setCookie: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+      // capture hook attaches a response listener; provide no-op stubs
+      on: jest.fn(),
+      off: jest.fn(),
+      mainFrame: jest.fn(() => ({ id: 'main' })),
       close: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<Page>;
 

--- a/src/services/captureSink.ts
+++ b/src/services/captureSink.ts
@@ -1,0 +1,82 @@
+/**
+ * CaptureSink — the raw-capture side of the fetch path.
+ *
+ * The scraper observes two byte-streams per fetch and hands each to a sink:
+ *   - the WIRE lane: the main document's HTTP response body, buffered in a
+ *     `response` listener BEFORE JS runs (the pre-render bytes);
+ *   - the DOM lane: `page.content()` AFTER load (the post-JS serialized DOM).
+ * API-based rulesets emit an 'api' lane from services.http.
+ *
+ * A RawCapture carries the bytes + their content hash + minimal provenance; the
+ * downstream sink writes the bytes to object storage (content-addressed by
+ * sha256) and emits the metadata row to the spine's raw-capture ingest. This
+ * module owns only the CONTRACT and the hashing — storage/emit are the sink's
+ * job, injected so the capture path is unit-testable without a browser, object
+ * store, or spine.
+ */
+import { createHash } from 'node:crypto';
+
+export type CaptureLane = 'wire' | 'dom' | 'api';
+
+export interface RawCapture {
+  /** The URL as requested (entry URL, pre-redirect). */
+  url: string;
+  /** The resolved URL after redirects, if different from `url`. */
+  finalUrl?: string;
+  lane: CaptureLane;
+  /** Uncompressed body bytes exactly as observed. */
+  bytes: Buffer;
+  /** Lowercase hex sha256 of the UNCOMPRESSED bytes — the content address. */
+  sha256: string;
+  statusCode?: number;
+  contentType?: string;
+  /** ISO-8601 instant the fetch was observed. */
+  fetchedAt: string;
+}
+
+export interface RawCaptureInput {
+  url: string;
+  finalUrl?: string;
+  lane: CaptureLane;
+  bytes: Buffer;
+  statusCode?: number;
+  contentType?: string;
+  /** Defaults to now (ISO) when omitted. */
+  fetchedAt?: string;
+}
+
+/** A destination for raw captures. Implementations store bytes + emit metadata. */
+export interface CaptureSink {
+  capture(c: RawCapture): Promise<void>;
+}
+
+/** Build a RawCapture, computing the content address from the bytes. */
+export function buildRawCapture(input: RawCaptureInput): RawCapture {
+  const sha256 = createHash('sha256').update(input.bytes).digest('hex');
+  const capture: RawCapture = {
+    url: input.url,
+    lane: input.lane,
+    bytes: input.bytes,
+    sha256,
+    fetchedAt: input.fetchedAt ?? new Date().toISOString(),
+  };
+  if (input.finalUrl !== undefined && input.finalUrl !== input.url) capture.finalUrl = input.finalUrl;
+  if (input.statusCode !== undefined) capture.statusCode = input.statusCode;
+  if (input.contentType !== undefined) capture.contentType = input.contentType;
+  return capture;
+}
+
+/** Default sink: drops captures. Used when capture is not configured. */
+export class NoopCaptureSink implements CaptureSink {
+  async capture(): Promise<void> {
+    /* intentionally empty */
+  }
+}
+
+/** Test sink: retains every capture handed to it. */
+export class CollectingCaptureSink implements CaptureSink {
+  readonly captures: RawCapture[] = [];
+  async capture(c: RawCapture): Promise<void> {
+    this.captures.push(c);
+  }
+}

--- a/src/services/engineServices/scrapingService.ts
+++ b/src/services/engineServices/scrapingService.ts
@@ -4,9 +4,10 @@
  * This adapter only navigates and returns raw HTML — extraction is the
  * plugin's job via its own ExtractionRuleset.
  */
-import type { Browser, Page } from 'puppeteer';
+import type { Browser, Page, HTTPResponse } from 'puppeteer';
 import { BrowserPool } from '../genericScraper.js';
 import { ScrapingService, ScrapePageOptions, ScrapePageResult, PageOptions } from '@figurecollecting/scraper-plugin-contract';
+import { CaptureSink, NoopCaptureSink, buildRawCapture } from '../captureSink.js';
 
 const DEFAULT_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36';
@@ -35,7 +36,12 @@ async function detectChallenge(
   return matchesAny(patterns.titleIncludes) || matchesAny(patterns.bodyIncludes);
 }
 
-async function navigateAndCapture(page: Page, url: string, options: ScrapePageOptions = {}): Promise<ScrapePageResult> {
+async function navigateAndCapture(
+  page: Page,
+  url: string,
+  options: ScrapePageOptions = {},
+  sink: CaptureSink = new NoopCaptureSink()
+): Promise<ScrapePageResult> {
   await page.setViewport({ width: 1280, height: 720 });
   await page.setUserAgent(options.userAgent || DEFAULT_USER_AGENT);
 
@@ -49,24 +55,65 @@ async function navigateAndCapture(page: Page, url: string, options: ScrapePageOp
     }
   }
 
-  const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT_MS });
-
-  const waitTime = capWaitTime(options.waitTime);
-  if (waitTime > 0) {
-    await new Promise(resolve => setTimeout(resolve, waitTime));
-  }
-
-  if (options.cloudflareDetection) {
-    const challenged = await detectChallenge(page, options.cloudflareDetection);
-    if (challenged) {
-      // Single bounded re-check wait. Plugins needing more elaborate
-      // challenge-clearing behavior can retry from their own workflow layer.
-      await new Promise(resolve => setTimeout(resolve, CHALLENGE_RECHECK_DELAY_MS));
+  // WIRE lane: buffer the main-document response body as it arrives, before JS
+  // runs. `.buffer()` must be called during the response event — after the
+  // browser consumes it for rendering it may no longer be retrievable. A body
+  // that is genuinely unavailable (e.g. a 3xx with no body) is skipped, not fatal.
+  let wire: { bytes: Buffer; statusCode?: number; contentType?: string } | undefined;
+  const onResponse = async (resp: HTTPResponse): Promise<void> => {
+    try {
+      if (resp.request().resourceType() === 'document' && resp.frame() === page.mainFrame()) {
+        const bytes = await resp.buffer();
+        wire = { bytes, statusCode: resp.status(), contentType: resp.headers()['content-type'] };
+      }
+    } catch {
+      /* body unavailable — leave the wire lane unset for this fetch */
     }
+  };
+  page.on('response', onResponse);
+
+  let response;
+  try {
+    response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT_MS });
+
+    const waitTime = capWaitTime(options.waitTime);
+    if (waitTime > 0) {
+      await new Promise(resolve => setTimeout(resolve, waitTime));
+    }
+
+    if (options.cloudflareDetection) {
+      const challenged = await detectChallenge(page, options.cloudflareDetection);
+      if (challenged) {
+        // Single bounded re-check wait. Plugins needing more elaborate
+        // challenge-clearing behavior can retry from their own workflow layer.
+        await new Promise(resolve => setTimeout(resolve, CHALLENGE_RECHECK_DELAY_MS));
+      }
+    }
+  } finally {
+    page.off('response', onResponse);
   }
 
   const html = await page.content();
   const title = await page.title();
+
+  // Hand both lanes to the sink. Capturing must never break a scrape.
+  const fetchedAt = new Date().toISOString();
+  const finalUrl = response?.url?.() ?? url;
+  try {
+    if (wire) {
+      await sink.capture(buildRawCapture({
+        url, finalUrl, lane: 'wire', bytes: wire.bytes,
+        statusCode: wire.statusCode, contentType: wire.contentType, fetchedAt,
+      }));
+    }
+    await sink.capture(buildRawCapture({
+      url, finalUrl, lane: 'dom', bytes: Buffer.from(html, 'utf8'),
+      statusCode: response?.status(), contentType: 'text/html', fetchedAt,
+    }));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`[CAPTURE] sink failed for ${url}: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   return {
     html,
@@ -76,7 +123,7 @@ async function navigateAndCapture(page: Page, url: string, options: ScrapePageOp
   };
 }
 
-export function createScrapingService(): ScrapingService {
+export function createScrapingService(captureSink: CaptureSink = new NoopCaptureSink()): ScrapingService {
   async function withPage<T>(fn: (page: Page) => Promise<T>, options: PageOptions = {}): Promise<T> {
     const stealth = options.stealth ?? false;
     const browser: Browser = stealth ? await BrowserPool.getStealthBrowser() : await BrowserPool.getBrowser();
@@ -110,10 +157,10 @@ export function createScrapingService(): ScrapingService {
 
   return {
     scrapePage: (url: string, options?: ScrapePageOptions) =>
-      withPage(page => navigateAndCapture(page, url, options), { stealth: false }),
+      withPage(page => navigateAndCapture(page, url, options, captureSink), { stealth: false }),
 
     scrapePageStealth: (url: string, options?: ScrapePageOptions) =>
-      withPage(page => navigateAndCapture(page, url, options), { stealth: true }),
+      withPage(page => navigateAndCapture(page, url, options, captureSink), { stealth: true }),
 
     withBrowser,
     withPage,


### PR DESCRIPTION
Phase 1 of the raw-capture pipeline (the spine schema for it landed in fc-aggregation #8).

Captures two byte-streams per fetch and hands each to an **injectable sink**:
- **wire** lane — the main-document HTTP response body, buffered in a `response` listener before JS runs (the P2a-validated approach);
- **dom** lane — `page.content()` after load.

Each is content-addressed by sha256. The sink is injectable (default `NoopCaptureSink`), so **no behaviour changes** until a real sink is wired, and the capture path is unit-testable with no browser/object-store/spine. Capture never breaks a scrape (failures are swallowed + logged).

**Not in this PR** (later phases): the object-storage blob writer, the raw-capture metadata emit to the spine, the `services.http` (API-ruleset) hook, and the bare-fetch CI lint.

TDD red→green; 5 new capture tests + the full scraping-service/consumer surface (88 tests) green; tsc clean.