### PR TITLE
Crawl driver I3a: compose engine services into the worker

### DIFF
--- a/src/driver/__tests__/assembleCrawlWorker.test.ts
+++ b/src/driver/__tests__/assembleCrawlWorker.test.ts
@@ -1,0 +1,131 @@
+/**
+ * assembleCrawlWorker — the I3 adapter that composes the real engine services into the
+ * CrawlWorkerDeps that makeCrawlWorker consumes. These tests verify the WIRING (URL resolution,
+ * the ScrapePageResult→FetchResult mapping, the CF-status throttle default, port delegation) —
+ * the per-item outcome table itself is already covered by crawlWorker.test.ts.
+ */
+import { assembleCrawlWorker, type CrawlWorkerServices } from '../assembleCrawlWorker';
+import type { CrawlTask } from '../dispatchScheduler';
+import type {
+  ExtractedData,
+  ExtractionRuleset,
+  RetrievalCapability,
+  ScrapePageResult,
+} from '@figurecollecting/scraper-plugin-contract';
+
+const TASK: CrawlTask = { id: 'FIGURE-42', host: 'www.amiami.com' };
+const RETRIEVAL: RetrievalCapability = { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}' } };
+const EXPECTED_URL = 'https://www.amiami.com/eng/detail/?gcode=FIGURE-42';
+
+const extracted = (): ExtractedData => ({
+  source: { site: 'amiami', itemId: 'FIGURE-42', extractedAt: '2026-08-08T00:00:00.000Z' },
+  fields: { name: 'Fig' },
+  warnings: [],
+});
+
+const ruleset = (extract = jest.fn().mockReturnValue(extracted())): ExtractionRuleset => ({
+  siteId: 'amiami',
+  version: '1.0.0',
+  extract,
+  validate: jest.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }),
+});
+
+const scrapeResult = (over: Partial<ScrapePageResult> = {}): ScrapePageResult => ({
+  html: '<html>ok</html>',
+  url: EXPECTED_URL,
+  title: 'Fig',
+  statusCode: 200,
+  ...over,
+});
+
+const fakeLedger = () => {
+  const done: string[] = [];
+  const failed: string[] = [];
+  return { done, failed, markDone: (id: string) => done.push(id), markFailed: (id: string) => failed.push(id) };
+};
+
+const build = (over: Partial<CrawlWorkerServices> = {}) => {
+  const ledger = fakeLedger();
+  const rs = ruleset();
+  const services: CrawlWorkerServices = {
+    scrape: jest.fn().mockResolvedValue(scrapeResult()),
+    getRulesetForUrl: jest.fn().mockReturnValue(rs),
+    retrievalFor: jest.fn().mockReturnValue(RETRIEVAL),
+    emit: jest.fn().mockResolvedValue({ sourceId: 's1' }),
+    ledger,
+    ...over,
+  };
+  return { services, ledger, rs, worker: assembleCrawlWorker(services) };
+};
+
+describe('assembleCrawlWorker — engine services → crawl worker', () => {
+  it('resolves the byId URL, fetches, extracts, emits, and marks the item done', async () => {
+    const { services, ledger, rs, worker } = build();
+
+    const outcome = await worker(TASK);
+
+    expect(services.retrievalFor).toHaveBeenCalledWith('www.amiami.com');
+    expect(services.scrape).toHaveBeenCalledWith(EXPECTED_URL);
+    expect(services.getRulesetForUrl).toHaveBeenCalledWith(EXPECTED_URL);
+    expect(rs.extract).toHaveBeenCalledWith('<html>ok</html>', EXPECTED_URL, undefined);
+    expect(services.emit).toHaveBeenCalledWith(extracted());
+    expect(ledger.done).toEqual(['FIGURE-42']);
+    expect(outcome).toBe('success');
+  });
+
+  it('routes a 403 (Cloudflare block) to rate-limited — no extract, no emit, item stays pending', async () => {
+    const { services, ledger, rs, worker } = build({
+      scrape: jest.fn().mockResolvedValue(scrapeResult({ statusCode: 403 })),
+    });
+
+    const outcome = await worker(TASK);
+
+    expect(rs.extract).not.toHaveBeenCalled();
+    expect(services.emit).not.toHaveBeenCalled();
+    expect(ledger.done).toEqual([]);
+    expect(ledger.failed).toEqual([]);
+    expect(outcome).toBe('rate-limited');
+  });
+
+  it('routes a 503 (Cloudflare "checking your browser") to rate-limited', async () => {
+    const { services, worker } = build({
+      scrape: jest.fn().mockResolvedValue(scrapeResult({ statusCode: 503 })),
+    });
+
+    expect(await worker(TASK)).toBe('rate-limited');
+    expect(services.emit).not.toHaveBeenCalled();
+  });
+
+  it('a host with no byId retrieval → markFailed + success, without scraping', async () => {
+    const { services, ledger, worker } = build({ retrievalFor: jest.fn().mockReturnValue(undefined) });
+
+    const outcome = await worker(TASK);
+
+    expect(services.scrape).not.toHaveBeenCalled();
+    expect(ledger.failed).toEqual(['FIGURE-42']);
+    expect(outcome).toBe('success');
+  });
+
+  it('threads a resolved ExtractContext into the ruleset extract', async () => {
+    const ctx = { config: {}, scraping: {}, logger: {} } as never;
+    const rs = ruleset();
+    const resolveContext = jest.fn().mockReturnValue(ctx);
+    const { worker } = build({ getRulesetForUrl: jest.fn().mockReturnValue(rs), resolveContext });
+
+    await worker(TASK);
+
+    expect(resolveContext).toHaveBeenCalledWith(TASK, EXPECTED_URL);
+    expect(rs.extract).toHaveBeenCalledWith('<html>ok</html>', EXPECTED_URL, ctx);
+  });
+
+  it('a custom throttleStatuses replaces the CF default (403 then flows through to emit)', async () => {
+    const { services, worker } = build({
+      throttleStatuses: [429],
+      scrape: jest.fn().mockResolvedValue(scrapeResult({ statusCode: 403 })),
+    });
+
+    await worker(TASK);
+
+    expect(services.emit).toHaveBeenCalled();
+  });
+});

--- a/src/driver/assembleCrawlWorker.ts
+++ b/src/driver/assembleCrawlWorker.ts
@@ -1,0 +1,69 @@
+/**
+ * assembleCrawlWorker — the I3 adapter: composes the real engine services into the
+ * `CrawlWorkerDeps` that `makeCrawlWorker` consumes, so the CrawlLoop can run against live
+ * scraping/extraction/emit. It is the ONLY place the driver's pure worker meets concrete engine
+ * services; the worker itself stays service-agnostic (see crawlWorker.ts).
+ *
+ * What it wires:
+ *   - resolveUrl : ProfileRegistry.retrievalFor(host) + resolveByIdUrl → the item URL.
+ *   - fetch      : ScrapingService.scrapePage(url) → { html, statusCode }.
+ *   - lookupRuleset : ExtractionRegistryImpl.getRulesetForUrl(url).
+ *   - emit       : IngestEmitter.send.
+ *   - ledger     : the per-store CoverageLedger.
+ *
+ * CLOUDFLARE NOTE (why the throttle default differs from the worker's): scrapePage does NOT throw
+ * on a Cloudflare challenge — it detects it, waits a bounded re-check, then returns the page with
+ * whatever status came back (see scrapingService.navigateAndCapture). The CF signal is not
+ * surfaced on ScrapePageResult, so the adapter routes CF by STATUS: the throttle default is
+ * [403, 429, 503] (403 = "access denied", 503 = "checking your browser", 429 = rate-limited). A
+ * challenge that returns HTTP 200 with a JS interstitial is NOT caught by status alone — the
+ * precise fix is an explicit `challenged` flag on ScrapePageResult (a small follow-on increment),
+ * which this adapter would then map to 'rate-limited'.
+ */
+import type { CrawlTask, Outcome } from './dispatchScheduler.js';
+import type { CoverageSink } from './crawlWorker.js';
+import { makeCrawlWorker } from './crawlWorker.js';
+import { resolveByIdUrl } from './retrievalPlanner.js';
+import type {
+  ExtractContext,
+  ExtractedData,
+  ExtractionRuleset,
+  RetrievalCapability,
+  ScrapePageResult,
+} from '@figurecollecting/scraper-plugin-contract';
+
+/** Cloudflare block codes (403/503) + rate-limit (429) — the crawl worker's throttle default. */
+const DEFAULT_CRAWL_THROTTLE_STATUSES = [403, 429, 503];
+
+export interface CrawlWorkerServices {
+  /** Page fetch — scrapingService.scrapePage or .scrapePageStealth (caller picks per pool). */
+  scrape: (url: string) => Promise<ScrapePageResult>;
+  /** URL → ruleset (engine ExtractionRegistryImpl.getRulesetForUrl). */
+  getRulesetForUrl: (url: string) => ExtractionRuleset | undefined;
+  /** Host → targeted-retrieval capability (driver ProfileRegistry.retrievalFor). */
+  retrievalFor: (host: string) => RetrievalCapability | undefined;
+  /** Deliver an extraction to the spine (IngestEmitter.send). */
+  emit: (extracted: ExtractedData) => Promise<unknown>;
+  /** Per-store coverage record (markDone / markFailed). */
+  ledger: CoverageSink;
+  /** Optional per-extraction context for multi-query rulesets (I3 supplies it; omit → 2-arg extract). */
+  resolveContext?: (task: CrawlTask, url: string) => ExtractContext | undefined;
+  /** Override the throttle statuses; default [403, 429, 503] (see the CLOUDFLARE NOTE). */
+  throttleStatuses?: number[];
+}
+
+/** Build the CrawlLoop-ready worker from concrete engine services. */
+export function assembleCrawlWorker(services: CrawlWorkerServices): (task: CrawlTask) => Promise<Outcome> {
+  return makeCrawlWorker({
+    resolveUrl: (task) => resolveByIdUrl(services.retrievalFor(task.host), task.id),
+    fetch: async (url) => {
+      const result = await services.scrape(url);
+      return { html: result.html, statusCode: result.statusCode };
+    },
+    lookupRuleset: services.getRulesetForUrl,
+    emit: services.emit,
+    ledger: services.ledger,
+    ...(services.resolveContext ? { resolveContext: services.resolveContext } : {}),
+    throttleStatuses: services.throttleStatuses ?? DEFAULT_CRAWL_THROTTLE_STATUSES,
+  });
+}


### PR DESCRIPTION
## What

`assembleCrawlWorker(services)` — the I3 **adapter** that turns the concrete engine services into the `CrawlWorkerDeps` `makeCrawlWorker` consumes. It's the single seam where the driver's pure worker (#243) meets live scraping/extraction/emit; the worker itself stays service-agnostic.

Wiring:
| Worker port | Engine service |
|---|---|
| `resolveUrl` | `ProfileRegistry.retrievalFor(host)` + `resolveByIdUrl` → item URL |
| `fetch` | `ScrapingService.scrapePage(url)` → `{html, statusCode}` |
| `lookupRuleset` | `ExtractionRegistryImpl.getRulesetForUrl(url)` |
| `emit` | `IngestEmitter.send` |
| `ledger` | the per-store `CoverageLedger` |

## The one substantive decision: Cloudflare → throttle by status

`scrapePage` **does not throw on a Cloudflare challenge** — `navigateAndCapture` (`scrapingService.ts:85-95`) detects it, waits a bounded re-check, then returns the page with whatever status came back; the CF signal isn't surfaced on `ScrapePageResult`. So the adapter routes CF **by status**: the throttle default here is `[403, 429, 503]` (vs the worker's bare `[429,503]`) — 403 "access denied", 503 "checking your browser", 429 rate-limit. These land CF blocks in the **rate-limited/leave-pending** bucket (back off + retry) rather than being burned as `markFailed`.

**Known residual (scoped as a follow-on):** a challenge that returns **HTTP 200** with a JS interstitial isn't caught by status alone. The precise fix is an additive `challenged?: boolean` on `ScrapePageResult` that `scrapePage` sets from its existing `detectChallenge`, which this adapter would map to `rate-limited`. Kept out of this PR to keep it a pure, non-contract-touching composition increment.

## Not yet wired (later I3 increments)

Per-host scrape options (cookies=`cf_clearance`, CF-detection patterns) and per-site `ExtractContext` construction — plus the runtime instantiation (populate `ProfileRegistry` from `allStoreCapabilities()`, enumerate → ledger → scheduler → loop). The runtime + on-cluster soak remain gated on **R12 pg-spine-ingress** and **claims-only-v1**.

## Tests

TDD (RED: module-missing → GREEN). 6 wiring tests (URL resolution, ScrapePageResult→FetchResult mapping, 403/503 CF→throttle, no-retrieval config gap, `ExtractContext` threading, throttle-override). **100% stmt/branch/func/line** on `assembleCrawlWorker.ts`; full driver suite **61/61**; `tsc --noEmit` clean.