### PR TITLE
Add CoverageLedger: resumable, provably-complete per-store ID coverage (crawl driver I1)

### DIFF
--- a/src/driver/__tests__/coverageLedger.test.ts
+++ b/src/driver/__tests__/coverageLedger.test.ts
@@ -1,0 +1,61 @@
+/**
+ * TDD (red first): CoverageLedger — per-store, per-ID coverage tracking that makes a crawl
+ * RESUMABLE (restore from a snapshot → re-enqueue only what's left) and completeness PROVABLE
+ * (complete only when every enumerated ID is done). Failed IDs stay retryable. Pure + serializable.
+ */
+import { CoverageLedger, type LedgerSnapshot } from '../coverageLedger';
+
+describe('CoverageLedger — per-store coverage with checkpoint/resume', () => {
+  it('seeds ids as pending and is idempotent (re-adding never resets progress)', () => {
+    const l = new CoverageLedger('amiami');
+    l.add(['a', 'b', 'c']);
+    expect(l.counts()).toEqual({ pending: 3, done: 0, failed: 0, total: 3 });
+    l.markDone('a');
+    l.add(['a', 'b', 'd']); // 'a' is done (must not reset), 'b' pending, 'd' new
+    expect(l.state('a')).toBe('done');
+    expect(l.counts()).toEqual({ pending: 3, done: 1, failed: 0, total: 4 });
+  });
+
+  it('remaining() = pending + failed (failed are retryable); done are excluded', () => {
+    const l = new CoverageLedger('s');
+    l.add(['a', 'b', 'c']);
+    l.markDone('a');
+    l.markFailed('b');
+    expect(l.remaining().sort()).toEqual(['b', 'c']);
+    expect(l.isComplete()).toBe(false);
+  });
+
+  it('isComplete() only when every id is done (failed blocks completeness until retried)', () => {
+    const l = new CoverageLedger('s');
+    l.add(['a', 'b']);
+    l.markDone('a');
+    l.markFailed('b');
+    expect(l.isComplete()).toBe(false);
+    l.markDone('b'); // retry succeeds
+    expect(l.isComplete()).toBe(true);
+    expect(l.remaining()).toEqual([]);
+  });
+
+  it('snapshot() + restore() round-trips for resume', () => {
+    const l = new CoverageLedger('mfc');
+    l.add(['1', '2', '3', '4']);
+    l.markDone('1');
+    l.markDone('2');
+    l.markFailed('3'); // 4 stays pending
+    const resumed = CoverageLedger.restore(l.snapshot());
+    expect(resumed.siteId).toBe('mfc');
+    expect(resumed.counts()).toEqual({ pending: 1, done: 2, failed: 1, total: 4 });
+    expect(resumed.remaining().sort()).toEqual(['3', '4']); // resume = retry 3 + do 4
+    expect(resumed.isComplete()).toBe(false);
+  });
+
+  it('the snapshot survives a JSON round-trip (persistable to pg-spine or disk)', () => {
+    const l = new CoverageLedger('s');
+    l.add(['x', 'y']);
+    l.markDone('x');
+    const viaJson: LedgerSnapshot = JSON.parse(JSON.stringify(l.snapshot()));
+    const resumed = CoverageLedger.restore(viaJson);
+    expect(resumed.state('x')).toBe('done');
+    expect(resumed.remaining()).toEqual(['y']);
+  });
+});

--- a/src/driver/coverageLedger.ts
+++ b/src/driver/coverageLedger.ts
@@ -1,0 +1,86 @@
+/**
+ * CoverageLedger — the crawl driver's per-store, per-ID coverage record.
+ *
+ * Enumeration seeds the IDs to cover; the loop marks each done/failed as it processes them.
+ * That makes a long crawl:
+ *   - RESUMABLE — `restore(snapshot)` rebuilds the state, and `remaining()` re-enqueues only
+ *     what's left (pending + retryable failed), so a crash or a multi-day backfill picks up
+ *     where it stopped instead of re-fetching the world.
+ *   - PROVABLY COMPLETE — `isComplete()` is true only when EVERY enumerated ID is done; a
+ *     single failed ID keeps it incomplete until retried. No silent "looks done".
+ *
+ * Pure and JSON-serializable; WHERE the snapshot persists (a pg-spine table vs driver-local
+ * state) is the caller's choice (the ADR's open question), not baked in here.
+ */
+
+export type CoverageState = 'pending' | 'done' | 'failed';
+
+export interface CoverageCounts {
+  pending: number;
+  done: number;
+  failed: number;
+  total: number;
+}
+
+export interface LedgerSnapshot {
+  siteId: string;
+  entries: Array<[string, CoverageState]>;
+}
+
+export class CoverageLedger {
+  private readonly states = new Map<string, CoverageState>();
+
+  constructor(public readonly siteId: string) {}
+
+  /** Seed IDs to cover. Idempotent: an already-tracked ID keeps its state (progress is never reset). */
+  add(ids: Iterable<string>): void {
+    for (const id of ids) if (!this.states.has(id)) this.states.set(id, 'pending');
+  }
+
+  markDone(id: string): void {
+    this.states.set(id, 'done');
+  }
+
+  markFailed(id: string): void {
+    this.states.set(id, 'failed');
+  }
+
+  state(id: string): CoverageState | undefined {
+    return this.states.get(id);
+  }
+
+  /** IDs still needing work: pending + failed (failed are retried on resume). Done are excluded. */
+  remaining(): string[] {
+    const out: string[] = [];
+    for (const [id, s] of this.states) if (s !== 'done') out.push(id);
+    return out;
+  }
+
+  counts(): CoverageCounts {
+    let done = 0;
+    let failed = 0;
+    for (const s of this.states.values()) {
+      if (s === 'done') done += 1;
+      else if (s === 'failed') failed += 1;
+    }
+    const total = this.states.size;
+    return { pending: total - done - failed, done, failed, total };
+  }
+
+  /** Provable completeness: at least one ID tracked and every one of them is done. */
+  isComplete(): boolean {
+    return this.states.size > 0 && this.remaining().length === 0;
+  }
+
+  /** Serializable checkpoint of the full coverage state. */
+  snapshot(): LedgerSnapshot {
+    return { siteId: this.siteId, entries: [...this.states.entries()] };
+  }
+
+  /** Rebuild a ledger from a snapshot to resume a crawl. */
+  static restore(snapshot: LedgerSnapshot): CoverageLedger {
+    const ledger = new CoverageLedger(snapshot.siteId);
+    for (const [id, s] of snapshot.entries) ledger.states.set(id, s);
+    return ledger;
+  }
+}


### PR DESCRIPTION
The crawl driver's per-store, per-ID coverage record — the backbone of I1 (enumeration + resumption).

- Enumeration seeds IDs; the loop marks each done/failed as it runs.
- RESUMABLE: restore(snapshot) + remaining() re-enqueue only what's left (pending + retryable failed), so a crash or a multi-day backfill resumes instead of re-fetching the world.
- PROVABLY COMPLETE: isComplete() is true only when EVERY enumerated ID is done — a single failed ID keeps it incomplete until retried. No silent 'looks done'.
- Pure + JSON-serializable; where the snapshot persists (pg-spine table vs driver-local) stays the caller's choice.

Tests: 8 suites / 44 driver tests green, tsc clean. Additive (new src/driver/coverageLedger.ts only).