### PR TITLE
Crawl driver I2: the fetch → extract → emit worker

### DIFF
--- a/src/driver/__tests__/crawlWorker.test.ts
+++ b/src/driver/__tests__/crawlWorker.test.ts
@@ -1,0 +1,179 @@
+/**
+ * crawlWorker — the crawl driver's I2 worker: the `(task) => Outcome` function the CrawlLoop
+ * launches per dispatch. It composes injected ports — resolveUrl → fetch → catch-gated extract →
+ * emit — and records each item's fate on the CoverageLedger, returning ONLY the host-mood Outcome
+ * ('success' recovers the host delay, 'rate-limited' backs it off). The two axes are independent:
+ * the ledger carries item done/failed; the Outcome carries whether the host cooperated.
+ *
+ * Outcome table under test:
+ *   no URL / no ruleset      → markFailed + 'success'      (config gap; host not contacted)
+ *   fetch throws / 429 / 503 → (pending) + 'rate-limited'  (host throttled/blocked → back off)
+ *   extract throws           → markFailed + 'success'      (page OK, content failed — not throttle)
+ *   emit throws              → (pending) + 'rate-limited'  (delivery failed → backpressure, retry)
+ *   emit OK                  → markDone   + 'success'      (covered)
+ */
+import { makeCrawlWorker, type CrawlWorkerDeps, type FetchResult } from '../crawlWorker';
+import type { CrawlTask } from '../dispatchScheduler';
+import type { ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+
+const TASK: CrawlTask = { id: 'abc123', host: 'www.amiami.com' };
+const URL = 'https://www.amiami.com/eng/detail/?gcode=abc123';
+
+const extracted = (over: Partial<ExtractedData> = {}): ExtractedData => ({
+  source: { site: 'amiami', itemId: 'abc123', extractedAt: '2026-08-08T00:00:00.000Z' },
+  fields: { name: 'Some Figure' },
+  warnings: [],
+  ...over,
+});
+
+const ruleset = (over: Partial<ExtractionRuleset> = {}): ExtractionRuleset => ({
+  siteId: 'amiami',
+  version: '1.0.0',
+  extract: jest.fn().mockReturnValue(extracted()),
+  validate: jest.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }),
+  ...over,
+});
+
+/** Minimal ledger double recording the two calls the worker makes. */
+const fakeLedger = () => {
+  const done: string[] = [];
+  const failed: string[] = [];
+  return { done, failed, markDone: (id: string) => done.push(id), markFailed: (id: string) => failed.push(id) };
+};
+
+const build = (over: Partial<CrawlWorkerDeps> = {}) => {
+  const ledger = fakeLedger();
+  const rs = ruleset();
+  const deps: CrawlWorkerDeps = {
+    resolveUrl: jest.fn().mockReturnValue(URL),
+    fetch: jest.fn<Promise<FetchResult>, [string]>().mockResolvedValue({ html: '<html>ok</html>', statusCode: 200 }),
+    lookupRuleset: jest.fn().mockReturnValue(rs),
+    emit: jest.fn().mockResolvedValue({ sourceId: 's1' }),
+    ledger,
+    ...over,
+  };
+  return { deps, ledger, rs, worker: makeCrawlWorker(deps) };
+};
+
+describe('makeCrawlWorker — per-item fetch → extract → emit', () => {
+  it('covers an item: fetch, extract, emit, markDone, and returns success', async () => {
+    const { deps, ledger, rs, worker } = build();
+
+    const outcome = await worker(TASK);
+
+    expect(deps.resolveUrl).toHaveBeenCalledWith(TASK);
+    expect(deps.fetch).toHaveBeenCalledWith(URL);
+    expect(deps.lookupRuleset).toHaveBeenCalledWith(URL);
+    expect(rs.extract).toHaveBeenCalledWith('<html>ok</html>', URL, undefined);
+    expect(deps.emit).toHaveBeenCalledWith(extracted());
+    expect(ledger.done).toEqual(['abc123']);
+    expect(ledger.failed).toEqual([]);
+    expect(outcome).toBe('success');
+  });
+
+  it('no retrieval URL → markFailed + success, without contacting the host', async () => {
+    const { deps, ledger, worker } = build({ resolveUrl: jest.fn().mockReturnValue(undefined) });
+
+    const outcome = await worker(TASK);
+
+    expect(deps.fetch).not.toHaveBeenCalled();
+    expect(ledger.failed).toEqual(['abc123']);
+    expect(ledger.done).toEqual([]);
+    expect(outcome).toBe('success');
+  });
+
+  it('no ruleset for the URL → markFailed + success, without fetching', async () => {
+    const { deps, ledger, worker } = build({ lookupRuleset: jest.fn().mockReturnValue(undefined) });
+
+    const outcome = await worker(TASK);
+
+    expect(deps.fetch).not.toHaveBeenCalled();
+    expect(ledger.failed).toEqual(['abc123']);
+    expect(outcome).toBe('success');
+  });
+
+  it('fetch throwing (network/CF block) → rate-limited, item left pending', async () => {
+    const { deps, ledger, rs, worker } = build({ fetch: jest.fn().mockRejectedValue(new Error('CF challenge')) });
+
+    const outcome = await worker(TASK);
+
+    expect(rs.extract).not.toHaveBeenCalled();
+    expect(deps.emit).not.toHaveBeenCalled();
+    expect(ledger.done).toEqual([]);
+    expect(ledger.failed).toEqual([]); // pending — a resume retries it
+    expect(outcome).toBe('rate-limited');
+  });
+
+  it.each([429, 503])('throttle status %i → rate-limited, no extract, item pending', async (status) => {
+    const { deps, ledger, rs, worker } = build({
+      fetch: jest.fn().mockResolvedValue({ html: '<html>challenge</html>', statusCode: status }),
+    });
+
+    const outcome = await worker(TASK);
+
+    expect(rs.extract).not.toHaveBeenCalled();
+    expect(deps.emit).not.toHaveBeenCalled();
+    expect(ledger.done).toEqual([]);
+    expect(ledger.failed).toEqual([]);
+    expect(outcome).toBe('rate-limited');
+  });
+
+  it('extract throwing (coverage-block / parse failure) → markFailed + success (host cooperated)', async () => {
+    const rs = ruleset({ extract: jest.fn().mockRejectedValue(new Error('coverage blocked')) });
+    const { deps, ledger, worker } = build({ lookupRuleset: jest.fn().mockReturnValue(rs) });
+
+    const outcome = await worker(TASK);
+
+    expect(deps.emit).not.toHaveBeenCalled();
+    expect(ledger.failed).toEqual(['abc123']);
+    expect(ledger.done).toEqual([]);
+    expect(outcome).toBe('success');
+  });
+
+  it('emit throwing (delivery failure) → rate-limited, item left pending (not marked failed)', async () => {
+    const { deps, ledger, worker } = build({ emit: jest.fn().mockRejectedValue(new Error('spine UNAVAILABLE')) });
+
+    const outcome = await worker(TASK);
+
+    expect(ledger.done).toEqual([]);
+    expect(ledger.failed).toEqual([]); // pending — delivery, not the item, failed
+    expect(outcome).toBe('rate-limited');
+  });
+
+  it('threads an ExtractContext from resolveContext into extract (multi-query rulesets)', async () => {
+    const ctx = { config: {}, scraping: {}, logger: {} } as never;
+    const rs = ruleset();
+    const resolveContext = jest.fn().mockReturnValue(ctx);
+    const { worker } = build({ lookupRuleset: jest.fn().mockReturnValue(rs), resolveContext });
+
+    await worker(TASK);
+
+    expect(resolveContext).toHaveBeenCalledWith(TASK, URL);
+    expect(rs.extract).toHaveBeenCalledWith('<html>ok</html>', URL, ctx);
+  });
+
+  it('a non-throttle error status (e.g. 404) still runs extract — the ruleset judges the content', async () => {
+    const rs = ruleset();
+    const { deps, worker } = build({
+      lookupRuleset: jest.fn().mockReturnValue(rs),
+      fetch: jest.fn().mockResolvedValue({ html: '<html>not found</html>', statusCode: 404 }),
+    });
+
+    await worker(TASK);
+
+    expect(rs.extract).toHaveBeenCalled();
+    expect(deps.emit).toHaveBeenCalled();
+  });
+
+  it('honors custom throttleStatuses (e.g. treat 202 as throttle)', async () => {
+    const { deps, worker } = build({
+      throttleStatuses: [202],
+      fetch: jest.fn().mockResolvedValue({ html: '<html/>', statusCode: 202 }),
+    });
+
+    const outcome = await worker(TASK);
+
+    expect(deps.emit).not.toHaveBeenCalled();
+    expect(outcome).toBe('rate-limited');
+  });
+});

--- a/src/driver/crawlWorker.ts
+++ b/src/driver/crawlWorker.ts
@@ -1,0 +1,105 @@
+/**
+ * crawlWorker — the crawl driver's I2 worker: the `(task) => Promise<Outcome>` function the
+ * CrawlLoop launches per dispatch. It composes the injected engine ports into one item pipeline:
+ *
+ *   resolveUrl(task) → fetch(url) → lookupRuleset(url).extract(html, url, ctx) → emit(extracted)
+ *
+ * and records the item's fate on the CoverageLedger. Everything is injected (no ScrapingService /
+ * ExtractionRegistry / IngestEmitter imports here) so the worker is a pure composition unit,
+ * deterministically testable with fakes; the real services wire in at I3.
+ *
+ * TWO INDEPENDENT AXES (do not conflate):
+ *   - Outcome ('success' | 'rate-limited') is the HOST's mood, fed back to the scheduler:
+ *     'success' recovers the host delay, 'rate-limited' backs it off. It is NOT item success.
+ *   - The ledger carries the ITEM's coverage fate: markDone (covered) / markFailed (won't cover
+ *     this pass). Left untouched = still pending, so a resume retries it.
+ *
+ *   no URL / no ruleset      → markFailed + 'success'      config/coverage gap; host not contacted
+ *   fetch throws / 429 / 503 → (pending)  + 'rate-limited' host throttled/blocked → back off, retry
+ *   extract throws           → markFailed + 'success'      page fetched OK; CONTENT failed (see note)
+ *   emit throws              → (pending)  + 'rate-limited' delivery failed → backpressure, retry
+ *   emit OK                  → markDone   + 'success'      covered
+ *
+ * LAYERING NOTE — why "extract throws" is a content failure, not a block: Cloudflare / throttle
+ * detection is the FETCH port's contract (it throws or returns a 429/503). So by the time control
+ * reaches extract, the page is real content; an extract throw is a genuine coverage-gate/parse
+ * failure (the plugin wraps extract with the coverage gate), which backing off the host would not
+ * fix. Spine-down backpressure via 'rate-limited' on emit failure is deliberately crude — a
+ * spine-health circuit breaker belongs at the loop/driver level (I3), not per item.
+ */
+import type { CrawlTask, Outcome } from './dispatchScheduler.js';
+import type { CoverageLedger } from './coverageLedger.js';
+import type { ExtractContext, ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+
+/** What the fetch port yields. It MUST throw on CF-block / network error (→ treated as throttle). */
+export interface FetchResult {
+  html: string;
+  statusCode?: number;
+}
+
+/** Only the two ledger mutations the worker performs — keeps it loosely coupled + easy to fake. */
+export type CoverageSink = Pick<CoverageLedger, 'markDone' | 'markFailed'>;
+
+export interface CrawlWorkerDeps {
+  /** Turn a task ({ host, id }) into the item URL via the host's `retrieval.byId` template. */
+  resolveUrl: (task: CrawlTask) => string | undefined;
+  /** Fetch the page. Contract: THROW on CF-block / network error; return a 429/503 status to throttle. */
+  fetch: (url: string) => Promise<FetchResult>;
+  /** Find the ruleset that extracts this URL's store (undefined → no coverage for it). */
+  lookupRuleset: (url: string) => ExtractionRuleset | undefined;
+  /** Deliver the extraction to the spine (reuses IngestEmitter.send at I3). */
+  emit: (extracted: ExtractedData) => Promise<unknown>;
+  /** Per-store coverage record: markDone on cover, markFailed on a permanent item failure. */
+  ledger: CoverageSink;
+  /** Optional per-extraction context for multi-query rulesets (I3 supplies it; omit → 2-arg extract). */
+  resolveContext?: (task: CrawlTask, url: string) => ExtractContext | undefined;
+  /** HTTP statuses meaning "throttled, back off" (default 429, 503). */
+  throttleStatuses?: number[];
+}
+
+const DEFAULT_THROTTLE_STATUSES = [429, 503];
+
+export function makeCrawlWorker(deps: CrawlWorkerDeps): (task: CrawlTask) => Promise<Outcome> {
+  const throttle = new Set(deps.throttleStatuses ?? DEFAULT_THROTTLE_STATUSES);
+
+  return async (task: CrawlTask): Promise<Outcome> => {
+    const url = deps.resolveUrl(task);
+    if (!url) {
+      deps.ledger.markFailed(task.id); // no targeted-retrieval URL for this host — coverage gap
+      return 'success';
+    }
+
+    const ruleset = deps.lookupRuleset(url);
+    if (!ruleset) {
+      deps.ledger.markFailed(task.id); // no ruleset registered for this store — coverage gap
+      return 'success';
+    }
+
+    let page: FetchResult;
+    try {
+      page = await deps.fetch(url);
+    } catch {
+      return 'rate-limited'; // network error / CF block → back off, leave the item pending
+    }
+    if (page.statusCode !== undefined && throttle.has(page.statusCode)) {
+      return 'rate-limited'; // host throttled → back off, leave the item pending
+    }
+
+    let extracted: ExtractedData;
+    try {
+      extracted = await ruleset.extract(page.html, url, deps.resolveContext?.(task, url));
+    } catch {
+      deps.ledger.markFailed(task.id); // page came back fine; content/coverage failed — not a throttle
+      return 'success';
+    }
+
+    try {
+      await deps.emit(extracted);
+    } catch {
+      return 'rate-limited'; // delivery failed (spine) → backpressure; item stays pending for retry
+    }
+
+    deps.ledger.markDone(task.id); // delivered → this ID is covered
+    return 'success';
+  };
+}


### PR DESCRIPTION
## What

Adds `makeCrawlWorker` — the crawl driver's **I2 worker**: the `(task) => Promise<Outcome>` function `CrawlLoop` launches per dispatch. It composes the injected engine ports into one item pipeline:

```
resolveUrl(task) → fetch(url) → lookupRuleset(url).extract(html, url, ctx) → emit(extracted)
```

and records each item's fate on the `CoverageLedger`, returning only the host-mood `Outcome`. Everything is injected (no `ScrapingService`/`ExtractionRegistry`/`IngestEmitter` imports) so the worker is a pure composition unit — the real services wire in at I3.

## Two independent axes (deliberate)

- **`Outcome` = the host's mood**, fed to the scheduler: `'success'` recovers the host delay, `'rate-limited'` backs it off. It is *not* item success.
- **The ledger = the item's coverage fate**: `markDone` / `markFailed`; left untouched = still pending, so a resume retries it.

| Situation | Ledger | `Outcome` |
|---|---|---|
| no URL / no ruleset | `markFailed` | `success` (config gap; host not contacted) |
| fetch throws / 429 / 503 | *pending* | `rate-limited` (host throttled → back off) |
| `extract` throws | `markFailed` | `success` (page OK, content failed — not a throttle) |
| `emit` throws | *pending* | `rate-limited` (delivery failed → backpressure, retry) |
| `emit` OK | `markDone` | `success` (covered) |

**Layering rationale:** CF/throttle detection is the *fetch* port's contract (it throws or returns 429/503), so by the time control reaches `extract` the page is real content — an extract throw is a genuine coverage-gate/parse failure, which backing the host off would not fix. Spine-down backpressure via `rate-limited` on emit failure is intentionally crude; a spine-health circuit breaker belongs at the loop level (I3).

## Wire shape (confirmed by reading the emit path)

The worker produces a base `ExtractedData` and hands it to the emitter unchanged. The spine wire carries `{source, fields_json, warnings}` only and **derives claims server-side** — so **claims-only-v1 needs no contract change**. (Transport is Connect-over-HTTP/1.1 with mesh mTLS, not gRPC.)

## Tests

TDD (RED: module-missing → GREEN). 11 tests covering every outcome-table row + the `ExtractContext` threading + custom throttle statuses. **100% stmt/branch/func/line** on `crawlWorker.ts`; full driver suite 55/55, `tsc --noEmit` clean.