### PR TITLE
Correct emit-transport comment: Linkerd meshes h2c; h1 is a friction/unary choice

### DIFF
--- a/src/services/ingestEmitter.ts
+++ b/src/services/ingestEmitter.ts
@@ -15,10 +15,14 @@
  *
  * TRANSPORT: createConnectTransport with httpVersion '1.1' — the Connect
  * protocol over plain HTTP/1.1. The spine ingest server serves cleartext
- * HTTP/1.1, and Linkerd meshes HTTP/1.1 natively (mTLS, no opaque-port
- * workaround), whereas it mishandles the cleartext-h2c stream on this hop.
- * Do NOT revert to createGrpcTransport (h2c) — that is the stream the mesh
- * cannot carry.
+ * HTTP/1.1, which Linkerd meshes natively (mTLS) with no appProtocol hint or
+ * opaque-port tuning. This RPC is UNARY, so HTTP/2 buys nothing here and h1 is
+ * the lowest-friction meshable transport. (Linkerd CAN mesh cleartext h2c via
+ * protocol detection; an earlier gRPC/h2c attempt on this hop did not mesh
+ * cleanly — an edge-case/version artifact, not a Linkerd limitation.) Keep this
+ * as Connect/h1: do NOT swap back to createGrpcTransport (h2c) without first
+ * re-validating the meshed hop end-to-end (e.g. an explicit
+ * appProtocol: kubernetes.io/h2c on the Service port).
  *
  * RETRY (SUCCESS = the RPC resolved OK — never key success on
  * stats.inserted > 0; a post-commit retry legitimately returns all-deduped


### PR DESCRIPTION
## Why

The `ingestEmitter.ts` TRANSPORT header asserted that Linkerd **"cannot carry"** the cleartext-h2c stream. Per current Linkerd docs (2.18), that's an overclaim: Linkerd's proxy **auto-detects** client-first h2c (the HTTP/2 connection preface) and meshes it with full L7 — no opaque-port or appProtocol config needed. Cleartext gRPC through Linkerd is a first-class, supported pattern.

The earlier gRPC/h2c attempt on *this* hop not meshing cleanly was almost certainly an **edge case** (app-TLS wrapping, a headless/direct-pod/unmeshed peer, or a pre-2.14 cluster before the `appProtocol: kubernetes.io/h2c` hint existed) — not a Linkerd limitation. It may well have been accurate for the cluster's Linkerd version at the time; this just stops the comment from stating it as a general law.

## What changed

**Comment only — zero code change.** The header now says the honest thing:
- Linkerd meshes cleartext h1 natively (mTLS), no tuning.
- The RPC is **unary**, so HTTP/2 buys nothing → h1 is the lowest-friction meshable transport (the real reason to prefer it).
- Linkerd *can* mesh cleartext h2c; the prior h2c attempt was an edge-case/version artifact.
- Keep it as Connect/h1, but the guardrail is now "don't swap back without re-validating the meshed hop end-to-end (e.g. an explicit `appProtocol: kubernetes.io/h2c`)" rather than a false absolute.

Verified against the deployed manifests (no `opaque-ports`; `proxyProtocol: HTTP/1`; mTLS via the Linkerd sidecar with `MeshTLSAuthentication` scoped to the scraper SA) and Linkerd 2.18 protocol-detection / mTLS / load-balancing docs.