### PR TITLE
CaptureSink Phase 2: ObjectStoreCaptureSink → Hetzner mindsignals-raw (sha256-v1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^5.2.0",
+        "minio": "^8.0.7",
         "patch-package": "^8.0.1",
         "puppeteer": "^25.3.0",
         "puppeteer-extra": "^3.3.6",
@@ -1767,6 +1768,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@open-draft/deferred-promise": {
       "version": "3.0.0",
@@ -4347,6 +4360,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -4432,7 +4457,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-lock": {
@@ -4826,6 +4850,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/block-stream2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/block-stream2/-/block-stream2-2.1.0.tgz",
+      "integrity": "sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/block-stream2/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -4906,6 +4953,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-or-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
+      "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.4",
@@ -5003,7 +5056,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -5646,6 +5698,15 @@
         }
       }
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -6185,6 +6246,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6361,6 +6428,45 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -6404,6 +6510,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -7286,6 +7401,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -8284,7 +8411,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -8514,6 +8640,60 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minio": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minio/-/minio-8.0.7.tgz",
+      "integrity": "sha512-E737MgufW8CeQAsTAtnEMrxZ9scMSf29kkhZoXzDTKj/Jszzo2SfeZUH9wbDQH2Rsq6TCtl/yQL0+XdVKZansQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.4",
+        "block-stream2": "^2.1.0",
+        "browser-or-node": "^2.1.1",
+        "buffer-crc32": "^1.0.0",
+        "eventemitter3": "^5.0.1",
+        "fast-xml-parser": "^5.3.4",
+        "ipaddr.js": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
+        "query-string": "^7.1.3",
+        "stream-json": "^1.8.0",
+        "through2": "^4.0.2",
+        "xml2js": "^0.5.0 || ^0.6.2"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/minio/node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/minio/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minio/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minipass": {
@@ -9183,6 +9363,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -9701,6 +9896,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10020,7 +10233,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10042,6 +10254,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -10318,6 +10539,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -10387,6 +10617,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -10406,11 +10651,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -10587,6 +10840,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/superagent": {
@@ -10836,6 +11104,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tldts": {
@@ -11373,7 +11664,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
@@ -11634,6 +11924,43 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^5.2.0",
+    "minio": "^8.0.7",
     "patch-package": "^8.0.1",
     "puppeteer": "^25.3.0",
     "puppeteer-extra": "^3.3.6",

--- a/src/__tests__/unit/objectStoreCaptureSink.test.ts
+++ b/src/__tests__/unit/objectStoreCaptureSink.test.ts
@@ -17,9 +17,11 @@ class FakeObjectStore implements ObjectStore {
   putDelayMs = 0;
   failPut = false;
   hangPut = false;
+  hangExists = false;
 
   async exists(key: string): Promise<boolean> {
     this.headCalls += 1;
+    if (this.hangExists) return new Promise<boolean>(() => {}); // never resolves
     return this.existing.has(key);
   }
 
@@ -90,11 +92,26 @@ describe('ObjectStoreCaptureSink — sha256-v1 contract', () => {
     expect(opts.metadata?.['content-encoding']).toBeUndefined();
   });
 
-  it('attaches convenience metadata (url + fetched-at) on the first PUT', async () => {
+  it('attaches convenience metadata (url + fetched-at + site) on the first PUT', async () => {
     await sink.capture(cap({ url: 'https://x.test/a', finalUrl: 'https://x.test/a?', fetchedAt: '2026-07-31T00:00:00.000Z' }));
     const md = store.puts[0].opts.metadata ?? {};
     expect(md['url']).toBe('https://x.test/a?'); // finalUrl preferred when present
     expect(md['fetched-at']).toBe('2026-07-31T00:00:00.000Z');
+    expect(md['site']).toBe('x.test');
+  });
+
+  it('header-safes a non-ASCII / hostile URL in metadata so it cannot fail the PUT', async () => {
+    await sink.capture(cap({ url: 'https://x.test/日本\r\ninject', finalUrl: undefined }));
+    const urlTag = store.puts[0].opts.metadata?.['url'] ?? '';
+    expect(urlTag).not.toMatch(/[\r\n]/); // no CRLF header injection
+    expect(urlTag).toMatch(/^[\x20-\x7e]*$/); // pure printable ASCII
+  });
+
+  it('omits the site tag when the URL is malformed (best-effort metadata)', async () => {
+    await sink.capture(cap({ url: 'not a valid url', finalUrl: undefined }));
+    const md = store.puts[0].opts.metadata ?? {};
+    expect(md['site']).toBeUndefined();
+    expect(md['url']).toBeDefined();
   });
 
   it('is idempotent: HEAD-then-PUT skips the write when the content address already exists', async () => {
@@ -123,6 +140,20 @@ describe('ObjectStoreCaptureSink — sha256-v1 contract', () => {
     expect(store.puts[0].key).toBe(`raw-json/sha256/${c.sha256.slice(0, 2)}/${c.sha256}.json.gz`);
   });
 
+  it('uses an explicit jsonPrefix for the api lane when configured', async () => {
+    const s = new ObjectStoreCaptureSink(store, { ...CONFIG, jsonPrefix: 'api-raw/' });
+    const c = cap({ lane: 'api', contentType: 'application/json', bytes: Buffer.from('{}', 'utf8') });
+    await s.capture(c);
+    expect(store.puts[0].key).toBe(`api-raw/sha256/${c.sha256.slice(0, 2)}/${c.sha256}.json.gz`);
+  });
+
+  it('does not corrupt a non-raw-html prefix when deriving the json sibling', async () => {
+    const s = new ObjectStoreCaptureSink(store, { ...CONFIG, prefix: 'custom/', jsonPrefix: undefined });
+    const c = cap({ lane: 'api', contentType: 'application/json', bytes: Buffer.from('{}', 'utf8') });
+    await s.capture(c);
+    expect(store.puts[0].key).toBe(`custom/sha256/${c.sha256.slice(0, 2)}/${c.sha256}.json.gz`);
+  });
+
   it('never throws when the store fails — it swallows and counts the failure', async () => {
     store.failPut = true;
     await expect(sink.capture(cap())).resolves.toBeUndefined();
@@ -133,8 +164,22 @@ describe('ObjectStoreCaptureSink — sha256-v1 contract', () => {
     store.hangPut = true;
     const start = Date.now();
     await expect(sink.capture(cap())).resolves.toBeUndefined();
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(1000); // resolved via the 100ms bound, not hung
+    expect(Date.now() - start).toBeLessThan(1000); // resolved via the 100ms bound, not hung
     expect(sink.stats().failed).toBe(1);
+  });
+
+  it('bounds a hung HEAD by putTimeoutMs (not only the PUT)', async () => {
+    store.hangExists = true;
+    const start = Date.now();
+    await expect(sink.capture(cap())).resolves.toBeUndefined();
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(sink.stats().failed).toBe(1);
+  });
+
+  it('falls back to the default timeout when putTimeoutMs is invalid (NaN/0)', async () => {
+    // A 0/NaN bound must NOT make every op time out immediately.
+    const s = new ObjectStoreCaptureSink(store, { ...CONFIG, putTimeoutMs: 0 });
+    await expect(s.capture(cap())).resolves.toBeUndefined();
+    expect(s.stats().stored).toBe(1);
   });
 });

--- a/src/__tests__/unit/objectStoreCaptureSink.test.ts
+++ b/src/__tests__/unit/objectStoreCaptureSink.test.ts
@@ -1,0 +1,141 @@
+import { jest } from '@jest/globals';
+import { gunzipSync } from 'node:zlib';
+import { buildRawCapture } from '../../services/captureSink';
+import {
+  ObjectStoreCaptureSink,
+  type ObjectStore,
+  type PutOptions,
+  type RawStoreConfig,
+} from '../../services/objectStoreCaptureSink';
+
+// A fake S3-compatible store: records PUTs, models a pre-existing corpus for
+// dedup, and can be made to hang or fail so we exercise the failure envelope
+// (a raw-capture failure must NEVER break a scrape, and must be bounded).
+class FakeObjectStore implements ObjectStore {
+  readonly puts: Array<{ key: string; body: Buffer; opts: PutOptions }> = [];
+  readonly existing = new Set<string>();
+  headCalls = 0;
+  putDelayMs = 0;
+  failPut = false;
+  hangPut = false;
+
+  async exists(key: string): Promise<boolean> {
+    this.headCalls += 1;
+    return this.existing.has(key);
+  }
+
+  async put(key: string, body: Buffer, opts: PutOptions): Promise<void> {
+    if (this.hangPut) return new Promise<void>(() => {}); // never resolves
+    if (this.putDelayMs) await new Promise(r => setTimeout(r, this.putDelayMs));
+    if (this.failPut) throw new Error('simulated store failure');
+    this.puts.push({ key, body, opts });
+    this.existing.add(key);
+  }
+}
+
+const CONFIG: RawStoreConfig = {
+  endpoint: 'https://hel1.your-objectstorage.com',
+  region: 'hel1',
+  bucket: 'mindsignals-raw',
+  prefix: 'raw-html/',
+  keyScheme: 'sha256-v1',
+  putTimeoutMs: 100,
+};
+
+// Fixed bytes → deterministic sha256 so we can assert the exact key.
+const HTML = Buffer.from('<html><body>figure 12345</body></html>', 'utf8');
+const cap = (over: Partial<Parameters<typeof buildRawCapture>[0]> = {}) =>
+  buildRawCapture({
+    url: 'https://myfigurecollection.net/item/12345',
+    lane: 'wire',
+    bytes: HTML,
+    statusCode: 200,
+    contentType: 'text/html',
+    fetchedAt: '2026-07-31T00:00:00.000Z',
+    ...over,
+  });
+
+describe('ObjectStoreCaptureSink — sha256-v1 contract', () => {
+  let store: FakeObjectStore;
+  let sink: ObjectStoreCaptureSink;
+
+  beforeEach(() => {
+    store = new FakeObjectStore();
+    sink = new ObjectStoreCaptureSink(store, CONFIG);
+  });
+
+  it('refuses to construct against an unknown key scheme', () => {
+    expect(() => new ObjectStoreCaptureSink(store, { ...CONFIG, keyScheme: 'sha256-v2' }))
+      .toThrow(/sha256-v1/);
+  });
+
+  it('writes to the content-addressed key: <prefix>sha256/<aa>/<hex>.html.gz', async () => {
+    const c = cap();
+    await sink.capture(c);
+
+    expect(store.puts).toHaveLength(1);
+    const expectedKey = `raw-html/sha256/${c.sha256.slice(0, 2)}/${c.sha256}.html.gz`;
+    expect(store.puts[0].key).toBe(expectedKey);
+  });
+
+  it('stores gzip(content) with Content-Type application/gzip and no content-encoding', async () => {
+    const c = cap();
+    await sink.capture(c);
+
+    const { body, opts } = store.puts[0];
+    // Object bytes are gzip of the EXACT uncompressed bytes (hash-before-compress).
+    expect(gunzipSync(body).equals(HTML)).toBe(true);
+    expect(opts.contentType).toBe('application/gzip');
+    // The .gz suffix declares compression; Content-Encoding must NOT be set.
+    expect(opts.contentEncoding).toBeUndefined();
+    expect(opts.metadata?.['content-encoding']).toBeUndefined();
+  });
+
+  it('attaches convenience metadata (url + fetched-at) on the first PUT', async () => {
+    await sink.capture(cap({ url: 'https://x.test/a', finalUrl: 'https://x.test/a?', fetchedAt: '2026-07-31T00:00:00.000Z' }));
+    const md = store.puts[0].opts.metadata ?? {};
+    expect(md['url']).toBe('https://x.test/a?'); // finalUrl preferred when present
+    expect(md['fetched-at']).toBe('2026-07-31T00:00:00.000Z');
+  });
+
+  it('is idempotent: HEAD-then-PUT skips the write when the content address already exists', async () => {
+    const c = cap();
+    const key = `raw-html/sha256/${c.sha256.slice(0, 2)}/${c.sha256}.html.gz`;
+    store.existing.add(key); // corpus already holds this content
+
+    await sink.capture(c);
+
+    expect(store.headCalls).toBe(1);
+    expect(store.puts).toHaveLength(0); // dedup hit — no PUT
+    expect(sink.stats().deduped).toBe(1);
+  });
+
+  it('writes exactly once across repeated captures of identical content', async () => {
+    await sink.capture(cap());
+    await sink.capture(cap());
+    await sink.capture(cap());
+    expect(store.puts).toHaveLength(1);
+    expect(sink.stats()).toMatchObject({ stored: 1, deduped: 2 });
+  });
+
+  it('routes the api lane to a json object (raw-json/…json.gz)', async () => {
+    const c = cap({ lane: 'api', contentType: 'application/json', bytes: Buffer.from('{"ok":true}', 'utf8') });
+    await sink.capture(c);
+    expect(store.puts[0].key).toBe(`raw-json/sha256/${c.sha256.slice(0, 2)}/${c.sha256}.json.gz`);
+  });
+
+  it('never throws when the store fails — it swallows and counts the failure', async () => {
+    store.failPut = true;
+    await expect(sink.capture(cap())).resolves.toBeUndefined();
+    expect(sink.stats().failed).toBe(1);
+  });
+
+  it('bounds a hung PUT by putTimeoutMs instead of stalling the scrape', async () => {
+    store.hangPut = true;
+    const start = Date.now();
+    await expect(sink.capture(cap())).resolves.toBeUndefined();
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(1000); // resolved via the 100ms bound, not hung
+    expect(sink.stats().failed).toBe(1);
+  });
+});

--- a/src/__tests__/unit/objectStoreCaptureSink.test.ts
+++ b/src/__tests__/unit/objectStoreCaptureSink.test.ts
@@ -1,4 +1,3 @@
-import { jest } from '@jest/globals';
 import { gunzipSync } from 'node:zlib';
 import { buildRawCapture } from '../../services/captureSink';
 import {

--- a/src/__tests__/unit/s3ObjectStore.test.ts
+++ b/src/__tests__/unit/s3ObjectStore.test.ts
@@ -1,0 +1,60 @@
+import { NoopCaptureSink } from '../../services/captureSink';
+import { ObjectStoreCaptureSink } from '../../services/objectStoreCaptureSink';
+import { loadRawStoreConfigFromEnv, createRawCaptureSink } from '../../services/s3ObjectStore';
+
+const FULL_ENV = {
+  RAW_STORE_S3_ENDPOINT: 'https://hel1.your-objectstorage.com',
+  RAW_STORE_S3_REGION: 'hel1',
+  RAW_STORE_S3_BUCKET: 'mindsignals-raw',
+  RAW_STORE_S3_PREFIX: 'raw-html/',
+  RAW_STORE_KEY_SCHEME: 'sha256-v1',
+  ACCESS_KEY_ID: 'AKIAEXAMPLE',
+  SECRET_ACCESS_KEY: 'secret-example',
+} as unknown as NodeJS.ProcessEnv;
+
+describe('loadRawStoreConfigFromEnv', () => {
+  it('parses the full contract + credential from env', () => {
+    const loaded = loadRawStoreConfigFromEnv(FULL_ENV);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.config).toMatchObject({
+      endpoint: 'https://hel1.your-objectstorage.com',
+      region: 'hel1',
+      bucket: 'mindsignals-raw',
+      prefix: 'raw-html/',
+      keyScheme: 'sha256-v1',
+    });
+    expect(loaded!.creds).toEqual({ accessKeyId: 'AKIAEXAMPLE', secretAccessKey: 'secret-example' });
+  });
+
+  it('returns null when any required value is missing (feature off)', () => {
+    for (const drop of ['RAW_STORE_S3_ENDPOINT', 'RAW_STORE_S3_BUCKET', 'ACCESS_KEY_ID', 'SECRET_ACCESS_KEY']) {
+      const env = { ...FULL_ENV };
+      delete (env as Record<string, unknown>)[drop];
+      expect(loadRawStoreConfigFromEnv(env)).toBeNull();
+    }
+  });
+
+  it('defaults prefix/keyScheme when omitted', () => {
+    const env = { ...FULL_ENV } as Record<string, unknown>;
+    delete env.RAW_STORE_S3_PREFIX;
+    delete env.RAW_STORE_KEY_SCHEME;
+    const loaded = loadRawStoreConfigFromEnv(env as NodeJS.ProcessEnv)!;
+    expect(loaded.config.prefix).toBe('raw-html/');
+    expect(loaded.config.keyScheme).toBe('sha256-v1');
+  });
+});
+
+describe('createRawCaptureSink', () => {
+  it('returns a NoopCaptureSink when capture is not configured', () => {
+    expect(createRawCaptureSink({} as NodeJS.ProcessEnv)).toBeInstanceOf(NoopCaptureSink);
+  });
+
+  it('returns a real ObjectStoreCaptureSink when configured', () => {
+    expect(createRawCaptureSink(FULL_ENV)).toBeInstanceOf(ObjectStoreCaptureSink);
+  });
+
+  it('fails fast on an unknown key scheme rather than silently dropping captures', () => {
+    const env = { ...FULL_ENV, RAW_STORE_KEY_SCHEME: 'sha256-v2' } as unknown as NodeJS.ProcessEnv;
+    expect(() => createRawCaptureSink(env)).toThrow(/sha256-v1/);
+  });
+});

--- a/src/__tests__/unit/s3ObjectStore.test.ts
+++ b/src/__tests__/unit/s3ObjectStore.test.ts
@@ -1,19 +1,28 @@
+import { jest } from '@jest/globals';
 import { NoopCaptureSink } from '../../services/captureSink';
 import { ObjectStoreCaptureSink } from '../../services/objectStoreCaptureSink';
-import { loadRawStoreConfigFromEnv, createRawCaptureSink } from '../../services/s3ObjectStore';
+import {
+  loadRawStoreConfigFromEnv,
+  createRawCaptureSink,
+  toS3MetaData,
+} from '../../services/s3ObjectStore';
 
+// Mirrors the ratified "1.B scraper Deployment wiring" fragment: PERSIST_RAW_HTML
+// gate + prefixed credential env-var names (the process sees RAW_STORE_S3_ACCESS_KEY_ID,
+// not the Secret's internal key ACCESS_KEY_ID).
 const FULL_ENV = {
+  PERSIST_RAW_HTML: 'true',
   RAW_STORE_S3_ENDPOINT: 'https://hel1.your-objectstorage.com',
   RAW_STORE_S3_REGION: 'hel1',
   RAW_STORE_S3_BUCKET: 'mindsignals-raw',
   RAW_STORE_S3_PREFIX: 'raw-html/',
   RAW_STORE_KEY_SCHEME: 'sha256-v1',
-  ACCESS_KEY_ID: 'AKIAEXAMPLE',
-  SECRET_ACCESS_KEY: 'secret-example',
+  RAW_STORE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+  RAW_STORE_S3_SECRET_ACCESS_KEY: 'secret-example',
 } as unknown as NodeJS.ProcessEnv;
 
 describe('loadRawStoreConfigFromEnv', () => {
-  it('parses the full contract + credential from env', () => {
+  it('parses the full contract + credential from the prefixed env names', () => {
     const loaded = loadRawStoreConfigFromEnv(FULL_ENV);
     expect(loaded).not.toBeNull();
     expect(loaded!.config).toMatchObject({
@@ -26,21 +35,38 @@ describe('loadRawStoreConfigFromEnv', () => {
     expect(loaded!.creds).toEqual({ accessKeyId: 'AKIAEXAMPLE', secretAccessKey: 'secret-example' });
   });
 
-  it('returns null when any required value is missing (feature off)', () => {
-    for (const drop of ['RAW_STORE_S3_ENDPOINT', 'RAW_STORE_S3_BUCKET', 'ACCESS_KEY_ID', 'SECRET_ACCESS_KEY']) {
-      const env = { ...FULL_ENV };
-      delete (env as Record<string, unknown>)[drop];
-      expect(loadRawStoreConfigFromEnv(env)).toBeNull();
-    }
+  it('is gated by PERSIST_RAW_HTML: fully configured but flag off → null (feature off, silent)', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const env = { ...FULL_ENV } as Record<string, unknown>;
+    delete env.PERSIST_RAW_HTML;
+    expect(loadRawStoreConfigFromEnv(env as NodeJS.ProcessEnv)).toBeNull();
+    expect(warn).not.toHaveBeenCalled(); // off-by-design is not a warning
+    warn.mockRestore();
   });
 
-  it('defaults prefix/keyScheme when omitted', () => {
+  it('enabled-but-incomplete → null AND a loud WARN (never a silent Noop)', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const env = { ...FULL_ENV } as Record<string, unknown>;
+    delete env.RAW_STORE_S3_ACCESS_KEY_ID; // the exact mismatch the review caught
+    expect(loadRawStoreConfigFromEnv(env as NodeJS.ProcessEnv)).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String((warn.mock.calls[0] ?? [])[0])).toMatch(/RAW_STORE_S3_ACCESS_KEY_ID/);
+    warn.mockRestore();
+  });
+
+  it('defaults prefix/jsonPrefix/keyScheme when omitted', () => {
     const env = { ...FULL_ENV } as Record<string, unknown>;
     delete env.RAW_STORE_S3_PREFIX;
     delete env.RAW_STORE_KEY_SCHEME;
     const loaded = loadRawStoreConfigFromEnv(env as NodeJS.ProcessEnv)!;
     expect(loaded.config.prefix).toBe('raw-html/');
+    expect(loaded.config.jsonPrefix).toBe('raw-json/');
     expect(loaded.config.keyScheme).toBe('sha256-v1');
+  });
+
+  it('drops an invalid putTimeoutMs so the sink falls back to its default', () => {
+    const loaded = loadRawStoreConfigFromEnv({ ...FULL_ENV, RAW_STORE_PUT_TIMEOUT_MS: 'nope' } as unknown as NodeJS.ProcessEnv)!;
+    expect(loaded.config.putTimeoutMs).toBeUndefined();
   });
 });
 
@@ -49,12 +75,31 @@ describe('createRawCaptureSink', () => {
     expect(createRawCaptureSink({} as NodeJS.ProcessEnv)).toBeInstanceOf(NoopCaptureSink);
   });
 
-  it('returns a real ObjectStoreCaptureSink when configured', () => {
+  it('returns a real ObjectStoreCaptureSink when configured + enabled', () => {
     expect(createRawCaptureSink(FULL_ENV)).toBeInstanceOf(ObjectStoreCaptureSink);
   });
 
   it('fails fast on an unknown key scheme rather than silently dropping captures', () => {
     const env = { ...FULL_ENV, RAW_STORE_KEY_SCHEME: 'sha256-v2' } as unknown as NodeJS.ProcessEnv;
     expect(() => createRawCaptureSink(env)).toThrow(/sha256-v1/);
+  });
+});
+
+describe('toS3MetaData — the real S3 header boundary', () => {
+  it('emits Content-Type + x-amz-meta-* and NEVER Content-Encoding', () => {
+    const md = toS3MetaData({
+      contentType: 'application/gzip',
+      metadata: { url: 'https://x.test/1', 'fetched-at': '2026-07-31T00:00:00.000Z', site: 'x.test' },
+    });
+    expect(md['Content-Type']).toBe('application/gzip');
+    expect(md['x-amz-meta-url']).toBe('https://x.test/1');
+    expect(md['x-amz-meta-fetched-at']).toBe('2026-07-31T00:00:00.000Z');
+    expect(md['x-amz-meta-site']).toBe('x.test');
+    expect(md['Content-Encoding']).toBeUndefined();
+    expect(md['content-encoding']).toBeUndefined();
+  });
+
+  it('handles absent metadata (only Content-Type)', () => {
+    expect(toS3MetaData({ contentType: 'application/gzip' })).toEqual({ 'Content-Type': 'application/gzip' });
   });
 });

--- a/src/services/engineServices/index.ts
+++ b/src/services/engineServices/index.ts
@@ -7,6 +7,7 @@ import { createScrapingService } from './scrapingService.js';
 import { createQueueService } from './queueService.js';
 import { createSessionService } from './sessionService.js';
 import { createWebhookService } from './webhookService.js';
+import { getRawCaptureSink } from '../s3ObjectStore.js';
 
 export { createRuntimeConfig, EnvRuntimeConfig } from './runtimeConfig.js';
 export { createPluginLogger } from './pluginLogger.js';
@@ -17,7 +18,7 @@ export { createWebhookService } from './webhookService.js';
 
 export function buildEngineServices(): EngineServices {
   return {
-    scraping: createScrapingService(),
+    scraping: createScrapingService(getRawCaptureSink()),
     queue: createQueueService(),
     sessions: createSessionService(),
     webhooks: createWebhookService(),

--- a/src/services/engineServices/scrapingService.ts
+++ b/src/services/engineServices/scrapingService.ts
@@ -8,6 +8,7 @@ import type { Browser, Page, HTTPResponse } from 'puppeteer';
 import { BrowserPool } from '../genericScraper.js';
 import { ScrapingService, ScrapePageOptions, ScrapePageResult, PageOptions } from '@figurecollecting/scraper-plugin-contract';
 import { CaptureSink, NoopCaptureSink, buildRawCapture } from '../captureSink.js';
+import { sanitizeForLog } from '../../utils/security.js';
 
 const DEFAULT_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36';
@@ -112,7 +113,8 @@ async function navigateAndCapture(
     }));
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn(`[CAPTURE] sink failed for ${url}: ${err instanceof Error ? err.message : String(err)}`);
+    // lgtm[js/log-injection] — url is caller-influenced; sanitize before logging
+    console.warn(`[CAPTURE] sink failed for ${sanitizeForLog(url)}: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   return {

--- a/src/services/objectStoreCaptureSink.ts
+++ b/src/services/objectStoreCaptureSink.ts
@@ -52,6 +52,11 @@ export interface RawStoreConfig {
   keyScheme: string;
   /** Hard bound on each HEAD/PUT so a slow store can't stall the fetch path. */
   putTimeoutMs?: number;
+  /**
+   * S3 addressing style for the adapter. Hetzner uses virtual-hosted style, so
+   * the adapter defaults to `false` (path-style off). Unused by the sink logic.
+   */
+  pathStyle?: boolean;
 }
 
 /** Observable counters — the leak/failure surface for prod (mirrors BrowserPool). */

--- a/src/services/objectStoreCaptureSink.ts
+++ b/src/services/objectStoreCaptureSink.ts
@@ -1,0 +1,152 @@
+/**
+ * ObjectStoreCaptureSink — CaptureSink Phase 2: persists raw captures to a
+ * content-addressed object store (Hetzner `mindsignals-raw`) per the ratified
+ * `sha256-v1` contract (fc-infra nodes/fc-app-01/raw-store/README.md):
+ *
+ *   key   = <prefix>sha256/<aa>/<sha256hex>.html.gz   (aa = first 2 hex of digest)
+ *   hash  = sha256 of the UNCOMPRESSED, exact-as-received bytes (hash-before-compress;
+ *           already computed by buildRawCapture — we never re-hash here)
+ *   body  = gzip(content), Content-Type: application/gzip, and deliberately NO
+ *           Content-Encoding: gzip (transparent double-decode footgun)
+ *   write = HEAD-then-PUT, write-once: a dedup hit records nothing here (the spine
+ *           capture table is the authoritative event log); nothing is ever DELETEd.
+ *
+ * The store is injected via a minimal SDK-agnostic port so this logic is unit-
+ * testable without creds, a network, or the real S3 SDK. A slow/broken store must
+ * NEVER break or stall a scrape: every op is timeout-bounded and failures are
+ * swallowed-but-counted (observable via stats()).
+ */
+import { gzipSync } from 'node:zlib';
+import type { CaptureSink, RawCapture } from './captureSink.js';
+
+/** Options for a single object write. */
+export interface PutOptions {
+  /** Always `application/gzip`. */
+  contentType: string;
+  /**
+   * Intentionally never set by this sink — the `.gz` suffix declares compression
+   * and `Content-Encoding: gzip` triggers transparent double-decoding in some
+   * clients. Present on the port only so tests can assert it stays unset.
+   */
+  contentEncoding?: string;
+  /** Best-effort convenience metadata describing the FIRST capture only. */
+  metadata?: Record<string, string>;
+}
+
+/** Minimal S3-compatible port. Concrete adapter (Hetzner) lives separately. */
+export interface ObjectStore {
+  /** HEAD — does this content address already exist? */
+  exists(key: string): Promise<boolean>;
+  /** PUT — write the object. Callers guarantee write-once by content address. */
+  put(key: string, body: Buffer, opts: PutOptions): Promise<void>;
+}
+
+/** Non-secret store contract (from raw-store-config.yaml) + operational bounds. */
+export interface RawStoreConfig {
+  endpoint: string;
+  region: string;
+  bucket: string;
+  /** Capture-type prefix, e.g. `raw-html/`. */
+  prefix: string;
+  /** Key-scheme contract version; this writer only knows `sha256-v1`. */
+  keyScheme: string;
+  /** Hard bound on each HEAD/PUT so a slow store can't stall the fetch path. */
+  putTimeoutMs?: number;
+}
+
+/** Observable counters — the leak/failure surface for prod (mirrors BrowserPool). */
+export interface SinkStats {
+  stored: number;
+  deduped: number;
+  failed: number;
+}
+
+const SUPPORTED_KEY_SCHEME = 'sha256-v1';
+const DEFAULT_PUT_TIMEOUT_MS = 5_000;
+
+export class ObjectStoreCaptureSink implements CaptureSink {
+  private readonly putTimeoutMs: number;
+  private stored = 0;
+  private deduped = 0;
+  private failed = 0;
+
+  constructor(
+    private readonly store: ObjectStore,
+    private readonly config: RawStoreConfig,
+  ) {
+    if (config.keyScheme !== SUPPORTED_KEY_SCHEME) {
+      throw new Error(
+        `unsupported raw-store key scheme "${config.keyScheme}" — this writer only knows "${SUPPORTED_KEY_SCHEME}"`,
+      );
+    }
+    this.putTimeoutMs = config.putTimeoutMs ?? DEFAULT_PUT_TIMEOUT_MS;
+  }
+
+  stats(): SinkStats {
+    return { stored: this.stored, deduped: this.deduped, failed: this.failed };
+  }
+
+  async capture(c: RawCapture): Promise<void> {
+    try {
+      const key = this.objectKey(c);
+
+      // HEAD-then-PUT: content-addressed, so an existing key means identical bytes.
+      if (await this.withTimeout(this.store.exists(key))) {
+        this.deduped += 1;
+        return;
+      }
+
+      const body = gzipSync(c.bytes);
+      await this.withTimeout(
+        this.store.put(key, body, {
+          contentType: 'application/gzip',
+          metadata: this.metadata(c),
+        }),
+      );
+      this.stored += 1;
+    } catch (err) {
+      // Raw capture is best-effort insurance; a store failure must never break or
+      // stall a scrape. Count it so the failure is observable in prod.
+      this.failed += 1;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[RAW-STORE] capture failed for ${c.url} (sha ${c.sha256.slice(0, 12)}…): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  /** `<prefix>sha256/<aa>/<sha256hex><ext>` — json lanes route to a raw-json/ sibling. */
+  private objectKey(c: RawCapture): string {
+    const aa = c.sha256.slice(0, 2);
+    const isJson = c.lane === 'api' || (c.contentType ?? '').includes('json');
+    const prefix = isJson ? this.config.prefix.replace('raw-html', 'raw-json') : this.config.prefix;
+    const ext = isJson ? '.json.gz' : '.html.gz';
+    return `${prefix}sha256/${aa}/${c.sha256}${ext}`;
+  }
+
+  private metadata(c: RawCapture): Record<string, string> {
+    const url = c.finalUrl ?? c.url;
+    const md: Record<string, string> = { url, 'fetched-at': c.fetchedAt };
+    try {
+      md.site = new URL(url).hostname;
+    } catch {
+      /* best-effort — a malformed URL just omits the site tag */
+    }
+    return md;
+  }
+
+  private withTimeout<T>(p: Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`raw-store op exceeded ${this.putTimeoutMs}ms`)),
+        this.putTimeoutMs,
+      );
+    });
+    return Promise.race([p, timeout]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  }
+}

--- a/src/services/objectStoreCaptureSink.ts
+++ b/src/services/objectStoreCaptureSink.ts
@@ -18,6 +18,7 @@
  */
 import { gzipSync } from 'node:zlib';
 import type { CaptureSink, RawCapture } from './captureSink.js';
+import { sanitizeForLog } from '../utils/security.js';
 
 /** Options for a single object write. */
 export interface PutOptions {
@@ -46,8 +47,10 @@ export interface RawStoreConfig {
   endpoint: string;
   region: string;
   bucket: string;
-  /** Capture-type prefix, e.g. `raw-html/`. */
+  /** Capture-type prefix for html lanes, e.g. `raw-html/`. */
   prefix: string;
+  /** Capture-type prefix for the json (api) lane, e.g. `raw-json/`. */
+  jsonPrefix?: string;
   /** Key-scheme contract version; this writer only knows `sha256-v1`. */
   keyScheme: string;
   /** Hard bound on each HEAD/PUT so a slow store can't stall the fetch path. */
@@ -68,6 +71,25 @@ export interface SinkStats {
 
 const SUPPORTED_KEY_SCHEME = 'sha256-v1';
 const DEFAULT_PUT_TIMEOUT_MS = 5_000;
+const MAX_METADATA_VALUE_LEN = 1024;
+
+/**
+ * S3 user-metadata is carried in HTTP headers: values must be header-safe (ASCII,
+ * no control chars) and bounded, or the PUT itself fails. A capture's URL is
+ * caller-influenced and may hold non-ASCII (international paths) or hostile bytes,
+ * so we make it header-safe here — a bad URL degrades the convenience tag, never
+ * the byte write.
+ */
+function headerSafe(value: string): string {
+  let s: string;
+  try {
+    s = encodeURI(value); // percent-encodes non-ASCII, preserves URL structure
+  } catch {
+    s = value.replace(/[^\x20-\x7e]/g, '');
+  }
+  s = s.replace(/[\x00-\x1f\x7f]/g, ''); // strip any residual control chars
+  return s.length > MAX_METADATA_VALUE_LEN ? s.slice(0, MAX_METADATA_VALUE_LEN) : s;
+}
 
 export class ObjectStoreCaptureSink implements CaptureSink {
   private readonly putTimeoutMs: number;
@@ -84,7 +106,8 @@ export class ObjectStoreCaptureSink implements CaptureSink {
         `unsupported raw-store key scheme "${config.keyScheme}" — this writer only knows "${SUPPORTED_KEY_SCHEME}"`,
       );
     }
-    this.putTimeoutMs = config.putTimeoutMs ?? DEFAULT_PUT_TIMEOUT_MS;
+    const t = config.putTimeoutMs;
+    this.putTimeoutMs = typeof t === 'number' && Number.isFinite(t) && t > 0 ? t : DEFAULT_PUT_TIMEOUT_MS;
   }
 
   stats(): SinkStats {
@@ -115,27 +138,37 @@ export class ObjectStoreCaptureSink implements CaptureSink {
       this.failed += 1;
       // eslint-disable-next-line no-console
       console.warn(
-        `[RAW-STORE] capture failed for ${c.url} (sha ${c.sha256.slice(0, 12)}…): ${
+        // lgtm[js/log-injection] — url is caller-influenced; sanitize before logging
+        `[RAW-STORE] capture failed for ${sanitizeForLog(c.url)} (sha ${c.sha256.slice(0, 12)}…): ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
     }
   }
 
-  /** `<prefix>sha256/<aa>/<sha256hex><ext>` — json lanes route to a raw-json/ sibling. */
+  /** `<prefix>sha256/<aa>/<sha256hex><ext>` — the json (api) lane uses jsonPrefix. */
   private objectKey(c: RawCapture): string {
     const aa = c.sha256.slice(0, 2);
     const isJson = c.lane === 'api' || (c.contentType ?? '').includes('json');
-    const prefix = isJson ? this.config.prefix.replace('raw-html', 'raw-json') : this.config.prefix;
+    const prefix = isJson ? this.jsonPrefix() : this.config.prefix;
     const ext = isJson ? '.json.gz' : '.html.gz';
     return `${prefix}sha256/${aa}/${c.sha256}${ext}`;
   }
 
+  private jsonPrefix(): string {
+    if (this.config.jsonPrefix) return this.config.jsonPrefix;
+    // Fallback only when unconfigured: derive a raw-json/ sibling from the html
+    // prefix if it follows the raw-html/ convention, else reuse the html prefix.
+    return this.config.prefix.includes('raw-html')
+      ? this.config.prefix.replace('raw-html', 'raw-json')
+      : this.config.prefix;
+  }
+
   private metadata(c: RawCapture): Record<string, string> {
     const url = c.finalUrl ?? c.url;
-    const md: Record<string, string> = { url, 'fetched-at': c.fetchedAt };
+    const md: Record<string, string> = { url: headerSafe(url), 'fetched-at': c.fetchedAt };
     try {
-      md.site = new URL(url).hostname;
+      md.site = headerSafe(new URL(url).hostname);
     } catch {
       /* best-effort — a malformed URL just omits the site tag */
     }

--- a/src/services/s3ObjectStore.ts
+++ b/src/services/s3ObjectStore.ts
@@ -1,0 +1,122 @@
+/**
+ * S3ObjectStore — the concrete Hetzner-Object-Storage adapter for the ObjectStore
+ * port, plus the env-driven factory that wires the real CaptureSink (or a Noop
+ * when capture is not configured).
+ *
+ * Config comes from the environment per the ratified raw-store contract
+ * (fc-infra nodes/fc-app-01/raw-store/raw-store-config.yaml + the synced Secret):
+ *   RAW_STORE_S3_ENDPOINT / _REGION / _BUCKET / _PREFIX / _KEY_SCHEME  (ConfigMap)
+ *   ACCESS_KEY_ID / SECRET_ACCESS_KEY                                   (Secret)
+ * The scraper reads env — it never talks to OpenBao itself (the infra syncs the
+ * credential into the deployment's environment).
+ *
+ * This adapter is thin glue over minio and is validated at deploy (a live PUT/HEAD
+ * against the bucket), not in unit tests — the sink logic is exercised against a
+ * fake ObjectStore in objectStoreCaptureSink.test.ts.
+ */
+import { Client as MinioClient } from 'minio';
+import type { CaptureSink } from './captureSink.js';
+import { NoopCaptureSink } from './captureSink.js';
+import {
+  ObjectStoreCaptureSink,
+  type ObjectStore,
+  type PutOptions,
+  type RawStoreConfig,
+} from './objectStoreCaptureSink.js';
+
+export interface S3Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+/** Maps the minimal ObjectStore port onto the minio client (statObject / putObject). */
+export class S3ObjectStore implements ObjectStore {
+  private readonly client: MinioClient;
+
+  constructor(
+    private readonly bucket: string,
+    config: RawStoreConfig,
+    creds: S3Credentials,
+  ) {
+    const url = new URL(config.endpoint);
+    this.client = new MinioClient({
+      endPoint: url.hostname,
+      port: url.port ? Number(url.port) : undefined,
+      useSSL: url.protocol === 'https:',
+      region: config.region,
+      accessKey: creds.accessKeyId,
+      secretKey: creds.secretAccessKey,
+      pathStyle: config.pathStyle ?? false, // Hetzner = virtual-hosted style
+    });
+  }
+
+  async exists(key: string): Promise<boolean> {
+    try {
+      await this.client.statObject(this.bucket, key);
+      return true;
+    } catch (err) {
+      // A genuine 404 means "not stored yet" — NOT a failure. Any other error
+      // (network, auth, 5xx) is a real fault: rethrow so the sink counts it and
+      // does not mistake it for absence (which would trigger a needless re-PUT).
+      const e = err as { code?: string; statusCode?: number };
+      if (e?.code === 'NotFound' || e?.code === 'NoSuchKey' || e?.statusCode === 404) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  async put(key: string, body: Buffer, opts: PutOptions): Promise<void> {
+    const metaData: Record<string, string> = { 'Content-Type': opts.contentType };
+    for (const [k, v] of Object.entries(opts.metadata ?? {})) {
+      metaData[`x-amz-meta-${k}`] = v;
+    }
+    await this.client.putObject(this.bucket, key, body, body.length, metaData);
+  }
+}
+
+/**
+ * Reads the raw-store contract + credential from the environment. Returns null
+ * when capture is not configured (any required value missing) → the caller
+ * falls back to a NoopCaptureSink (feature off).
+ */
+export function loadRawStoreConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): { config: RawStoreConfig; creds: S3Credentials } | null {
+  const endpoint = env.RAW_STORE_S3_ENDPOINT;
+  const bucket = env.RAW_STORE_S3_BUCKET;
+  const accessKeyId = env.ACCESS_KEY_ID;
+  const secretAccessKey = env.SECRET_ACCESS_KEY;
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) return null;
+
+  const config: RawStoreConfig = {
+    endpoint,
+    region: env.RAW_STORE_S3_REGION ?? 'us-east-1',
+    bucket,
+    prefix: env.RAW_STORE_S3_PREFIX ?? 'raw-html/',
+    keyScheme: env.RAW_STORE_KEY_SCHEME ?? 'sha256-v1',
+    putTimeoutMs: env.RAW_STORE_PUT_TIMEOUT_MS ? Number(env.RAW_STORE_PUT_TIMEOUT_MS) : undefined,
+    pathStyle: env.RAW_STORE_S3_PATH_STYLE !== undefined ? env.RAW_STORE_S3_PATH_STYLE === 'true' : undefined,
+  };
+  return { config, creds: { accessKeyId, secretAccessKey } };
+}
+
+/**
+ * The composition-root factory: a real content-addressed sink when the raw-store
+ * env is present, otherwise a NoopCaptureSink. Constructing the sink asserts the
+ * key scheme (fail-fast on a misconfigured contract version).
+ */
+export function createRawCaptureSink(env: NodeJS.ProcessEnv = process.env): CaptureSink {
+  const loaded = loadRawStoreConfigFromEnv(env);
+  if (!loaded) return new NoopCaptureSink();
+  const store = new S3ObjectStore(loaded.config.bucket, loaded.config, loaded.creds);
+  return new ObjectStoreCaptureSink(store, loaded.config);
+}
+
+// Process-wide singleton so every fetch path shares one client + one set of
+// observable counters. Lazily built from the environment on first use.
+let sharedSink: CaptureSink | undefined;
+export function getRawCaptureSink(): CaptureSink {
+  if (!sharedSink) sharedSink = createRawCaptureSink();
+  return sharedSink;
+}

--- a/src/services/s3ObjectStore.ts
+++ b/src/services/s3ObjectStore.ts
@@ -4,9 +4,13 @@
  * when capture is not configured).
  *
  * Config comes from the environment per the ratified raw-store contract
- * (fc-infra nodes/fc-app-01/raw-store/raw-store-config.yaml + the synced Secret):
- *   RAW_STORE_S3_ENDPOINT / _REGION / _BUCKET / _PREFIX / _KEY_SCHEME  (ConfigMap)
- *   ACCESS_KEY_ID / SECRET_ACCESS_KEY                                   (Secret)
+ * (fc-infra nodes/fc-app-01/raw-store/README.md — the "1.B scraper Deployment
+ * wiring" fragment):
+ *   PERSIST_RAW_HTML=true                                        (the se-09 kill-switch)
+ *   RAW_STORE_S3_ENDPOINT / _REGION / _BUCKET / _PREFIX / _KEY_SCHEME   (ConfigMap, envFrom)
+ *   RAW_STORE_S3_ACCESS_KEY_ID / RAW_STORE_S3_SECRET_ACCESS_KEY   (Secret raw-store-s3-creds,
+ *       whose internal keys are ACCESS_KEY_ID/SECRET_ACCESS_KEY, mapped to these
+ *       prefixed env-var names via secretKeyRef — the process sees the prefixed names)
  * The scraper reads env — it never talks to OpenBao itself (the infra syncs the
  * credential into the deployment's environment).
  *
@@ -67,35 +71,65 @@ export class S3ObjectStore implements ObjectStore {
   }
 
   async put(key: string, body: Buffer, opts: PutOptions): Promise<void> {
-    const metaData: Record<string, string> = { 'Content-Type': opts.contentType };
-    for (const [k, v] of Object.entries(opts.metadata ?? {})) {
-      metaData[`x-amz-meta-${k}`] = v;
-    }
-    await this.client.putObject(this.bucket, key, body, body.length, metaData);
+    await this.client.putObject(this.bucket, key, body, body.length, toS3MetaData(opts));
   }
 }
 
 /**
+ * The exact header set handed to S3: `Content-Type` + `x-amz-meta-*` user metadata,
+ * and deliberately NO `Content-Encoding` (the `.gz` suffix declares compression).
+ * Exported so the real header boundary is unit-tested without a live client.
+ */
+export function toS3MetaData(opts: PutOptions): Record<string, string> {
+  const metaData: Record<string, string> = { 'Content-Type': opts.contentType };
+  for (const [k, v] of Object.entries(opts.metadata ?? {})) {
+    metaData[`x-amz-meta-${k}`] = v;
+  }
+  return metaData;
+}
+
+/** A finite, positive millisecond value from env, or undefined (sink uses its default). */
+function parsePositiveMs(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
  * Reads the raw-store contract + credential from the environment. Returns null
- * when capture is not configured (any required value missing) → the caller
- * falls back to a NoopCaptureSink (feature off).
+ * when capture is off (PERSIST_RAW_HTML !== 'true') or the config is incomplete.
+ * An ENABLED-but-incomplete state is logged loudly — never a silent Noop — because
+ * a name/wiring mismatch would otherwise disable the (irrecoverable) insurance
+ * corpus with no signal.
  */
 export function loadRawStoreConfigFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): { config: RawStoreConfig; creds: S3Credentials } | null {
+  // se-09 kill-switch: capture is off by default; absence here is intended silence.
+  if (env.PERSIST_RAW_HTML !== 'true') return null;
+
   const endpoint = env.RAW_STORE_S3_ENDPOINT;
   const bucket = env.RAW_STORE_S3_BUCKET;
-  const accessKeyId = env.ACCESS_KEY_ID;
-  const secretAccessKey = env.SECRET_ACCESS_KEY;
-  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) return null;
+  const accessKeyId = env.RAW_STORE_S3_ACCESS_KEY_ID;
+  const secretAccessKey = env.RAW_STORE_S3_SECRET_ACCESS_KEY;
+
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[RAW-STORE] PERSIST_RAW_HTML=true but required config/credentials are missing — capture DISABLED ' +
+        '(needs RAW_STORE_S3_ENDPOINT, RAW_STORE_S3_BUCKET, RAW_STORE_S3_ACCESS_KEY_ID, RAW_STORE_S3_SECRET_ACCESS_KEY)',
+    );
+    return null;
+  }
 
   const config: RawStoreConfig = {
     endpoint,
     region: env.RAW_STORE_S3_REGION ?? 'us-east-1',
     bucket,
     prefix: env.RAW_STORE_S3_PREFIX ?? 'raw-html/',
+    jsonPrefix: env.RAW_STORE_S3_JSON_PREFIX ?? 'raw-json/',
     keyScheme: env.RAW_STORE_KEY_SCHEME ?? 'sha256-v1',
-    putTimeoutMs: env.RAW_STORE_PUT_TIMEOUT_MS ? Number(env.RAW_STORE_PUT_TIMEOUT_MS) : undefined,
+    putTimeoutMs: parsePositiveMs(env.RAW_STORE_PUT_TIMEOUT_MS),
     pathStyle: env.RAW_STORE_S3_PATH_STYLE !== undefined ? env.RAW_STORE_S3_PATH_STYLE === 'true' : undefined,
   };
   return { config, creds: { accessKeyId, secretAccessKey } };
@@ -103,8 +137,8 @@ export function loadRawStoreConfigFromEnv(
 
 /**
  * The composition-root factory: a real content-addressed sink when the raw-store
- * env is present, otherwise a NoopCaptureSink. Constructing the sink asserts the
- * key scheme (fail-fast on a misconfigured contract version).
+ * env is present and enabled, otherwise a NoopCaptureSink. Constructing the sink
+ * asserts the key scheme (fail-fast on a misconfigured contract version).
  */
 export function createRawCaptureSink(env: NodeJS.ProcessEnv = process.env): CaptureSink {
   const loaded = loadRawStoreConfigFromEnv(env);

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -25,6 +25,7 @@ import { getSessionManager, resetSessionManager, SessionManager, SessionPausedEv
 import { notifyItemFailed } from './webhookClient.js';
 import { enrichmentLogger } from '../utils/logger.js';
 import { createScrapingService } from './engineServices/scrapingService.js';
+import { getRawCaptureSink } from './s3ObjectStore.js';
 import { createIngestEmitterFromEnv } from './ingestEmitter.js';
 import type {
   ExtractionRuleset,
@@ -927,7 +928,7 @@ export class ScrapeQueue {
     if (!this.rawPageFetcher) {
       // Same raw page-fetch machinery plugins get via EngineServices — the
       // engine only fetches; extraction is the plugin's job.
-      this.rawPageFetcher = createScrapingService();
+      this.rawPageFetcher = createScrapingService(getRawCaptureSink());
     }
     return this.rawPageFetcher;
   }


### PR DESCRIPTION
## What
Phase 2 of the raw-capture pipeline: the real `CaptureSink` that persists captures (Phase 1's wire/dom lanes, #228) to the content-addressed Hetzner `mindsignals-raw` bucket. Bytes go **directly** scraper→object-store (no round-trip through the backend), gated by `PERSIST_RAW_HTML`.

## Design
- **`ObjectStoreCaptureSink`** — SDK-agnostic sink implementing the ratified `sha256-v1` contract (fc-infra `nodes/fc-app-01/raw-store/README.md`): key `<prefix>sha256/<aa>/<hex>.html.gz`, hash-before-compress, `gzip` body with `Content-Type: application/gzip` and **no** `Content-Encoding`, **HEAD-then-PUT write-once (never delete)**, asserts `KEY_SCHEME == sha256-v1`.
- **`S3ObjectStore`** — thin `minio` (8.0.7) adapter over the `ObjectStore` port (`statObject`/`putObject`); Hetzner virtual-hosted style.
- **Env-gated factory** — real sink only when `PERSIST_RAW_HTML=true` **and** `RAW_STORE_S3_*` + `RAW_STORE_S3_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` are present; otherwise `NoopCaptureSink`. An *enabled-but-incomplete* config logs a loud WARN — never a silent Noop.
- **Best-effort by construction** — every HEAD/PUT is timeout-bounded and failures are swallowed-but-counted (`stats()`); a slow/broken store can never break or stall a scrape (and, unlike a background fire-and-forget, cannot accumulate unbounded buffers — the lesson from the #233 leak).

## Security posture
The scraper is the internet-exposed service and holds the write credential, so blast radius is contained: `mindsignals-raw` is a dedicated Hetzner project (credential-isolated from backups), the bucket has versioning + delete-protection, and the sink itself only PUTs (skip-if-exists), never deletes.

## Adversarial review
Ran a 4-lens red-team (contract / security / resilience / simplicity) with per-finding adjudication: **28 raw → 10 confirmed → all fixed** here. Highlights:
- **HIGH** — loader read the bare `ACCESS_KEY_ID`/`SECRET_ACCESS_KEY`, but the ratified deployment injects the **prefixed** `RAW_STORE_S3_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` (k8s `env[].name`) → would have silently disabled capture. Fixed + loud-WARN backstop.
- **MED** — `PERSIST_RAW_HTML` kill-switch gate was missing; log-injection on the caller-influenced URL (now `sanitizeForLog`, matching the repo pattern); unbounded/non-ASCII URL in `x-amz-meta-url` could fail the PUT (now header-safe).
- **LOW** — invalid `putTimeoutMs` guard; explicit `jsonPrefix` instead of a `String.replace` hack; added tests for the site tag, malformed-URL fallback, hung-HEAD bound, and the real header boundary (`toS3MetaData`).

## Tests
35 unit tests (sink + adapter/loader/factory), full suite 488 pass (the one failing suite, `backendCommunication`, is pre-existing on develop — `import.meta` under the integration transform).

## Deployment / follow-ups
- Enabling in prod = set `PERSIST_RAW_HTML=true` + the `RAW_STORE_S3_*`/cred env in **Coolify** (the ratified ConfigMap+Secret targets k3s ns fc, the future cutover home). Sink code is deployment-agnostic.
- The ratified raw-store config + bootstrap live on the **unmerged fc-infra `feat/raw-html-store`** branch — should be merged.
- The pre-existing dead method `hasItemsInCooldownOrPaused` (scrapeQueue.ts) was flagged but left out of scope.