### PR TITLE
Crawl-ingest driver I0: scheduling core, async loop, retrieval planner

### DIFF
--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -200,6 +200,35 @@ export interface DomainRateLimit {
 }
 
 /**
+ * Targeted-retrieval addressability — how SPECIFIC items are fetched ON REQUEST (by id, a
+ * bounded id range, a batch/list of ids, or a name/keyword search), as opposed to full-catalog
+ * discovery. This is what enables range-limited on-request fetches and cross-store lookup. The
+ * per-store DATA is supplied by the plugin (mapped down from the private profile registry); the
+ * engine consumes only this generic shape.
+ */
+export interface RetrievalCapability {
+  /** Build an item URL/endpoint from an identifier; `{id}` is substituted. `idKind` names the id. */
+  byId?: { urlTemplate: string; idKind?: string };
+  /** Identifiers are sequential/enumerable, so a bounded [from,to] sweep is valid. */
+  byRange?: boolean;
+  /** One endpoint returns up to `maxBatch` items per call (cheaper than N by-id fetches). */
+  byBatch?: { maxBatch: number };
+  /** Map a free-text query (name/keyword) to candidate items; `{q}` is substituted. */
+  bySearch?: { urlTemplate: string };
+}
+
+/**
+ * The engine-facing capability view of a store: its public `SiteConfig` (siteId / domains /
+ * rateLimit / requiresBrowser) plus retrieval addressability. The crawl driver schedules from
+ * this — `rateLimit` → per-host throttle, `requiresBrowser` → pool, `retrieval` → targeted
+ * fetches — without ever importing the private StoreProfile axes. The plugin maps each private
+ * StoreProfile down to this shape at registration.
+ */
+export interface StoreCapabilities extends SiteConfig {
+  retrieval?: RetrievalCapability;
+}
+
+/**
  * Per-extraction context handed to `extract()` by the engine (E1 seam).
  * Generic engine surface only: site config, page/batch/API fetch access, and
  * a logger — so rulesets that need multiple queries per item (search + detail,

--- a/src/driver/__tests__/assembleScheduler.test.ts
+++ b/src/driver/__tests__/assembleScheduler.test.ts
@@ -1,0 +1,60 @@
+/**
+ * TDD (red first): assembleScheduler — the profile-injection wiring. Given a ProfileRegistry
+ * and pool capacities, it produces a ready-to-run DispatchScheduler whose per-host throttle is
+ * seeded from each store's rateLimit and whose pool is resolved from requiresBrowser. Hosts with
+ * no profile fall back to a default rate config and the cheap fetch pool (never a browser slot).
+ */
+import type { StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import { ProfileRegistry } from '../profileRegistry';
+import { assembleScheduler } from '../assembleScheduler';
+
+const caps = (over: Partial<StoreCapabilities> = {}): StoreCapabilities => ({
+  siteId: 'amiami', name: 'AmiAmi', domains: ['amiami.com'],
+  rateLimit: {
+    domain: 'amiami.com', baseDelayMs: 2000, minDelayMs: 300, maxDelayMs: 180_000,
+    backoffMultiplier: 1.4, recoveryDivisor: 1.4, successThreshold: 3,
+  },
+  requiresBrowser: true, allowedCookies: [], ...over,
+});
+
+describe('assembleScheduler — wire ProfileRegistry into a runnable scheduler', () => {
+  it('routes a mapped store to its pool and seeds its rate config', () => {
+    const reg = new ProfileRegistry();
+    reg.register(caps({ siteId: 'amiami', domains: ['amiami.com'], requiresBrowser: true }));
+    reg.register(caps({
+      siteId: 'hlj', name: 'HLJ', domains: ['hlj.com'], requiresBrowser: false,
+      rateLimit: {
+        domain: 'hlj.com', baseDelayMs: 500, minDelayMs: 100, maxDelayMs: 60_000,
+        backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3,
+      },
+    }));
+    const { scheduler, limiter } = assembleScheduler(reg, { browser: 1, fetch: 2 });
+    scheduler.enqueue({ id: 'a', host: 'amiami.com' }); // browser, base 2000
+    scheduler.enqueue({ id: 'h', host: 'hlj.com' }); // fetch, base 500
+    const da = scheduler.dispatch(10_000);
+    expect(da?.pool).toBe('browser');
+    expect(limiter.currentDelay('amiami.com')).toBe(2000); // from the store's rate config
+    const dh = scheduler.dispatch(10_000);
+    expect(dh?.pool).toBe('fetch');
+    expect(limiter.currentDelay('hlj.com')).toBe(500);
+  });
+
+  it('falls back to the default rate config and the fetch pool for an unmapped host', () => {
+    const reg = new ProfileRegistry();
+    const { scheduler, limiter, router } = assembleScheduler(reg, { browser: 1, fetch: 1 });
+    scheduler.enqueue({ id: 'u', host: 'unknown.example' });
+    const d = scheduler.dispatch(10_000);
+    expect(d?.pool).toBe('fetch'); // unmapped → cheap fetch pool, never a browser slot
+    expect(limiter.currentDelay('unknown.example')).toBe(2067); // default base delay
+    expect(router.inFlightOf('fetch')).toBe(1);
+  });
+
+  it('honors a custom default rate config for unmapped hosts', () => {
+    const reg = new ProfileRegistry();
+    const { limiter } = assembleScheduler(reg, { browser: 1, fetch: 1 }, {
+      baseDelayMs: 999, minDelayMs: 100, maxDelayMs: 5000,
+      backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 2,
+    });
+    expect(limiter.currentDelay('whatever.com')).toBe(999);
+  });
+});

--- a/src/driver/__tests__/crawlLoop.test.ts
+++ b/src/driver/__tests__/crawlLoop.test.ts
@@ -1,0 +1,98 @@
+/**
+ * TDD: CrawlLoop — the dispatch → worker → settle runtime. Driven by a VIRTUAL clock (sleep
+ * advances a counter; time only moves when the loop sleeps) and microtask-yield workers, so the
+ * async behaviour is fully deterministic — no real timers.
+ */
+import type { StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import type { Outcome } from '../dispatchScheduler';
+import { ProfileRegistry } from '../profileRegistry';
+import { assembleScheduler } from '../assembleScheduler';
+import { CrawlLoop } from '../crawlLoop';
+
+const makeClock = () => {
+  let t = 0;
+  return { now: () => t, sleep: async (ms: number): Promise<void> => { t += ms; }, at: () => t };
+};
+
+const caps = (siteId: string, host: string, requiresBrowser: boolean, baseDelayMs = 1000): StoreCapabilities => ({
+  siteId, name: siteId, domains: [host], requiresBrowser, allowedCookies: [],
+  rateLimit: {
+    domain: host, baseDelayMs, minDelayMs: 100, maxDelayMs: 60_000,
+    backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3,
+  },
+});
+
+describe('CrawlLoop — dispatch → worker → settle runtime', () => {
+  it('processes every queued task and reports stats', async () => {
+    const clk = makeClock();
+    const { scheduler } = assembleScheduler(new ProfileRegistry(), { browser: 2, fetch: 4 });
+    const seen: string[] = [];
+    const worker = async (t: { id: string }): Promise<Outcome> => { seen.push(t.id); return 'success'; };
+    scheduler.enqueue({ id: 'a', host: 'h1.com' });
+    scheduler.enqueue({ id: 'b', host: 'h2.com' });
+    const stats = await new CrawlLoop(scheduler, { ...clk, worker }).run();
+    expect(seen.sort()).toEqual(['a', 'b']);
+    expect(stats).toMatchObject({ dispatched: 2, completed: 2, failed: 0 });
+  });
+
+  it('runs distinct fetch-pool tasks concurrently up to capacity', async () => {
+    const clk = makeClock();
+    const { scheduler } = assembleScheduler(new ProfileRegistry(), { browser: 1, fetch: 4 });
+    let concurrent = 0;
+    let max = 0;
+    const worker = async (): Promise<Outcome> => {
+      concurrent += 1; max = Math.max(max, concurrent);
+      await Promise.resolve();
+      concurrent -= 1; return 'success';
+    };
+    for (const id of ['a', 'b', 'c']) scheduler.enqueue({ id, host: `${id}.com` }); // 3 distinct fetch hosts
+    await new CrawlLoop(scheduler, { ...clk, worker }).run();
+    expect(max).toBe(3); // all three in flight at once (fetch cap 4)
+  });
+
+  it('caps concurrency at the browser pool size', async () => {
+    const clk = makeClock();
+    const reg = new ProfileRegistry();
+    reg.register(caps('a', 'a.com', true));
+    reg.register(caps('b', 'b.com', true)); // both browser
+    const { scheduler } = assembleScheduler(reg, { browser: 1, fetch: 4 });
+    let concurrent = 0;
+    let max = 0;
+    const worker = async (): Promise<Outcome> => {
+      concurrent += 1; max = Math.max(max, concurrent);
+      await Promise.resolve();
+      concurrent -= 1; return 'success';
+    };
+    scheduler.enqueue({ id: '1', host: 'a.com' });
+    scheduler.enqueue({ id: '2', host: 'b.com' });
+    const stats = await new CrawlLoop(scheduler, { ...clk, worker }).run();
+    expect(max).toBe(1); // browser cap 1 serialized them
+    expect(stats.completed).toBe(2);
+  });
+
+  it('serializes same-host tasks across the throttle, advancing the clock', async () => {
+    const clk = makeClock();
+    const reg = new ProfileRegistry();
+    reg.register(caps('s', 'h.com', false, 1000)); // fetch pool, 1000ms base delay
+    const { scheduler } = assembleScheduler(reg, { browser: 1, fetch: 4 });
+    const times: number[] = [];
+    const worker = async (): Promise<Outcome> => { times.push(clk.at()); return 'success'; };
+    scheduler.enqueue({ id: '1', host: 'h.com' });
+    scheduler.enqueue({ id: '2', host: 'h.com' });
+    await new CrawlLoop(scheduler, { ...clk, worker }).run();
+    expect(times.length).toBe(2);
+    expect(times[1] - times[0]).toBeGreaterThanOrEqual(1000); // second waited out the throttle
+  });
+
+  it('a thrown worker settles as rate-limited (backs the host off) and counts as failed', async () => {
+    const clk = makeClock();
+    const reg = new ProfileRegistry();
+    reg.register(caps('s', 'h.com', false, 1000));
+    const { scheduler, limiter } = assembleScheduler(reg, { browser: 1, fetch: 4 });
+    const worker = async (): Promise<Outcome> => { throw new Error('boom'); };
+    scheduler.enqueue({ id: '1', host: 'h.com' });
+    const stats = await new CrawlLoop(scheduler, { ...clk, worker }).run();
+    expect(stats.failed).toBe(1);
+    expect(limiter.currentDelay('h.com')).toBe(2000); // 1000 * backoff 2
+  });
+});

--- a/src/driver/__tests__/dispatchScheduler.test.ts
+++ b/src/driver/__tests__/dispatchScheduler.test.ts
@@ -1,10 +1,8 @@
 /**
- * TDD (red first): DispatchScheduler — composes HostRateLimiter (per-host timing) and
- * PoolRouter (per-pool capacity) into the crawl driver's scheduler. A queued task may
- * dispatch only when BOTH gates open: its host is past its rate-limit delay AND its access
- * tier's pool has a free slot. Dispatching acquires both resources; `settle` releases the
- * pool slot and records the host outcome (success -> recover, rate-limited -> back off).
- * Pure + synchronous — `now` is passed explicitly, so no timers in the tests.
+ * DispatchScheduler — composes HostRateLimiter (per-host timing) and PoolRouter (per-pool
+ * capacity). A queued task dispatches only when its host is past its delay AND its pool has a
+ * free slot. Tasks are `{ id, host }`; the host's pool is resolved via the injected `poolFor`
+ * (the ProfileRegistry maps public `requiresBrowser` → browser/fetch). Pure + synchronous.
  */
 import { HostRateLimiter, type HostRateConfig } from '../hostRateLimiter';
 import { PoolRouter, type PoolKind } from '../poolRouter';
@@ -14,13 +12,15 @@ const cfg = (over: Partial<HostRateConfig> = {}): HostRateConfig => ({
   baseDelayMs: 1000, minDelayMs: 250, maxDelayMs: 60000,
   backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3, ...over,
 });
-const classify = (a: string): PoolKind =>
-  ['cloudflare', 'datadome', 'robotchecker', 'aws-waf', 'headless-fingerprint'].includes(a) ? 'browser' : 'fetch';
+
+// Hosts the ProfileRegistry would route to the browser pool (requiresBrowser=true); the rest fetch.
+const BROWSER_HOSTS = new Set(['cf.com', 'x.com', 'y.com', 'z.com']);
+const poolFor = (host: string): PoolKind => (BROWSER_HOSTS.has(host) ? 'browser' : 'fetch');
 
 const mk = (cap = { browser: 1, fetch: 2 }) => {
   const limiter = new HostRateLimiter(() => cfg());
-  const router = new PoolRouter(cap, classify);
-  return { limiter, router, sched: new DispatchScheduler(limiter, router) };
+  const router = new PoolRouter(cap);
+  return { limiter, router, sched: new DispatchScheduler(limiter, router, poolFor) };
 };
 
 describe('DispatchScheduler — host-ready AND pool-slot gating', () => {
@@ -30,19 +30,19 @@ describe('DispatchScheduler — host-ready AND pool-slot gating', () => {
 
   it('dispatches a ready task, records the host dispatch, and takes a pool slot', () => {
     const { sched, limiter } = mk();
-    sched.enqueue({ id: 't1', host: 'a.com', access: 'none' });
+    sched.enqueue({ id: 't1', host: 'hlj.com' }); // fetch pool
     const d = sched.dispatch(1000);
     expect(d?.task.id).toBe('t1');
     expect(d?.pool).toBe('fetch');
     expect(sched.pending()).toBe(0);
-    expect(limiter.msUntilReady('a.com', 1000)).toBe(1000); // host now throttled by its delay
+    expect(limiter.msUntilReady('hlj.com', 1000)).toBe(1000); // host now throttled
   });
 
   it('skips a throttled host and dispatches the next ready one, leaving the throttled task queued', () => {
     const { sched, limiter } = mk();
     limiter.recordDispatch('busy.com', 1000); // throttled until 2000
-    sched.enqueue({ id: 'busy', host: 'busy.com', access: 'none' });
-    sched.enqueue({ id: 'free', host: 'free.com', access: 'none' });
+    sched.enqueue({ id: 'busy', host: 'busy.com' });
+    sched.enqueue({ id: 'free', host: 'free.com' });
     const d = sched.dispatch(1500);
     expect(d?.task.id).toBe('free');
     expect(sched.pending()).toBe(1);
@@ -50,9 +50,9 @@ describe('DispatchScheduler — host-ready AND pool-slot gating', () => {
 
   it('skips a saturated pool and dispatches into a pool with room', () => {
     const { sched, router } = mk(); // browser cap 1
-    router.tryAcquire('cloudflare'); // browser pool full
-    sched.enqueue({ id: 'br', host: 'cf.com', access: 'cloudflare' });
-    sched.enqueue({ id: 'fe', host: 'hlj.com', access: 'none' });
+    router.tryAcquire('browser'); // browser pool full
+    sched.enqueue({ id: 'br', host: 'cf.com' }); // browser (full)
+    sched.enqueue({ id: 'fe', host: 'hlj.com' }); // fetch (room)
     const d = sched.dispatch(0);
     expect(d?.task.id).toBe('fe');
     expect(d?.pool).toBe('fetch');
@@ -61,8 +61,8 @@ describe('DispatchScheduler — host-ready AND pool-slot gating', () => {
 
   it('holds a second same-pool task until a settle frees the slot', () => {
     const { sched } = mk(); // browser cap 1
-    sched.enqueue({ id: 'b1', host: 'x.com', access: 'cloudflare' });
-    sched.enqueue({ id: 'b2', host: 'y.com', access: 'cloudflare' });
+    sched.enqueue({ id: 'b1', host: 'x.com' });
+    sched.enqueue({ id: 'b2', host: 'y.com' });
     const d1 = sched.dispatch(0);
     expect(d1?.task.id).toBe('b1');
     expect(sched.dispatch(0)).toBeNull(); // b2 blocked: browser pool saturated
@@ -72,7 +72,7 @@ describe('DispatchScheduler — host-ready AND pool-slot gating', () => {
 
   it('settle records the host outcome (rate-limited backs the delay off)', () => {
     const { sched, limiter } = mk();
-    sched.enqueue({ id: 't', host: 'z.com', access: 'cloudflare' });
+    sched.enqueue({ id: 't', host: 'z.com' });
     const d = sched.dispatch(0)!;
     sched.settle(d.task, d.pool, 'rate-limited');
     expect(limiter.currentDelay('z.com')).toBe(2000); // 1000 * backoff 2
@@ -81,12 +81,12 @@ describe('DispatchScheduler — host-ready AND pool-slot gating', () => {
   it('msUntilNext: 0 when ready, the min host delay when throttled, Infinity when the pool is saturated or empty', () => {
     const { sched, limiter, router } = mk();
     expect(sched.msUntilNext(0)).toBe(Infinity); // empty
-    sched.enqueue({ id: 'a', host: 'a.com', access: 'none' });
+    sched.enqueue({ id: 'a', host: 'hlj.com' }); // fetch
     expect(sched.msUntilNext(0)).toBe(0); // ready now
-    limiter.recordDispatch('a.com', 0); // throttled until 1000
+    limiter.recordDispatch('hlj.com', 0); // throttled until 1000
     expect(sched.msUntilNext(400)).toBe(600);
-    router.tryAcquire('none');
-    router.tryAcquire('none'); // fetch cap 2 now full -> task's pool has no room
+    router.tryAcquire('fetch');
+    router.tryAcquire('fetch'); // fetch cap 2 now full -> task's pool has no room
     expect(sched.msUntilNext(400)).toBe(Infinity);
   });
 });

--- a/src/driver/__tests__/dispatchScheduler.test.ts
+++ b/src/driver/__tests__/dispatchScheduler.test.ts
@@ -1,0 +1,92 @@
+/**
+ * TDD (red first): DispatchScheduler — composes HostRateLimiter (per-host timing) and
+ * PoolRouter (per-pool capacity) into the crawl driver's scheduler. A queued task may
+ * dispatch only when BOTH gates open: its host is past its rate-limit delay AND its access
+ * tier's pool has a free slot. Dispatching acquires both resources; `settle` releases the
+ * pool slot and records the host outcome (success -> recover, rate-limited -> back off).
+ * Pure + synchronous — `now` is passed explicitly, so no timers in the tests.
+ */
+import { HostRateLimiter, type HostRateConfig } from '../hostRateLimiter';
+import { PoolRouter, type PoolKind } from '../poolRouter';
+import { DispatchScheduler } from '../dispatchScheduler';
+
+const cfg = (over: Partial<HostRateConfig> = {}): HostRateConfig => ({
+  baseDelayMs: 1000, minDelayMs: 250, maxDelayMs: 60000,
+  backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3, ...over,
+});
+const classify = (a: string): PoolKind =>
+  ['cloudflare', 'datadome', 'robotchecker', 'aws-waf', 'headless-fingerprint'].includes(a) ? 'browser' : 'fetch';
+
+const mk = (cap = { browser: 1, fetch: 2 }) => {
+  const limiter = new HostRateLimiter(() => cfg());
+  const router = new PoolRouter(cap, classify);
+  return { limiter, router, sched: new DispatchScheduler(limiter, router) };
+};
+
+describe('DispatchScheduler — host-ready AND pool-slot gating', () => {
+  it('returns null when the queue is empty', () => {
+    expect(mk().sched.dispatch(0)).toBeNull();
+  });
+
+  it('dispatches a ready task, records the host dispatch, and takes a pool slot', () => {
+    const { sched, limiter } = mk();
+    sched.enqueue({ id: 't1', host: 'a.com', access: 'none' });
+    const d = sched.dispatch(1000);
+    expect(d?.task.id).toBe('t1');
+    expect(d?.pool).toBe('fetch');
+    expect(sched.pending()).toBe(0);
+    expect(limiter.msUntilReady('a.com', 1000)).toBe(1000); // host now throttled by its delay
+  });
+
+  it('skips a throttled host and dispatches the next ready one, leaving the throttled task queued', () => {
+    const { sched, limiter } = mk();
+    limiter.recordDispatch('busy.com', 1000); // throttled until 2000
+    sched.enqueue({ id: 'busy', host: 'busy.com', access: 'none' });
+    sched.enqueue({ id: 'free', host: 'free.com', access: 'none' });
+    const d = sched.dispatch(1500);
+    expect(d?.task.id).toBe('free');
+    expect(sched.pending()).toBe(1);
+  });
+
+  it('skips a saturated pool and dispatches into a pool with room', () => {
+    const { sched, router } = mk(); // browser cap 1
+    router.tryAcquire('cloudflare'); // browser pool full
+    sched.enqueue({ id: 'br', host: 'cf.com', access: 'cloudflare' });
+    sched.enqueue({ id: 'fe', host: 'hlj.com', access: 'none' });
+    const d = sched.dispatch(0);
+    expect(d?.task.id).toBe('fe');
+    expect(d?.pool).toBe('fetch');
+    expect(sched.pending()).toBe(1);
+  });
+
+  it('holds a second same-pool task until a settle frees the slot', () => {
+    const { sched } = mk(); // browser cap 1
+    sched.enqueue({ id: 'b1', host: 'x.com', access: 'cloudflare' });
+    sched.enqueue({ id: 'b2', host: 'y.com', access: 'cloudflare' });
+    const d1 = sched.dispatch(0);
+    expect(d1?.task.id).toBe('b1');
+    expect(sched.dispatch(0)).toBeNull(); // b2 blocked: browser pool saturated
+    sched.settle(d1!.task, d1!.pool, 'success'); // frees the browser slot
+    expect(sched.dispatch(0)?.task.id).toBe('b2');
+  });
+
+  it('settle records the host outcome (rate-limited backs the delay off)', () => {
+    const { sched, limiter } = mk();
+    sched.enqueue({ id: 't', host: 'z.com', access: 'cloudflare' });
+    const d = sched.dispatch(0)!;
+    sched.settle(d.task, d.pool, 'rate-limited');
+    expect(limiter.currentDelay('z.com')).toBe(2000); // 1000 * backoff 2
+  });
+
+  it('msUntilNext: 0 when ready, the min host delay when throttled, Infinity when the pool is saturated or empty', () => {
+    const { sched, limiter, router } = mk();
+    expect(sched.msUntilNext(0)).toBe(Infinity); // empty
+    sched.enqueue({ id: 'a', host: 'a.com', access: 'none' });
+    expect(sched.msUntilNext(0)).toBe(0); // ready now
+    limiter.recordDispatch('a.com', 0); // throttled until 1000
+    expect(sched.msUntilNext(400)).toBe(600);
+    router.tryAcquire('none');
+    router.tryAcquire('none'); // fetch cap 2 now full -> task's pool has no room
+    expect(sched.msUntilNext(400)).toBe(Infinity);
+  });
+});

--- a/src/driver/__tests__/hostRateLimiter.test.ts
+++ b/src/driver/__tests__/hostRateLimiter.test.ts
@@ -1,0 +1,76 @@
+/**
+ * TDD (red first): HostRateLimiter — the new driver's PER-HOST throttle,
+ * replacing the legacy queue's single global delay. Each host carries its own
+ * delay/backoff/recovery seeded from that store's rate config (StoreProfile
+ * `rateLimit`), so parallel stores never share a throttle and a Cloudflare
+ * block on one host cannot slow another.
+ */
+import { HostRateLimiter, type HostRateConfig } from '../hostRateLimiter';
+
+const cfg = (over: Partial<HostRateConfig> = {}): HostRateConfig => ({
+  baseDelayMs: 1000,
+  minDelayMs: 250,
+  maxDelayMs: 60000,
+  backoffMultiplier: 2,
+  recoveryDivisor: 2,
+  successThreshold: 3,
+  ...over,
+});
+
+describe('HostRateLimiter — per-host throttle', () => {
+  it('starts each host at its own base delay (independent config)', () => {
+    const rl = new HostRateLimiter((host) =>
+      host === 'a.com' ? cfg({ baseDelayMs: 1000 }) : cfg({ baseDelayMs: 5000 }),
+    );
+    expect(rl.currentDelay('a.com')).toBe(1000);
+    expect(rl.currentDelay('b.com')).toBe(5000);
+  });
+
+  it('a rate-limit backoff on host A does not affect host B', () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000, backoffMultiplier: 2 }));
+    rl.recordRateLimited('a.com');
+    expect(rl.currentDelay('a.com')).toBe(2000); // backed off
+    expect(rl.currentDelay('b.com')).toBe(1000); // untouched — separate host state
+  });
+
+  it('recovers per host after successThreshold consecutive successes', () => {
+    const rl = new HostRateLimiter(() =>
+      cfg({ baseDelayMs: 4000, recoveryDivisor: 2, successThreshold: 3 }),
+    );
+    rl.recordRateLimited('a.com'); // 8000
+    rl.recordSuccess('a.com');
+    rl.recordSuccess('a.com');
+    expect(rl.currentDelay('a.com')).toBe(8000); // not yet at threshold
+    rl.recordSuccess('a.com'); // 3rd → one recovery step
+    expect(rl.currentDelay('a.com')).toBe(4000); // 8000 / 2
+  });
+
+  it('clamps delay to [minDelayMs, maxDelayMs]', () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000, maxDelayMs: 1500, backoffMultiplier: 2 }));
+    rl.recordRateLimited('a.com'); // 2000 → clamp 1500
+    rl.recordRateLimited('a.com'); // 3000 → clamp 1500
+    expect(rl.currentDelay('a.com')).toBe(1500);
+  });
+
+  it('msUntilReady counts down the per-host delay from the last dispatch', () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000 }));
+    rl.recordDispatch('a.com', 10_000);
+    expect(rl.msUntilReady('a.com', 10_400)).toBe(600); // 1000 - 400 elapsed
+    expect(rl.msUntilReady('a.com', 11_000)).toBe(0); // delay elapsed → ready
+    expect(rl.msUntilReady('never-dispatched.com', 11_000)).toBe(0); // fresh host is ready
+  });
+
+  it('falls back to the default config for a host with no profile', () => {
+    const rl = new HostRateLimiter(() => undefined, cfg({ baseDelayMs: 2067 }));
+    expect(rl.currentDelay('unmapped.example')).toBe(2067);
+  });
+
+  it('resets the success streak on a rate-limit (no accidental recovery)', () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000, successThreshold: 3, recoveryDivisor: 2 }));
+    rl.recordSuccess('a.com');
+    rl.recordSuccess('a.com');
+    rl.recordRateLimited('a.com'); // streak reset + backoff → 2000
+    rl.recordSuccess('a.com'); // only 1 toward threshold now
+    expect(rl.currentDelay('a.com')).toBe(2000); // no recovery yet
+  });
+});

--- a/src/driver/__tests__/hostRateLimiter.test.ts
+++ b/src/driver/__tests__/hostRateLimiter.test.ts
@@ -73,4 +73,10 @@ describe('HostRateLimiter — per-host throttle', () => {
     rl.recordSuccess('a.com'); // only 1 toward threshold now
     expect(rl.currentDelay('a.com')).toBe(2000); // no recovery yet
   });
+
+  it('treats a dispatch at now=0 as real (0 is a valid time, not the never-dispatched sentinel)', () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000 }));
+    rl.recordDispatch('a.com', 0);
+    expect(rl.msUntilReady('a.com', 400)).toBe(600); // throttled from t=0, not treated as fresh
+  });
 });

--- a/src/driver/__tests__/poolRouter.test.ts
+++ b/src/driver/__tests__/poolRouter.test.ts
@@ -1,67 +1,51 @@
 /**
- * TDD (red first): PoolRouter — routes each store to the browser/mint pool vs the cheap
- * fetch pool by its access tier, and bounds each pool's concurrency against the crawl-rate
- * budget (the binding constraint per infra-budget, NOT connection count).
- *
- * The access->pool classifier is INJECTED so the private access taxonomy (StoreProfile.access)
- * never enters the public engine — same seam as HostRateLimiter's `configFor`. Pure + synchronous.
+ * PoolRouter — a pure by-pool concurrency semaphore. Callers pass the resolved PoolKind (the
+ * driver derives it from a store's public `requiresBrowser`, so the private access taxonomy
+ * never reaches the engine). Capacity is sized against the crawl-rate budget.
  */
-import { PoolRouter, type PoolKind } from '../poolRouter';
+import { PoolRouter } from '../poolRouter';
 
-// A stand-in classifier: challenge / anti-bot tiers need a real browser; the rest fetch cheaply.
-const classify = (access: string): PoolKind =>
-  ['cloudflare', 'datadome', 'robotchecker', 'aws-waf', 'headless-fingerprint'].includes(access)
-    ? 'browser'
-    : 'fetch';
-
-describe('PoolRouter — access-tier routing + per-pool capacity', () => {
-  it('routes access tiers to pools via the injected classifier', () => {
-    const r = new PoolRouter({ browser: 2, fetch: 4 }, classify);
-    expect(r.poolFor('cloudflare')).toBe('browser');
-    expect(r.poolFor('datadome')).toBe('browser');
-    expect(r.poolFor('none')).toBe('fetch');
-    expect(r.poolFor('age-cookie')).toBe('fetch');
-  });
-
+describe('PoolRouter — per-pool capacity', () => {
   it('acquires slots up to the pool capacity, then reports saturation', () => {
-    const r = new PoolRouter({ browser: 2, fetch: 4 }, classify);
-    expect(r.tryAcquire('cloudflare')).toEqual({ ok: true, pool: 'browser' });
-    expect(r.tryAcquire('datadome')).toEqual({ ok: true, pool: 'browser' });
+    const r = new PoolRouter({ browser: 2, fetch: 4 });
+    expect(r.tryAcquire('browser')).toBe(true);
+    expect(r.tryAcquire('browser')).toBe(true);
     expect(r.hasCapacity('browser')).toBe(false);
-    expect(r.tryAcquire('aws-waf')).toEqual({ ok: false, pool: 'browser' }); // saturated
+    expect(r.tryAcquire('browser')).toBe(false); // saturated
   });
 
   it('keeps pool capacities independent (browser saturation does not block fetch)', () => {
-    const r = new PoolRouter({ browser: 1, fetch: 2 }, classify);
-    expect(r.tryAcquire('cloudflare').ok).toBe(true); // browser now full
-    expect(r.tryAcquire('cloudflare').ok).toBe(false);
-    expect(r.tryAcquire('none').ok).toBe(true); // fetch pool unaffected
-    expect(r.tryAcquire('auth').ok).toBe(true);
+    const r = new PoolRouter({ browser: 1, fetch: 2 });
+    expect(r.tryAcquire('browser')).toBe(true);
+    expect(r.tryAcquire('browser')).toBe(false); // browser full
+    expect(r.tryAcquire('fetch')).toBe(true); // fetch unaffected
+    expect(r.tryAcquire('fetch')).toBe(true);
     expect(r.hasCapacity('fetch')).toBe(false);
   });
 
   it('release frees a slot for reuse', () => {
-    const r = new PoolRouter({ browser: 1, fetch: 1 }, classify);
-    expect(r.tryAcquire('cloudflare').ok).toBe(true);
-    expect(r.tryAcquire('cloudflare').ok).toBe(false);
+    const r = new PoolRouter({ browser: 1, fetch: 1 });
+    expect(r.tryAcquire('browser')).toBe(true);
+    expect(r.tryAcquire('browser')).toBe(false);
     r.release('browser');
     expect(r.available('browser')).toBe(1);
-    expect(r.tryAcquire('cloudflare').ok).toBe(true);
+    expect(r.tryAcquire('browser')).toBe(true);
   });
 
   it('release never underflows below zero', () => {
-    const r = new PoolRouter({ browser: 1, fetch: 1 }, classify);
-    r.release('browser'); // nothing in flight
+    const r = new PoolRouter({ browser: 1, fetch: 1 });
+    r.release('browser');
     r.release('browser');
     expect(r.inFlightOf('browser')).toBe(0);
     expect(r.available('browser')).toBe(1);
   });
 
   it('available reflects in-flight and never reports negative', () => {
-    const r = new PoolRouter({ browser: 3, fetch: 1 }, classify);
-    r.tryAcquire('cloudflare');
-    r.tryAcquire('datadome');
+    const r = new PoolRouter({ browser: 3, fetch: 1 });
+    r.tryAcquire('browser');
+    r.tryAcquire('browser');
     expect(r.inFlightOf('browser')).toBe(2);
     expect(r.available('browser')).toBe(1);
+    expect(r.capacityOf('browser')).toBe(3);
   });
 });

--- a/src/driver/__tests__/poolRouter.test.ts
+++ b/src/driver/__tests__/poolRouter.test.ts
@@ -1,0 +1,67 @@
+/**
+ * TDD (red first): PoolRouter — routes each store to the browser/mint pool vs the cheap
+ * fetch pool by its access tier, and bounds each pool's concurrency against the crawl-rate
+ * budget (the binding constraint per infra-budget, NOT connection count).
+ *
+ * The access->pool classifier is INJECTED so the private access taxonomy (StoreProfile.access)
+ * never enters the public engine — same seam as HostRateLimiter's `configFor`. Pure + synchronous.
+ */
+import { PoolRouter, type PoolKind } from '../poolRouter';
+
+// A stand-in classifier: challenge / anti-bot tiers need a real browser; the rest fetch cheaply.
+const classify = (access: string): PoolKind =>
+  ['cloudflare', 'datadome', 'robotchecker', 'aws-waf', 'headless-fingerprint'].includes(access)
+    ? 'browser'
+    : 'fetch';
+
+describe('PoolRouter — access-tier routing + per-pool capacity', () => {
+  it('routes access tiers to pools via the injected classifier', () => {
+    const r = new PoolRouter({ browser: 2, fetch: 4 }, classify);
+    expect(r.poolFor('cloudflare')).toBe('browser');
+    expect(r.poolFor('datadome')).toBe('browser');
+    expect(r.poolFor('none')).toBe('fetch');
+    expect(r.poolFor('age-cookie')).toBe('fetch');
+  });
+
+  it('acquires slots up to the pool capacity, then reports saturation', () => {
+    const r = new PoolRouter({ browser: 2, fetch: 4 }, classify);
+    expect(r.tryAcquire('cloudflare')).toEqual({ ok: true, pool: 'browser' });
+    expect(r.tryAcquire('datadome')).toEqual({ ok: true, pool: 'browser' });
+    expect(r.hasCapacity('browser')).toBe(false);
+    expect(r.tryAcquire('aws-waf')).toEqual({ ok: false, pool: 'browser' }); // saturated
+  });
+
+  it('keeps pool capacities independent (browser saturation does not block fetch)', () => {
+    const r = new PoolRouter({ browser: 1, fetch: 2 }, classify);
+    expect(r.tryAcquire('cloudflare').ok).toBe(true); // browser now full
+    expect(r.tryAcquire('cloudflare').ok).toBe(false);
+    expect(r.tryAcquire('none').ok).toBe(true); // fetch pool unaffected
+    expect(r.tryAcquire('auth').ok).toBe(true);
+    expect(r.hasCapacity('fetch')).toBe(false);
+  });
+
+  it('release frees a slot for reuse', () => {
+    const r = new PoolRouter({ browser: 1, fetch: 1 }, classify);
+    expect(r.tryAcquire('cloudflare').ok).toBe(true);
+    expect(r.tryAcquire('cloudflare').ok).toBe(false);
+    r.release('browser');
+    expect(r.available('browser')).toBe(1);
+    expect(r.tryAcquire('cloudflare').ok).toBe(true);
+  });
+
+  it('release never underflows below zero', () => {
+    const r = new PoolRouter({ browser: 1, fetch: 1 }, classify);
+    r.release('browser'); // nothing in flight
+    r.release('browser');
+    expect(r.inFlightOf('browser')).toBe(0);
+    expect(r.available('browser')).toBe(1);
+  });
+
+  it('available reflects in-flight and never reports negative', () => {
+    const r = new PoolRouter({ browser: 3, fetch: 1 }, classify);
+    r.tryAcquire('cloudflare');
+    r.tryAcquire('datadome');
+    expect(r.inFlightOf('browser')).toBe(2);
+    expect(r.available('browser')).toBe(1);
+  });
+});

--- a/src/driver/__tests__/profileRegistry.test.ts
+++ b/src/driver/__tests__/profileRegistry.test.ts
@@ -1,0 +1,68 @@
+/**
+ * TDD (red first): ProfileRegistry — indexes public StoreCapabilities by host and feeds the
+ * crawl driver's scheduler seams: rateLimit → HostRateLimiter, requiresBrowser → PoolRouter
+ * pool, retrieval → targeted on-request fetches. Populated by the plugin (each private
+ * StoreProfile mapped down to StoreCapabilities); the engine never sees the moat axes.
+ */
+import type { StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import { ProfileRegistry } from '../profileRegistry';
+
+const caps = (over: Partial<StoreCapabilities> = {}): StoreCapabilities => ({
+  siteId: 'amiami',
+  name: 'AmiAmi',
+  domains: ['www.amiami.com', 'amiami.com'],
+  rateLimit: {
+    domain: 'amiami.com', baseDelayMs: 2000, minDelayMs: 300, maxDelayMs: 180_000,
+    backoffMultiplier: 1.4, recoveryDivisor: 1.4, successThreshold: 3,
+  },
+  requiresBrowser: true,
+  allowedCookies: [],
+  retrieval: { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } },
+  ...over,
+});
+
+describe('ProfileRegistry — host-indexed store capabilities', () => {
+  it('indexes by every domain (host-normalized) and by siteId', () => {
+    const r = new ProfileRegistry();
+    r.register(caps());
+    expect(r.forHost('www.amiami.com')?.siteId).toBe('amiami');
+    expect(r.forHost('amiami.com')?.siteId).toBe('amiami'); // both domains resolve
+    expect(r.forHost('AMIAMI.com')?.siteId).toBe('amiami'); // case-insensitive
+    expect(r.forSite('amiami')?.siteId).toBe('amiami');
+    expect(r.forHost('unknown.com')).toBeUndefined();
+    expect(r.size()).toBe(1);
+  });
+
+  it('feeds the scheduler seams: rate config, pool (from requiresBrowser), retrieval', () => {
+    const r = new ProfileRegistry();
+    r.register(caps({ requiresBrowser: true })); // amiami → browser pool
+    r.register(caps({ siteId: 'hlj', name: 'HLJ', domains: ['hlj.com'], requiresBrowser: false, retrieval: undefined }));
+    expect(r.rateConfigFor('www.amiami.com')?.baseDelayMs).toBe(2000);
+    expect(r.poolFor('www.amiami.com')).toBe('browser');
+    expect(r.poolFor('hlj.com')).toBe('fetch'); // requiresBrowser=false → cheap fetch pool
+    expect(r.retrievalFor('www.amiami.com')?.byId?.urlTemplate).toContain('{id}');
+    expect(r.retrievalFor('hlj.com')).toBeUndefined(); // enumeration-only
+  });
+
+  it('returns undefined seams for an unknown host (never throws)', () => {
+    const r = new ProfileRegistry();
+    expect(r.rateConfigFor('nope.com')).toBeUndefined();
+    expect(r.poolFor('nope.com')).toBeUndefined();
+    expect(r.retrievalFor('nope.com')).toBeUndefined();
+  });
+
+  it('all() returns one entry per registered site', () => {
+    const r = new ProfileRegistry();
+    r.register(caps());
+    r.register(caps({ siteId: 'hlj', domains: ['hlj.com'] }));
+    expect(r.all().map((c) => c.siteId).sort()).toEqual(['amiami', 'hlj']);
+  });
+
+  it('re-registering a siteId replaces it (last wins)', () => {
+    const r = new ProfileRegistry();
+    r.register(caps({ requiresBrowser: true }));
+    r.register(caps({ requiresBrowser: false })); // same siteId, now fetch
+    expect(r.poolFor('www.amiami.com')).toBe('fetch');
+    expect(r.size()).toBe(1);
+  });
+});

--- a/src/driver/__tests__/retrievalPlanner.test.ts
+++ b/src/driver/__tests__/retrievalPlanner.test.ts
@@ -1,0 +1,69 @@
+/**
+ * retrievalPlanner — targeted-retrieval request → fetch plans via each store's retrieval
+ * templates. Covers by-id detail plans, single-store search, the cross-store `lookup` fan-out
+ * (the buy-decision seam), and the `unsupported` coverage-gap report.
+ */
+import type { RetrievalCapability, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import { ProfileRegistry } from '../profileRegistry';
+import { planRetrieval, resolveByIdUrl, resolveSearchUrl } from '../retrievalPlanner';
+
+const caps = (siteId: string, host: string, retrieval?: RetrievalCapability): StoreCapabilities => ({
+  siteId, name: siteId, domains: [host], requiresBrowser: false, allowedCookies: [],
+  rateLimit: {
+    domain: host, baseDelayMs: 1000, minDelayMs: 100, maxDelayMs: 60_000,
+    backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3,
+  },
+  retrieval,
+});
+
+const registry = () => {
+  const r = new ProfileRegistry();
+  r.register(caps('amiami', 'amiami.com', { byId: { urlTemplate: 'https://amiami.com/detail/?gcode={id}', idKind: 'store-internal' } }));
+  r.register(caps('hlj', 'hlj.com', { bySearch: { urlTemplate: 'https://hlj.com/search?q={q}' } }));
+  r.register(caps('nogo', 'nogo.com', undefined)); // enumeration-only, no retrieval
+  return r;
+};
+
+describe('retrieval URL resolvers', () => {
+  it('resolveByIdUrl substitutes {id}, url-encoded; undefined when unsupported', () => {
+    expect(resolveByIdUrl({ byId: { urlTemplate: 'https://x/d/?g={id}' } }, 'FIG-1 2')).toBe('https://x/d/?g=FIG-1%202');
+    expect(resolveByIdUrl({}, 'x')).toBeUndefined();
+    expect(resolveByIdUrl(undefined, 'x')).toBeUndefined();
+  });
+
+  it('resolveSearchUrl substitutes {q}, url-encoded; undefined when unsupported', () => {
+    expect(resolveSearchUrl({ bySearch: { urlTemplate: 'https://x/s?q={q}' } }, 'nendoroid miku')).toBe('https://x/s?q=nendoroid%20miku');
+    expect(resolveSearchUrl({}, 'x')).toBeUndefined();
+  });
+});
+
+describe('planRetrieval', () => {
+  it('byId: one detail plan per item id for a supporting store', () => {
+    const p = planRetrieval(registry(), { mode: 'byId', host: 'amiami.com', itemIds: ['FIGURE-1', 'FIGURE-2'] });
+    expect(p.plans.map((x) => x.url)).toEqual([
+      'https://amiami.com/detail/?gcode=FIGURE-1',
+      'https://amiami.com/detail/?gcode=FIGURE-2',
+    ]);
+    expect(p.plans.every((x) => x.kind === 'detail' && x.siteId === 'amiami')).toBe(true);
+    expect(p.unsupported).toEqual([]);
+  });
+
+  it('byId: a store that cannot be fetched by id comes back unsupported', () => {
+    const p = planRetrieval(registry(), { mode: 'byId', host: 'hlj.com', itemIds: ['x'] }); // hlj only has search
+    expect(p.plans).toEqual([]);
+    expect(p.unsupported).toEqual(['hlj']);
+  });
+
+  it('search: one search plan for a supporting store', () => {
+    const p = planRetrieval(registry(), { mode: 'search', host: 'hlj.com', query: 'miku' });
+    expect(p.plans).toEqual([{ host: 'hlj.com', siteId: 'hlj', url: 'https://hlj.com/search?q=miku', kind: 'search' }]);
+    expect(p.unsupported).toEqual([]);
+  });
+
+  it('lookup: fans a JAN/name out to every search-capable store and reports the rest as gaps', () => {
+    const p = planRetrieval(registry(), { mode: 'lookup', query: '4571245296726' });
+    expect(p.plans.map((x) => x.host)).toEqual(['hlj.com']); // only hlj supports search
+    expect(p.plans[0].url).toContain('4571245296726');
+    expect(p.unsupported.sort()).toEqual(['amiami', 'nogo']); // no bySearch → coverage gap
+  });
+});

--- a/src/driver/assembleScheduler.ts
+++ b/src/driver/assembleScheduler.ts
@@ -1,0 +1,42 @@
+/**
+ * assembleScheduler — the profile-injection wiring that closes I0.
+ *
+ * Turns a populated ProfileRegistry into a ready-to-run DispatchScheduler by connecting the
+ * three seams:
+ *   - HostRateLimiter's `configFor` ← `registry.rateConfigFor(host)` (per-store throttle;
+ *     unmapped hosts get `defaultRate`).
+ *   - PoolRouter ← the caller's per-pool capacity (sized vs the crawl-rate budget).
+ *   - DispatchScheduler's `poolFor` ← `registry.poolFor(host)` (requiresBrowser → browser/fetch;
+ *     unmapped hosts get the cheap fetch pool — never an expensive browser slot).
+ *
+ * The private StoreProfile axes never enter here — only the public StoreCapabilities the
+ * ProfileRegistry holds. Returns the scheduler plus its primitives for lifecycle control.
+ */
+import { HostRateLimiter, type HostRateConfig } from './hostRateLimiter.js';
+import { PoolRouter, type PoolCapacity, type PoolKind } from './poolRouter.js';
+import { DispatchScheduler } from './dispatchScheduler.js';
+import type { ProfileRegistry } from './profileRegistry.js';
+
+/** Rate config for hosts with no StoreProfile (the legacy MFC-sync global default constants). */
+const DEFAULT_RATE: HostRateConfig = {
+  baseDelayMs: 2067, minDelayMs: 274, maxDelayMs: 180_000,
+  backoffMultiplier: 1.4, recoveryDivisor: 1.4, successThreshold: 3,
+};
+
+export interface AssembledDriver {
+  scheduler: DispatchScheduler;
+  limiter: HostRateLimiter;
+  router: PoolRouter;
+}
+
+export function assembleScheduler(
+  registry: ProfileRegistry,
+  capacity: PoolCapacity,
+  defaultRate: HostRateConfig = DEFAULT_RATE,
+): AssembledDriver {
+  const limiter = new HostRateLimiter((host) => registry.rateConfigFor(host), defaultRate);
+  const router = new PoolRouter(capacity);
+  const poolFor = (host: string): PoolKind => registry.poolFor(host) ?? 'fetch';
+  const scheduler = new DispatchScheduler(limiter, router, poolFor);
+  return { scheduler, limiter, router };
+}

--- a/src/driver/crawlLoop.ts
+++ b/src/driver/crawlLoop.ts
@@ -1,0 +1,87 @@
+/**
+ * CrawlLoop — the crawl driver's async runtime. Turns a DispatchScheduler into a running
+ * crawler: greedily dispatch every task runnable at the current instant (launching a worker
+ * per dispatch, concurrently up to each pool's capacity), then block until either an in-flight
+ * worker finishes (freeing a pool slot) or the next throttled host becomes ready
+ * (`msUntilNext`) — whichever comes first. Each worker's result is settled back onto the
+ * scheduler (success → recover the host delay, rate-limited/thrown → back off).
+ *
+ * All effects are injected — `now()`, `sleep(ms)`, and the `worker` — so the loop is
+ * deterministic and testable with a virtual clock (no real timers). The worker is where I2
+ * plugs in: fetch → catch-gated extract → SpineIngest emit.
+ */
+import type { CrawlTask, DispatchScheduler, Outcome } from './dispatchScheduler.js';
+import type { PoolKind } from './poolRouter.js';
+
+export interface CrawlLoopDeps {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  /** Process one dispatched task. A thrown error is treated as a rate-limit (backs the host off). */
+  worker: (task: CrawlTask) => Promise<Outcome>;
+}
+
+export interface CrawlLoopStats {
+  dispatched: number;
+  completed: number;
+  failed: number;
+}
+
+export class CrawlLoop {
+  constructor(
+    private readonly scheduler: DispatchScheduler,
+    private readonly deps: CrawlLoopDeps,
+    /** Cap a single sleep so a very long throttle still wakes to re-check periodically. */
+    private readonly maxTickMs = 60_000,
+  ) {}
+
+  async run(): Promise<CrawlLoopStats> {
+    const inFlight = new Set<Promise<void>>();
+    const stats: CrawlLoopStats = { dispatched: 0, completed: 0, failed: 0 };
+
+    const launch = (task: CrawlTask, pool: PoolKind): void => {
+      stats.dispatched += 1;
+      let tracked: Promise<void>;
+      const work = (async () => {
+        let outcome: Outcome;
+        try {
+          outcome = await this.deps.worker(task);
+        } catch {
+          outcome = 'rate-limited';
+          stats.failed += 1;
+        }
+        this.scheduler.settle(task, pool, outcome);
+        stats.completed += 1;
+      })();
+      tracked = work.finally(() => {
+        inFlight.delete(tracked);
+      });
+      inFlight.add(tracked);
+    };
+
+    while (true) {
+      // Dispatch everything runnable right now.
+      let d = this.scheduler.dispatch(this.deps.now());
+      while (d !== null) {
+        launch(d.task, d.pool);
+        d = this.scheduler.dispatch(this.deps.now());
+      }
+
+      if (this.scheduler.pending() === 0 && inFlight.size === 0) break; // drained
+
+      const wait = this.scheduler.msUntilNext(this.deps.now());
+      if (inFlight.size > 0) {
+        // Wake on the earlier of: a worker completing (frees a pool slot), or a host readying.
+        const racers: Array<Promise<unknown>> = [...inFlight];
+        if (wait !== Infinity) racers.push(this.deps.sleep(Math.min(wait, this.maxTickMs)));
+        await Promise.race(racers);
+      } else {
+        // Nothing in flight: the only blocker is host throttle. Infinity here means no pool can
+        // ever admit the pending work (misconfigured zero capacity) — stop rather than spin.
+        if (wait === Infinity) break;
+        await this.deps.sleep(Math.min(wait, this.maxTickMs));
+      }
+    }
+
+    return stats;
+  }
+}

--- a/src/driver/dispatchScheduler.ts
+++ b/src/driver/dispatchScheduler.ts
@@ -3,23 +3,23 @@
  *
  * Composes the two I0 primitives into a single "what can run right now?" decision:
  *   - HostRateLimiter gates by per-host TIMING (a host must be past its rate-limit delay).
- *   - PoolRouter gates by per-pool CAPACITY (the access tier's pool must have a free slot).
+ *   - PoolRouter gates by per-pool CAPACITY (the store's pool must have a free slot).
  * A queued task dispatches only when BOTH gates open. Dispatching acquires both resources
  * (records the host dispatch + takes a pool slot); `settle` returns the pool slot and records
  * the host outcome so the delay recovers on success or backs off on a rate-limit.
  *
- * Pure and synchronous: every time-aware call takes `now` explicitly (delegated to
- * HostRateLimiter), so the scheduler is deterministic and testable without timers. The
- * surrounding driver loop owns the actual sleeping (via `msUntilNext`) and worker execution.
+ * A task is just `{ id, host }` — the engine never carries the private access taxonomy. The
+ * host's pool is resolved through the injected `poolFor` (the ProfileRegistry maps a store's
+ * public `requiresBrowser` → browser/fetch). Pure and synchronous: every time-aware call takes
+ * `now` explicitly, so the scheduler is deterministic and testable without timers.
  */
 import type { HostRateLimiter } from './hostRateLimiter.js';
 import type { PoolRouter, PoolKind } from './poolRouter.js';
 
-/** A unit of crawl work: a host to fetch from and the access tier that selects its pool. */
+/** A unit of crawl work: which host to fetch from. Pool + rate are resolved from the host. */
 export interface CrawlTask {
   id: string;
   host: string;
-  access: string;
 }
 
 export interface Dispatch {
@@ -35,6 +35,8 @@ export class DispatchScheduler {
   constructor(
     private readonly limiter: HostRateLimiter,
     private readonly router: PoolRouter,
+    /** Resolve a host to its pool (ProfileRegistry: public `requiresBrowser` → browser/fetch). */
+    private readonly poolFor: (host: string) => PoolKind,
   ) {}
 
   enqueue(task: CrawlTask): void {
@@ -46,20 +48,20 @@ export class DispatchScheduler {
   }
 
   /**
-   * Pick and dispatch the first queued task that can run at `now` — host past its delay AND
-   * its pool has a free slot. On success the task is removed from the queue, a pool slot is
-   * taken, and the host dispatch is recorded (starting its next delay). Returns null when
-   * nothing is dispatchable right now (every host throttled and/or every needed pool full).
+   * Pick and dispatch the first queued task that can run at `now` — host past its delay AND its
+   * pool has a free slot. On success the task leaves the queue, a pool slot is taken, and the
+   * host dispatch is recorded (starting its next delay). Returns null when nothing is
+   * dispatchable right now (every host throttled and/or every needed pool full).
    */
   dispatch(now: number): Dispatch | null {
     for (let i = 0; i < this.queue.length; i++) {
       const task = this.queue[i];
       if (this.limiter.msUntilReady(task.host, now) > 0) continue; // host still throttled
-      const acquired = this.router.tryAcquire(task.access); // takes a slot iff the pool has room
-      if (!acquired.ok) continue; // pool saturated — leave the task queued
+      const pool = this.poolFor(task.host);
+      if (!this.router.tryAcquire(pool)) continue; // pool saturated — leave the task queued
       this.limiter.recordDispatch(task.host, now);
       this.queue.splice(i, 1);
-      return { task, pool: acquired.pool };
+      return { task, pool };
     }
     return null;
   }
@@ -80,8 +82,7 @@ export class DispatchScheduler {
   msUntilNext(now: number): number {
     let min = Infinity;
     for (const task of this.queue) {
-      const pool = this.router.poolFor(task.access);
-      if (!this.router.hasCapacity(pool)) continue; // needs a settle, not a wait
+      if (!this.router.hasCapacity(this.poolFor(task.host))) continue; // needs a settle, not a wait
       const wait = this.limiter.msUntilReady(task.host, now);
       if (wait <= 0) return 0;
       if (wait < min) min = wait;

--- a/src/driver/dispatchScheduler.ts
+++ b/src/driver/dispatchScheduler.ts
@@ -1,0 +1,91 @@
+/**
+ * DispatchScheduler — the crawl driver's scheduler core.
+ *
+ * Composes the two I0 primitives into a single "what can run right now?" decision:
+ *   - HostRateLimiter gates by per-host TIMING (a host must be past its rate-limit delay).
+ *   - PoolRouter gates by per-pool CAPACITY (the access tier's pool must have a free slot).
+ * A queued task dispatches only when BOTH gates open. Dispatching acquires both resources
+ * (records the host dispatch + takes a pool slot); `settle` returns the pool slot and records
+ * the host outcome so the delay recovers on success or backs off on a rate-limit.
+ *
+ * Pure and synchronous: every time-aware call takes `now` explicitly (delegated to
+ * HostRateLimiter), so the scheduler is deterministic and testable without timers. The
+ * surrounding driver loop owns the actual sleeping (via `msUntilNext`) and worker execution.
+ */
+import type { HostRateLimiter } from './hostRateLimiter.js';
+import type { PoolRouter, PoolKind } from './poolRouter.js';
+
+/** A unit of crawl work: a host to fetch from and the access tier that selects its pool. */
+export interface CrawlTask {
+  id: string;
+  host: string;
+  access: string;
+}
+
+export interface Dispatch {
+  task: CrawlTask;
+  pool: PoolKind;
+}
+
+export type Outcome = 'success' | 'rate-limited';
+
+export class DispatchScheduler {
+  private readonly queue: CrawlTask[] = [];
+
+  constructor(
+    private readonly limiter: HostRateLimiter,
+    private readonly router: PoolRouter,
+  ) {}
+
+  enqueue(task: CrawlTask): void {
+    this.queue.push(task);
+  }
+
+  pending(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Pick and dispatch the first queued task that can run at `now` — host past its delay AND
+   * its pool has a free slot. On success the task is removed from the queue, a pool slot is
+   * taken, and the host dispatch is recorded (starting its next delay). Returns null when
+   * nothing is dispatchable right now (every host throttled and/or every needed pool full).
+   */
+  dispatch(now: number): Dispatch | null {
+    for (let i = 0; i < this.queue.length; i++) {
+      const task = this.queue[i];
+      if (this.limiter.msUntilReady(task.host, now) > 0) continue; // host still throttled
+      const acquired = this.router.tryAcquire(task.access); // takes a slot iff the pool has room
+      if (!acquired.ok) continue; // pool saturated — leave the task queued
+      this.limiter.recordDispatch(task.host, now);
+      this.queue.splice(i, 1);
+      return { task, pool: acquired.pool };
+    }
+    return null;
+  }
+
+  /** Complete a dispatched task: return its pool slot and record the host outcome. */
+  settle(task: CrawlTask, pool: PoolKind, outcome: Outcome): void {
+    this.router.release(pool);
+    if (outcome === 'success') this.limiter.recordSuccess(task.host);
+    else this.limiter.recordRateLimited(task.host);
+  }
+
+  /**
+   * Ms until the next dispatch could succeed WITHOUT an intervening settle — i.e. how long the
+   * loop may sleep. 0 if a task is ready now; otherwise the smallest host delay among tasks
+   * whose pool currently has capacity; Infinity if the queue is empty or every queued task's
+   * pool is saturated (those need a settle to free a slot, not the passage of time).
+   */
+  msUntilNext(now: number): number {
+    let min = Infinity;
+    for (const task of this.queue) {
+      const pool = this.router.poolFor(task.access);
+      if (!this.router.hasCapacity(pool)) continue; // needs a settle, not a wait
+      const wait = this.limiter.msUntilReady(task.host, now);
+      if (wait <= 0) return 0;
+      if (wait < min) min = wait;
+    }
+    return min;
+  }
+}

--- a/src/driver/hostRateLimiter.ts
+++ b/src/driver/hostRateLimiter.ts
@@ -1,0 +1,104 @@
+/**
+ * HostRateLimiter — the new crawl driver's PER-HOST throttle.
+ *
+ * The legacy queue kept ONE global delay/backoff for every request. This keeps
+ * an independent throttle per host, each seeded from that store's rate config
+ * (StoreProfile `rateLimit`), so parallel stores never share a throttle and a
+ * Cloudflare backoff on one host cannot slow another.
+ *
+ * Pure and synchronous: `msUntilReady` is the only time-aware method and takes
+ * `now` explicitly, so behaviour is deterministic and testable without timers.
+ */
+
+/** The rate knobs the limiter needs. `DomainRateLimit` is structurally assignable. */
+export interface HostRateConfig {
+  baseDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  backoffMultiplier: number;
+  recoveryDivisor: number;
+  successThreshold: number;
+}
+
+interface HostState {
+  config: HostRateConfig;
+  currentDelay: number;
+  lastRequestTime: number; // 0 = never dispatched
+  consecutiveSuccesses: number;
+}
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
+
+const DEFAULT_CONFIG: HostRateConfig = {
+  baseDelayMs: 2067,
+  minDelayMs: 274,
+  maxDelayMs: 180_000,
+  backoffMultiplier: 1.4,
+  recoveryDivisor: 1.4,
+  successThreshold: 3,
+};
+
+export class HostRateLimiter {
+  private readonly hosts = new Map<string, HostState>();
+
+  /**
+   * @param configFor     resolves a host to its rate config (from its StoreProfile).
+   * @param defaultConfig  used when `configFor` returns undefined (unmapped host).
+   */
+  constructor(
+    private readonly configFor: (host: string) => HostRateConfig | undefined,
+    private readonly defaultConfig: HostRateConfig = DEFAULT_CONFIG,
+  ) {}
+
+  private stateFor(host: string): HostState {
+    let s = this.hosts.get(host);
+    if (!s) {
+      const config = this.configFor(host) ?? this.defaultConfig;
+      s = { config, currentDelay: config.baseDelayMs, lastRequestTime: 0, consecutiveSuccesses: 0 };
+      this.hosts.set(host, s);
+    }
+    return s;
+  }
+
+  /** The host's current inter-request delay (ms). */
+  currentDelay(host: string): number {
+    return this.stateFor(host).currentDelay;
+  }
+
+  /** Ms until the next request to this host may dispatch (0 = ready now). */
+  msUntilReady(host: string, now: number): number {
+    const s = this.stateFor(host);
+    if (s.lastRequestTime === 0) return 0; // never dispatched → ready
+    return Math.max(0, s.lastRequestTime + s.currentDelay - now);
+  }
+
+  /** Mark a request dispatched to this host at `now`. */
+  recordDispatch(host: string, now: number): void {
+    this.stateFor(host).lastRequestTime = now;
+  }
+
+  /** A success: recover the delay one step after `successThreshold` in a row. */
+  recordSuccess(host: string): void {
+    const s = this.stateFor(host);
+    s.consecutiveSuccesses += 1;
+    if (s.consecutiveSuccesses >= s.config.successThreshold) {
+      s.currentDelay = clamp(
+        s.currentDelay / s.config.recoveryDivisor,
+        s.config.minDelayMs,
+        s.config.maxDelayMs,
+      );
+      s.consecutiveSuccesses = 0;
+    }
+  }
+
+  /** A rate-limit / block: back the delay off and reset the success streak. */
+  recordRateLimited(host: string): void {
+    const s = this.stateFor(host);
+    s.currentDelay = clamp(
+      s.currentDelay * s.config.backoffMultiplier,
+      s.config.minDelayMs,
+      s.config.maxDelayMs,
+    );
+    s.consecutiveSuccesses = 0;
+  }
+}

--- a/src/driver/hostRateLimiter.ts
+++ b/src/driver/hostRateLimiter.ts
@@ -23,7 +23,7 @@ export interface HostRateConfig {
 interface HostState {
   config: HostRateConfig;
   currentDelay: number;
-  lastRequestTime: number; // 0 = never dispatched
+  lastRequestTime: number; // -1 = never dispatched
   consecutiveSuccesses: number;
 }
 
@@ -54,7 +54,7 @@ export class HostRateLimiter {
     let s = this.hosts.get(host);
     if (!s) {
       const config = this.configFor(host) ?? this.defaultConfig;
-      s = { config, currentDelay: config.baseDelayMs, lastRequestTime: 0, consecutiveSuccesses: 0 };
+      s = { config, currentDelay: config.baseDelayMs, lastRequestTime: -1, consecutiveSuccesses: 0 };
       this.hosts.set(host, s);
     }
     return s;
@@ -68,7 +68,7 @@ export class HostRateLimiter {
   /** Ms until the next request to this host may dispatch (0 = ready now). */
   msUntilReady(host: string, now: number): number {
     const s = this.stateFor(host);
-    if (s.lastRequestTime === 0) return 0; // never dispatched → ready
+    if (s.lastRequestTime < 0) return 0; // never dispatched → ready
     return Math.max(0, s.lastRequestTime + s.currentDelay - now);
   }
 

--- a/src/driver/poolRouter.ts
+++ b/src/driver/poolRouter.ts
@@ -1,0 +1,81 @@
+/**
+ * PoolRouter — the crawl driver's access-tier pool router.
+ *
+ * The driver runs two worker pools that differ by COST, not by host:
+ *   - `browser`  — the expensive browser/mint tier (real headless Chrome, cf_clearance mint,
+ *                  fingerprint evasion) for stores whose access barrier demands a browser.
+ *   - `fetch`    — the cheap HTTP tier for stores reachable with a plain request (+ a cookie
+ *                  or auth header).
+ * Each pool is bounded by a capacity sized against the crawl-RATE budget (the binding
+ * constraint per infra-budget), so a burst of Cloudflare stores can never starve the cheap
+ * fetch stores and vice-versa.
+ *
+ * The access -> pool mapping is INJECTED (`classify`) rather than hard-coded: the private
+ * access taxonomy (StoreProfile.access) lives in the ruleset registry and must not leak into
+ * the public engine. This mirrors HostRateLimiter taking `configFor`. Pure and synchronous —
+ * capacity is a simple in-flight counter, so behaviour is deterministic and timer-free.
+ */
+
+export type PoolKind = 'browser' | 'fetch';
+
+/** Max concurrent in-flight workers per pool (sized vs the crawl-rate budget). */
+export interface PoolCapacity {
+  browser: number;
+  fetch: number;
+}
+
+export class PoolRouter {
+  private readonly inFlight: Record<PoolKind, number> = { browser: 0, fetch: 0 };
+
+  /**
+   * @param capacity  per-pool concurrency ceilings.
+   * @param classify  maps a store's access tier to its pool. Injected so the private access
+   *                  taxonomy stays out of the public engine.
+   */
+  constructor(
+    private readonly capacity: PoolCapacity,
+    private readonly classify: (access: string) => PoolKind,
+  ) {}
+
+  /** Which pool a store with this access tier belongs to. */
+  poolFor(access: string): PoolKind {
+    return this.classify(access);
+  }
+
+  /** Configured concurrency ceiling for a pool. */
+  capacityOf(pool: PoolKind): number {
+    return this.capacity[pool];
+  }
+
+  /** Workers currently in flight in a pool. */
+  inFlightOf(pool: PoolKind): number {
+    return this.inFlight[pool];
+  }
+
+  /** Free slots in a pool (never negative). */
+  available(pool: PoolKind): number {
+    return Math.max(0, this.capacity[pool] - this.inFlight[pool]);
+  }
+
+  /** Whether a pool has a free slot right now. */
+  hasCapacity(pool: PoolKind): boolean {
+    return this.available(pool) > 0;
+  }
+
+  /**
+   * Try to take a slot for a store with this access tier. Returns the resolved pool and
+   * whether a slot was granted; on `ok: false` the pool is saturated and the caller should
+   * defer this store. Does NOT block.
+   */
+  tryAcquire(access: string): { ok: boolean; pool: PoolKind } {
+    const pool = this.classify(access);
+    if (this.available(pool) <= 0) return { ok: false, pool };
+    this.inFlight[pool] += 1;
+    return { ok: true, pool };
+  }
+
+  /** Return a slot to a pool. Clamped at zero so an over-release can never invent capacity. */
+  release(pool: PoolKind): void {
+    if (this.inFlight[pool] > 0) this.inFlight[pool] -= 1;
+  }
+}

--- a/src/driver/poolRouter.ts
+++ b/src/driver/poolRouter.ts
@@ -1,19 +1,17 @@
 /**
- * PoolRouter — the crawl driver's access-tier pool router.
+ * PoolRouter — the crawl driver's two-pool concurrency limiter.
  *
- * The driver runs two worker pools that differ by COST, not by host:
- *   - `browser`  — the expensive browser/mint tier (real headless Chrome, cf_clearance mint,
- *                  fingerprint evasion) for stores whose access barrier demands a browser.
- *   - `fetch`    — the cheap HTTP tier for stores reachable with a plain request (+ a cookie
- *                  or auth header).
+ * The driver runs two worker pools that differ by COST:
+ *   - `browser` — the expensive browser/mint tier (real headless Chrome, cf_clearance mint,
+ *                 fingerprint evasion) for stores whose access barrier demands a browser.
+ *   - `fetch`   — the cheap HTTP tier for stores reachable with a plain request.
  * Each pool is bounded by a capacity sized against the crawl-RATE budget (the binding
- * constraint per infra-budget), so a burst of Cloudflare stores can never starve the cheap
+ * constraint per infra-budget), so a burst of browser-gated stores can never starve the cheap
  * fetch stores and vice-versa.
  *
- * The access -> pool mapping is INJECTED (`classify`) rather than hard-coded: the private
- * access taxonomy (StoreProfile.access) lives in the ruleset registry and must not leak into
- * the public engine. This mirrors HostRateLimiter taking `configFor`. Pure and synchronous —
- * capacity is a simple in-flight counter, so behaviour is deterministic and timer-free.
+ * This is a pure by-pool semaphore set: callers pass the resolved `PoolKind` (the driver derives
+ * it from a store's public `requiresBrowser` via the ProfileRegistry — the private access
+ * taxonomy never enters the engine). Synchronous and timer-free, so behaviour is deterministic.
  */
 
 export type PoolKind = 'browser' | 'fetch';
@@ -27,20 +25,7 @@ export interface PoolCapacity {
 export class PoolRouter {
   private readonly inFlight: Record<PoolKind, number> = { browser: 0, fetch: 0 };
 
-  /**
-   * @param capacity  per-pool concurrency ceilings.
-   * @param classify  maps a store's access tier to its pool. Injected so the private access
-   *                  taxonomy stays out of the public engine.
-   */
-  constructor(
-    private readonly capacity: PoolCapacity,
-    private readonly classify: (access: string) => PoolKind,
-  ) {}
-
-  /** Which pool a store with this access tier belongs to. */
-  poolFor(access: string): PoolKind {
-    return this.classify(access);
-  }
+  constructor(private readonly capacity: PoolCapacity) {}
 
   /** Configured concurrency ceiling for a pool. */
   capacityOf(pool: PoolKind): number {
@@ -62,16 +47,11 @@ export class PoolRouter {
     return this.available(pool) > 0;
   }
 
-  /**
-   * Try to take a slot for a store with this access tier. Returns the resolved pool and
-   * whether a slot was granted; on `ok: false` the pool is saturated and the caller should
-   * defer this store. Does NOT block.
-   */
-  tryAcquire(access: string): { ok: boolean; pool: PoolKind } {
-    const pool = this.classify(access);
-    if (this.available(pool) <= 0) return { ok: false, pool };
+  /** Take a slot in the pool; returns false (without taking one) if the pool is saturated. */
+  tryAcquire(pool: PoolKind): boolean {
+    if (this.available(pool) <= 0) return false;
     this.inFlight[pool] += 1;
-    return { ok: true, pool };
+    return true;
   }
 
   /** Return a slot to a pool. Clamped at zero so an over-release can never invent capacity. */

--- a/src/driver/profileRegistry.ts
+++ b/src/driver/profileRegistry.ts
@@ -1,0 +1,68 @@
+/**
+ * ProfileRegistry — the crawl driver's per-store capability index.
+ *
+ * Indexes public `StoreCapabilities` by host (every domain) and by siteId, and exposes the
+ * three seams the scheduler consumes:
+ *   - `rateConfigFor(host)` → HostRateLimiter (a `DomainRateLimit` is structurally a
+ *      `HostRateConfig`, so it drops straight in).
+ *   - `poolFor(host)`       → PoolRouter — `requiresBrowser` picks the expensive browser/mint
+ *      pool vs the cheap fetch pool (the coarse D3 split; a finer mint-vs-fingerprint split can
+ *      layer on later without changing this seam).
+ *   - `retrievalFor(host)`  → the targeted on-request fetch path (undefined = enumeration-only).
+ *
+ * Populated by the plugin, which maps each PRIVATE StoreProfile down to public
+ * StoreCapabilities at registration — so the engine schedules real stores without ever
+ * importing the moat axes.
+ */
+import type {
+  DomainRateLimit,
+  RetrievalCapability,
+  StoreCapabilities,
+} from '@figurecollecting/scraper-plugin-contract';
+import type { PoolKind } from './poolRouter.js';
+
+/** Host key: lowercased, trimmed, `www.` stripped, so domain variants collapse to one store. */
+const normalizeHost = (host: string): string => host.trim().toLowerCase().replace(/^www\./, '');
+
+export class ProfileRegistry {
+  private readonly byHost = new Map<string, StoreCapabilities>();
+  private readonly bySite = new Map<string, StoreCapabilities>();
+
+  /** Register (or replace, last-wins) a store's capabilities, indexing all of its domains. */
+  register(caps: StoreCapabilities): void {
+    this.bySite.set(caps.siteId, caps);
+    for (const domain of caps.domains) this.byHost.set(normalizeHost(domain), caps);
+  }
+
+  forHost(host: string): StoreCapabilities | undefined {
+    return this.byHost.get(normalizeHost(host));
+  }
+
+  forSite(siteId: string): StoreCapabilities | undefined {
+    return this.bySite.get(siteId);
+  }
+
+  all(): StoreCapabilities[] {
+    return [...this.bySite.values()];
+  }
+
+  size(): number {
+    return this.bySite.size;
+  }
+
+  /** Per-host rate config for HostRateLimiter (undefined = unmapped host → its default). */
+  rateConfigFor(host: string): DomainRateLimit | undefined {
+    return this.forHost(host)?.rateLimit;
+  }
+
+  /** Pool for PoolRouter: browser-required stores → the browser/mint pool, else the fetch pool. */
+  poolFor(host: string): PoolKind | undefined {
+    const caps = this.forHost(host);
+    return caps ? (caps.requiresBrowser ? 'browser' : 'fetch') : undefined;
+  }
+
+  /** Targeted-retrieval capability for on-request fetches (undefined = enumeration-only). */
+  retrievalFor(host: string): RetrievalCapability | undefined {
+    return this.forHost(host)?.retrieval;
+  }
+}

--- a/src/driver/retrievalPlanner.ts
+++ b/src/driver/retrievalPlanner.ts
@@ -1,0 +1,76 @@
+/**
+ * retrievalPlanner — turns a targeted-retrieval REQUEST into concrete fetch plans using each
+ * store's `RetrievalCapability` templates, as opposed to full-catalog enumeration. Three modes:
+ *   - `byId`   — you hold a store's item ids → one detail-fetch plan per id (re-fetch / known ids).
+ *   - `search` — you hold a query for one store → one search plan.
+ *   - `lookup` — you hold a name/JAN and want it ACROSS stores → a search plan for every store
+ *                that supports search (the buy-decision fan-out). Stores that can't serve the
+ *                mode come back in `unsupported`, so the caller knows the coverage gap explicitly.
+ *
+ * Search returns candidates, not final items — the two-stage `search → candidate ids → byId`
+ * refinement is the caller's next step (a follow-on increment). Pure and synchronous.
+ */
+import type { RetrievalCapability } from '@figurecollecting/scraper-plugin-contract';
+import type { ProfileRegistry } from './profileRegistry.js';
+
+/** Build an item detail URL from the byId template, `{id}` url-encoded. */
+export function resolveByIdUrl(retrieval: RetrievalCapability | undefined, itemId: string): string | undefined {
+  const template = retrieval?.byId?.urlTemplate;
+  return template ? template.replace('{id}', encodeURIComponent(itemId)) : undefined;
+}
+
+/** Build a search URL from the bySearch template, `{q}` url-encoded. */
+export function resolveSearchUrl(retrieval: RetrievalCapability | undefined, query: string): string | undefined {
+  const template = retrieval?.bySearch?.urlTemplate;
+  return template ? template.replace('{q}', encodeURIComponent(query)) : undefined;
+}
+
+export type RetrievalRequest =
+  | { mode: 'byId'; host: string; itemIds: string[] }
+  | { mode: 'search'; host: string; query: string }
+  | { mode: 'lookup'; query: string };
+
+export interface FetchPlan {
+  host: string;
+  siteId: string;
+  url: string;
+  kind: 'detail' | 'search';
+  itemId?: string;
+}
+
+export interface RetrievalPlan {
+  plans: FetchPlan[];
+  /** Store identifiers (siteId, or the host if unknown) that cannot serve the requested mode. */
+  unsupported: string[];
+}
+
+export function planRetrieval(registry: ProfileRegistry, req: RetrievalRequest): RetrievalPlan {
+  const plans: FetchPlan[] = [];
+  const unsupported: string[] = [];
+
+  if (req.mode === 'byId') {
+    const caps = registry.forHost(req.host);
+    for (const itemId of req.itemIds) {
+      const url = resolveByIdUrl(caps?.retrieval, itemId);
+      if (url) plans.push({ host: req.host, siteId: caps?.siteId ?? '', url, kind: 'detail', itemId });
+    }
+    if (plans.length === 0) unsupported.push(caps?.siteId ?? req.host);
+    return { plans, unsupported };
+  }
+
+  if (req.mode === 'search') {
+    const caps = registry.forHost(req.host);
+    const url = resolveSearchUrl(caps?.retrieval, req.query);
+    if (url) plans.push({ host: req.host, siteId: caps?.siteId ?? '', url, kind: 'search' });
+    else unsupported.push(caps?.siteId ?? req.host);
+    return { plans, unsupported };
+  }
+
+  // lookup: fan the query out to every store that supports search
+  for (const caps of registry.all()) {
+    const url = resolveSearchUrl(caps.retrieval, req.query);
+    if (url) plans.push({ host: caps.domains[0], siteId: caps.siteId, url, kind: 'search' });
+    else unsupported.push(caps.siteId);
+  }
+  return { plans, unsupported };
+}


### PR DESCRIPTION
The new multi-store crawl-ingest driver (2b) — replaces the legacy single-global-throttle MFC-sync scrapeQueue paradigm. Additive for now (all new code under src/driver/); wiring the engine over to it + retiring the legacy queue follow in later increments.

## I0 scheduling core (pure, synchronous, timer-free — deterministically testable)
- HostRateLimiter — per-host throttle seeded from each store's rateLimit (a Cloudflare backoff on one host can't slow another).
- PoolRouter — a by-pool concurrency semaphore (browser/mint vs cheap fetch), sized against the crawl-rate budget.
- DispatchScheduler — dispatches a task only when its host is past its delay AND its pool has a slot; settle() releases + records the outcome; msUntilNext() tells the loop how long to sleep.
- ProfileRegistry — indexes public StoreCapabilities by host; feeds rateLimit -> throttle, requiresBrowser -> pool, retrieval -> targeted fetch.
- assembleScheduler — wires a ProfileRegistry into a runnable scheduler; unmapped hosts default to the cheap fetch pool + baseline delay.

## CrawlLoop
Async dispatch -> worker -> settle runtime: greedily dispatches everything runnable, launches workers concurrently up to pool capacity, and wakes on the earlier of a worker finishing or the next host readying. All effects injected (now/sleep/worker) — tested with a virtual clock (concurrency capping, throttle serialization, thrown-worker back-off).

## Contract + retrieval
- Adds public StoreCapabilities (SiteConfig + retrieval) and RetrievalCapability. The private StoreProfile access taxonomy NEVER enters the engine — pool is derived from public requiresBrowser; the plugin maps private profiles -> public capabilities at registration (follows a contract release).
- retrievalPlanner — targeted on-request fetches: by-id / single-store search / cross-store lookup fan-out (the buy-decision seam), with an explicit unsupported coverage-gap report.

## Verification
39 unit tests, tsc clean. Moat boundary respected throughout (injection seams; engine consumes only public shapes).