### PR TITLE
Make ruleset extract() async-capable and add ExtractContext seam

### DIFF
--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -199,10 +199,34 @@ export interface DomainRateLimit {
   successThreshold: number;
 }
 
+/**
+ * Per-extraction context handed to `extract()` by the engine (E1 seam).
+ * Generic engine surface only: site config, page/batch/API fetch access, and
+ * a logger — so rulesets that need multiple queries per item (search + detail,
+ * batch endpoints, official APIs) can issue them through engine-managed
+ * plumbing instead of owning their own HTTP stack. A minimal engine may not
+ * yet provide `batchFetch`/`officialApi`; rulesets must treat `ctx` as
+ * optional and degrade gracefully when it is absent.
+ */
+export interface ExtractContext {
+  config: SiteConfig;
+  scraping: ScrapingService & {
+    batchFetch(codes: string[], opts?: Record<string, unknown>): Promise<Record<string, unknown>>;
+    officialApi(name: string, params: Record<string, unknown>, auth?: Record<string, unknown>): Promise<unknown>;
+  };
+  logger: PluginLogger;
+}
+
 export interface ExtractionRuleset {
   siteId: string;
   version: string;
-  extract(html: string, url: string): ExtractedData;
+  /**
+   * Extract structured data from a fetched page. Async-capable via this
+   * single method: the engine ALWAYS awaits the result, so a plain
+   * synchronous body remains valid with zero ceremony. `ctx` is optional —
+   * existing two-argument rulesets are unaffected.
+   */
+  extract(html: string, url: string, ctx?: ExtractContext): ExtractedData | Promise<ExtractedData>;
   validate(data: ExtractedData): ValidationResult;
 }
 

--- a/src/__tests__/unit/extractionRegistry.test.ts
+++ b/src/__tests__/unit/extractionRegistry.test.ts
@@ -70,7 +70,7 @@ describe('ExtractionRegistry', () => {
     expect(registry.getSiteConfigForUrl('https://unregistered.example.test/item/1')).toBeUndefined();
   });
 
-  it('resolves the ruleset registered for the same siteId as the matched hostname', () => {
+  it('resolves the ruleset registered for the same siteId as the matched hostname', async () => {
     const registry = createExtractionRegistry();
     registry.registerSite(buildSiteConfig());
     registry.registerRuleset(buildRuleset('alpha'));
@@ -78,7 +78,8 @@ describe('ExtractionRegistry', () => {
     const ruleset = registry.getRulesetForUrl('https://alpha.example.test/item/42');
     expect(ruleset?.siteId).toBe('alpha');
 
-    const extracted = ruleset!.extract('<html></html>', 'https://alpha.example.test/item/42');
+    // extract() is async-capable (E1) — consumers always await the result.
+    const extracted = await ruleset!.extract('<html></html>', 'https://alpha.example.test/item/42');
     expect(extracted.source.site).toBe('alpha');
   });
 

--- a/src/__tests__/unit/scrapeQueueIngest.test.ts
+++ b/src/__tests__/unit/scrapeQueueIngest.test.ts
@@ -34,7 +34,7 @@ jest.mock('../../services/webhookClient', () => ({
   notifyItemSkipped: (...args: any[]) => mockNotifyItemSkipped(...args),
 }));
 
-import type { ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+import type { ExtractContext, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
 import { ScrapeQueue, resetScrapeQueue } from '../../services/scrapeQueue';
 import { createExtractionRegistry, ExtractionRegistryImpl } from '../../services/extractionRegistry';
 
@@ -210,6 +210,50 @@ describe('ScrapeQueue - ingest cutover', () => {
     expect(send).toHaveBeenCalledTimes(1);
     expect(send.mock.calls[0][0].fields).toEqual({ name: 'Fate/stay night' });
     expect(data).toEqual({ name: 'Fate/stay night' });
+  });
+
+  it('awaits extract() when the ruleset returns a Promise from the single contract method (E1)', async () => {
+    // E1 contract evolution: extract() itself is async-capable. This ruleset
+    // is typed straight against ExtractionRuleset — no extractAsync, no casts.
+    // Declaring the optional ctx?: ExtractContext third parameter locks the
+    // E1 seam at compile level; the engine still invokes with two arguments.
+    const extractFn = jest.fn(async (html: string, url: string, _ctx?: ExtractContext) => ({
+      source: {
+        site: 'mock-mfc',
+        itemId: '12345',
+        url,
+        extractedAt: '2026-07-24T00:00:00.000Z',
+        rulesetVersion: '2.0.0',
+      },
+      fields: { name: 'Async Marin', jan: '4530956107891' },
+      warnings: [],
+    }));
+    const ruleset: ExtractionRuleset = {
+      siteId: 'mock-mfc',
+      version: '2.0.0',
+      extract: extractFn,
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const result = queue.enqueue('12345', { priority: 'WARM', sessionId: 'session1' });
+    await advanceAndFlush(500);
+    const data = await result.promise;
+
+    expect(extractFn).toHaveBeenCalledWith(FIXTURE_HTML, 'https://myfigurecollection.net/item/12345');
+    // the RESOLVED extraction (not a Promise) went to the spine
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0].fields).toEqual({ name: 'Async Marin', jan: '4530956107891' });
+    expect(send.mock.calls[0][0].source.site).toBe('mock-mfc');
+    // waiting callers resolve with the extracted field bag, not undefined
+    expect(data).toEqual({ name: 'Async Marin', jan: '4530956107891' });
+    expect(queue.getStats().completed).toBe(1);
   });
 
   it('scrapes the caller-supplied url option instead of building an MFC URL from the key', async () => {

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -949,12 +949,13 @@ export class ScrapeQueue {
 
     let extracted: PluginExtractedData;
     try {
-      // Rulesets may optionally expose an async extraction path (API-backed
-      // sites like VNDB, AmiAmi) alongside the required sync extract(); prefer
-      // it when present via duck-typing so the plugin contract stays untouched.
+      // extract() is async-capable (E1): the contract allows it to return
+      // ExtractedData or a Promise, so the result is ALWAYS awaited — sync
+      // rulesets pass through unchanged. The duck-typed extractAsync path
+      // predates E1 and is kept for rulesets that still expose it.
       extracted = typeof (ruleset as { extractAsync?: unknown }).extractAsync === 'function'
         ? await (ruleset as unknown as { extractAsync(h: string, u: string): Promise<PluginExtractedData> }).extractAsync(page.html, item.url)
-        : ruleset.extract(page.html, item.url);
+        : await ruleset.extract(page.html, item.url);
     } catch (error: any) {
       console.error(
         `[SCRAPE QUEUE] Extraction failed for ${item.url} (ruleset ${ruleset.siteId}@${ruleset.version}): ${sanitizeForLog(error?.message ?? String(error))}`


### PR DESCRIPTION
**E1 of the expressive-contract evolution** — makes the ruleset `extract()` async-capable and adds a generic multi-query injection seam. Minimal and backward-compatible.

## Change
- `ExtractionRuleset.extract(html, url, ctx?): ExtractedData | Promise<ExtractedData>` — the engine **always awaits**; a synchronous body stays valid and zero-ceremony.
- Adds `ExtractContext` (generic engine surface): `{ config, scraping: ScrapingService & { batchFetch, officialApi }, logger }`.

## Moat boundary (respected)
`ExtractedData` is **untouched** — still `{ source, fields, warnings }`. No `core`/`coverage`/`StoreProfile`/expressive types enter the public contract (those live private, in `scraper-rulesets`).

## Engine
The single production call site (`scrapeQueue`) awaits the now-possibly-`Promise` result; the pre-existing duck-typed `extractAsync` dispatch is **preserved** for rulesets that still expose it (legacy path, removable once AmiAmi migrates to async `extract()`).

## Verification
- TDD red→green: a ruleset returning `Promise<ExtractedData>` is correctly awaited; a synchronous ruleset still works unchanged (backward-compat).
- Full affected suites green, **zero regression**.
- Branched off canonical `upstream/develop`.
