### PR TITLE
Fix 25 GB context leak: reliably release per-request browser contexts

### DIFF
--- a/src/__tests__/unit/browserContextTeardown.test.ts
+++ b/src/__tests__/unit/browserContextTeardown.test.ts
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+import puppeteer from 'puppeteer';
+import type { Page, Browser } from 'puppeteer';
+import { BrowserPool } from '../../services/genericScraper';
+import { createScrapingService } from '../../services/engineServices/scrapingService';
+
+// The browser is intentionally long-lived (a relaunch costs 4-7s and re-triggers
+// Cloudflare); the per-request unit is the BrowserContext. A context that fails
+// to close leaked onto its immortal browser and was silently swallowed — the
+// ~25 GB OOM. These tests pin the reliable-teardown fix.
+describe('BrowserContext teardown & leak accounting', () => {
+  let mockPage: jest.Mocked<Page>;
+  let mockContext: any;
+  let mockBrowser: jest.Mocked<Browser>;
+
+  const makeContext = (closeImpl: () => Promise<any>) => ({
+    newPage: jest.fn<(...a: any[]) => any>().mockResolvedValue(mockPage),
+    close: jest.fn<(...a: any[]) => any>().mockImplementation(closeImpl),
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await BrowserPool.reset();
+    (BrowserPool as any).stealthBrowser = null;
+
+    mockPage = {
+      goto: jest.fn<(...a: any[]) => any>().mockResolvedValue({ status: () => 200 }),
+      title: jest.fn<(...a: any[]) => any>().mockResolvedValue('T'),
+      content: jest.fn<(...a: any[]) => any>().mockResolvedValue('<html></html>'),
+      evaluate: jest.fn<(...a: any[]) => any>().mockResolvedValue('b'),
+      setViewport: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      setUserAgent: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      setCookie: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      close: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Page>;
+
+    mockContext = makeContext(() => Promise.resolve());
+    mockBrowser = {
+      createBrowserContext: jest.fn<(...a: any[]) => any>().mockImplementation(async () => mockContext),
+      close: jest.fn<(...a: any[]) => any>().mockResolvedValue(undefined),
+      connected: true,
+    } as unknown as jest.Mocked<Browser>;
+    jest.mocked(puppeteer.launch).mockClear();
+    jest.mocked(puppeteer.launch).mockResolvedValue(mockBrowser);
+  });
+
+  it('clean close: returns the pooled browser and counts the context', async () => {
+    const service = createScrapingService();
+    await service.scrapePage('https://a.test/1');
+
+    expect(mockContext.close).toHaveBeenCalled();
+    expect(BrowserPool.getPoolSize()).toBe(BrowserPool.getPoolCapacity());
+    expect(BrowserPool.contextStats()).toEqual({ opened: 1, closed: 1, failed: 0, leaked: 0 });
+  });
+
+  it('failing close: RETIRES the pooled browser instead of leaking it, and counts the failure', async () => {
+    mockContext = makeContext(() => Promise.reject(new Error('context stuck')));
+    const service = createScrapingService();
+
+    await service.scrapePage('https://a.test/1');
+
+    // the poisoned browser was closed (retired), not silently returned
+    expect(mockBrowser.close).toHaveBeenCalled();
+    const stats = BrowserPool.contextStats();
+    expect(stats.failed).toBe(1);
+    expect(stats.closed).toBe(0);
+  });
+
+  it('failing close on stealth: retires the singleton so the next request relaunches it', async () => {
+    mockContext = makeContext(() => Promise.reject(new Error('context stuck')));
+    const service = createScrapingService();
+
+    await service.scrapePageStealth('https://a.test/1');
+
+    expect((BrowserPool as any).stealthBrowser).toBeNull();
+    expect(BrowserPool.contextStats().failed).toBe(1);
+  });
+
+  it('closeContext: a hung close times out and is treated as a leak (not an infinite hang)', async () => {
+    jest.useFakeTimers();
+    const hanging = { close: () => new Promise(() => {}) } as any;
+    const p = BrowserPool.closeContext(hanging);
+    await jest.advanceTimersByTimeAsync(10_000);
+    await expect(p).resolves.toBe(false);
+    expect(BrowserPool.contextStats().failed).toBe(1);
+    jest.useRealTimers();
+  });
+});

--- a/src/services/engineServices/scrapingService.ts
+++ b/src/services/engineServices/scrapingService.ts
@@ -80,7 +80,7 @@ export function createScrapingService(): ScrapingService {
   async function withPage<T>(fn: (page: Page) => Promise<T>, options: PageOptions = {}): Promise<T> {
     const stealth = options.stealth ?? false;
     const browser: Browser = stealth ? await BrowserPool.getStealthBrowser() : await BrowserPool.getBrowser();
-    const context = await browser.createBrowserContext();
+    const context = await BrowserPool.openContext(browser);
 
     try {
       const page: Page = await context.newPage();
@@ -92,9 +92,17 @@ export function createScrapingService(): ScrapingService {
       }
       return await fn(page);
     } finally {
-      await context.close().catch(() => {});
-      if (!stealth) {
+      // The browser is intentionally long-lived; the context is the per-request
+      // unit. If it will not close cleanly it has leaked onto that browser, so
+      // retire the browser rather than reuse it (paying the relaunch/Cloudflare
+      // cost only on the rare failure). A clean close returns the pooled browser.
+      const closedCleanly = await BrowserPool.closeContext(context);
+      if (stealth) {
+        if (!closedCleanly) await BrowserPool.retireStealthBrowser(browser);
+      } else if (closedCleanly) {
         await BrowserPool.returnBrowser(browser);
+      } else {
+        await BrowserPool.retirePooledBrowser(browser);
       }
     }
   }

--- a/src/services/genericScraper.ts
+++ b/src/services/genericScraper.ts
@@ -1,4 +1,4 @@
-import puppeteer, { Browser, Page } from 'puppeteer';
+import puppeteer, { Browser, BrowserContext, Page } from 'puppeteer';
 import zlib from 'zlib';
 import crypto from 'crypto';
 import { sanitizeForLog, sanitizeObjectForLog, capWaitTime, truncateString, MAX_STRING_LENGTH } from '../utils/security.js';
@@ -190,12 +190,26 @@ export class BrowserPool {
   private static readonly POOL_SIZE = 3; // Keep 3 browsers ready
   private static isInitialized = false;
 
+  // Per-context lifecycle counters. Browsers are intentionally long-lived (a
+  // fresh launch costs 4-7s and re-triggers Cloudflare), so the per-request unit
+  // is the BrowserContext. A context that fails to close LEAKS onto its immortal
+  // browser — the historical `context.close().catch(() => {})` swallowed exactly
+  // that failure, which is how the process climbed to ~25 GB and OOM-crashed the
+  // host. These counters make the leak observable; `leaked = opened - closed`.
+  private static contextsOpened = 0;
+  private static contextsClosed = 0;
+  private static contextsFailed = 0;
+  private static readonly CONTEXT_CLOSE_TIMEOUT_MS = 10_000;
+
   // Added for improved test isolation
   static async reset(): Promise<void> {
     // Close all existing browsers first
     await this.closeAll();
     this.browsers = [];
     this.isInitialized = false;
+    this.contextsOpened = 0;
+    this.contextsClosed = 0;
+    this.contextsFailed = 0;
   }
 
 
@@ -332,6 +346,72 @@ export class BrowserPool {
       console.log('[BROWSER POOL] Pool full, browser will be closed');
       browser.close().catch((err: any) => console.error('[BROWSER POOL] Error closing extra browser:', err));
     }
+  }
+
+  /** Open a fresh per-request context on a (long-lived) browser, counting it. */
+  static async openContext(browser: Browser): Promise<BrowserContext> {
+    const context = await browser.createBrowserContext();
+    this.contextsOpened++;
+    return context;
+  }
+
+  /**
+   * Close a per-request context, bounded by a timeout so a hung Cloudflare page
+   * cannot stall teardown. Returns true if it closed cleanly. A false return
+   * means the context LEAKED onto its long-lived browser — the caller must
+   * retire that browser rather than keep reusing it. The failure is logged with
+   * live counters + RSS, never swallowed.
+   */
+  static async closeContext(context: BrowserContext): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        context.close(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error('context.close() timed out')), this.CONTEXT_CLOSE_TIMEOUT_MS);
+        }),
+      ]);
+      this.contextsClosed++;
+      return true;
+    } catch (err) {
+      this.contextsFailed++;
+      const rssMb = Math.round(process.memoryUsage().rss / 1048576);
+      console.error(
+        `[BROWSER POOL] context.close() FAILED — leaked context on a long-lived browser ` +
+        `(opened=${this.contextsOpened} closed=${this.contextsClosed} failed=${this.contextsFailed} ` +
+        `leaked=${this.contextsOpened - this.contextsClosed} rss=${rssMb}MB): ` +
+        `${err instanceof Error ? err.message : String(err)}`
+      );
+      return false;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /** Retire a pooled browser that can no longer cleanly release contexts, and
+   *  replenish the pool with a fresh one. */
+  static async retirePooledBrowser(browser: Browser): Promise<void> {
+    console.warn('[BROWSER POOL] Retiring a pooled browser after a context-close failure');
+    await browser.close().catch((err: any) => console.error('[BROWSER POOL] Error closing retired browser:', err));
+    await this.replenishPool();
+  }
+
+  /** Retire the stealth singleton so the next stealth request relaunches it —
+   *  re-passing Cloudflare once, acceptable ONLY on a failure, never per-call. */
+  static async retireStealthBrowser(browser: Browser): Promise<void> {
+    console.warn('[BROWSER POOL] Retiring the stealth browser after a context-close failure');
+    if (this.stealthBrowser === browser) this.stealthBrowser = null;
+    await browser.close().catch((err: any) => console.error('[BROWSER POOL] Error closing retired stealth browser:', err));
+  }
+
+  /** Context lifecycle counters, for leak observability / a metrics endpoint. */
+  static contextStats(): { opened: number; closed: number; failed: number; leaked: number } {
+    return {
+      opened: this.contextsOpened,
+      closed: this.contextsClosed,
+      failed: this.contextsFailed,
+      leaked: this.contextsOpened - this.contextsClosed,
+    };
   }
 
 


### PR DESCRIPTION
**Root cause (from the 2026-07-30 host OOM crash):** a scraper process reached ~25 GB resident and the kernel OOM-killer took down the WSL box. The browsers are *intentionally* long-lived (a relaunch costs 4-7s and re-triggers Cloudflare); the per-request unit is the `BrowserContext`. But `withPage`'s teardown did `context.close().catch(() => {})` — **swallowing close failures silently**, so any context that failed to close leaked permanently onto its immortal browser, invisibly, forever.

**Fix (keeps the long-lived-browser design):**
- `BrowserPool.closeContext()` — closes the context bounded by a 10s timeout (a hung Cloudflare page can't stall teardown), logs failures with live counters + RSS instead of swallowing them, returns whether it closed cleanly.
- On a failed close, **retire the browser** (close + relaunch/replenish) rather than reuse a poisoned one — paying the Cloudflare/launch cost only on the rare failure, never per-call.
- `opened / closed / failed / leaked` counters (`BrowserPool.contextStats()`) make the leak observable in production, which confirms the fix for real without a heavy local soak.

TDD red→green: clean close returns the pooled browser; a failing close retires it (pooled) / relaunches the stealth singleton; a hung close times out to a leak rather than an infinite hang. Full consumer surface green (87 tests), tsc clean.