### PR TITLE
Bump plugin-contract to 0.2.0 (publish StoreCapabilities/RetrievalCapability)

### DIFF
--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figurecollecting/scraper-plugin-contract",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
The StoreCapabilities + RetrievalCapability types merged in #240 but the registry still has 0.1.0 (npm versions are immutable; the publish workflow skipped since the version was unchanged). This bumps to 0.2.0 (additive, backward-compatible) so the Publish Plugin Contract workflow releases it to GitHub Packages on merge.

Unblocks wiring scraper-rulesets: once 0.2.0 is published, its plugin can map each private StoreProfile to the public StoreCapabilities and register real stores into the driver's ProfileRegistry (retrieval templates included).