### PR TITLE
Crawl driver I3 (#1): seed ProfileRegistry from all registered stores

### DIFF
--- a/src/__tests__/unit/extractionRegistry.test.ts
+++ b/src/__tests__/unit/extractionRegistry.test.ts
@@ -1,5 +1,5 @@
 import { createExtractionRegistry } from '../../services/extractionRegistry';
-import { SiteConfig, ExtractionRuleset, ExtractedData, ValidationResult } from '@figurecollecting/scraper-plugin-contract';
+import { SiteConfig, StoreCapabilities, ExtractionRuleset, ExtractedData, ValidationResult } from '@figurecollecting/scraper-plugin-contract';
 
 function buildSiteConfig(overrides: Partial<SiteConfig> = {}): SiteConfig {
   return {
@@ -109,5 +109,31 @@ describe('ExtractionRegistry', () => {
   it('throws a clear error for a malformed URL rather than crashing silently', () => {
     const registry = createExtractionRegistry();
     expect(() => registry.getSiteConfigForUrl('not-a-url')).toThrow();
+  });
+});
+
+describe('ExtractionRegistry.allStores', () => {
+  it('returns every registered store (the ProfileRegistry source — all of them, no subset)', () => {
+    const registry = createExtractionRegistry();
+    registry.registerSite(buildSiteConfig({ siteId: 'alpha', domains: ['alpha.example.test'] }));
+    registry.registerSite(buildSiteConfig({ siteId: 'beta', domains: ['beta.example.test'] }));
+
+    expect(registry.allStores().map((s) => s.siteId).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  it('is empty before any registration', () => {
+    expect(createExtractionRegistry().allStores()).toEqual([]);
+  });
+
+  it("preserves a store's retrieval axis so it rides through to the ProfileRegistry", () => {
+    const registry = createExtractionRegistry();
+    const caps: StoreCapabilities = {
+      ...buildSiteConfig({ siteId: 'amiami', domains: ['amiami.com'] }),
+      retrieval: { byId: { urlTemplate: 'https://amiami.com/detail/{id}' } },
+    };
+    registry.registerSite(caps);
+
+    const stored = registry.allStores().find((s) => s.siteId === 'amiami');
+    expect(stored?.retrieval?.byId?.urlTemplate).toBe('https://amiami.com/detail/{id}');
   });
 });

--- a/src/driver/__tests__/buildProfileRegistry.test.ts
+++ b/src/driver/__tests__/buildProfileRegistry.test.ts
@@ -1,0 +1,53 @@
+/**
+ * buildProfileRegistry — populates a driver ProfileRegistry from the public StoreCapabilities the
+ * engine holds (ExtractionRegistryImpl.allStores()). Every store flows in: pool + rate come from
+ * the SiteConfig base (so all stores are schedulable), retrieval rides through when present.
+ */
+import { buildProfileRegistry } from '../profileRegistry';
+import type { StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+
+const caps = (over: Partial<StoreCapabilities> & { siteId: string; domains: string[] }): StoreCapabilities => ({
+  name: over.siteId,
+  rateLimit: {
+    domain: over.domains[0],
+    baseDelayMs: 1000,
+    minDelayMs: 250,
+    maxDelayMs: 60000,
+    backoffMultiplier: 2,
+    recoveryDivisor: 2,
+    successThreshold: 3,
+  },
+  requiresBrowser: false,
+  allowedCookies: [],
+  ...over,
+});
+
+describe('buildProfileRegistry', () => {
+  it('indexes every store by host for scheduling — pool from requiresBrowser, rate from rateLimit', () => {
+    const reg = buildProfileRegistry([
+      caps({ siteId: 'amiami', domains: ['www.amiami.com'], requiresBrowser: true }),
+      caps({ siteId: 'hobbysearch', domains: ['hobbysearch.co.jp'] }),
+    ]);
+
+    expect(reg.size()).toBe(2);
+    expect(reg.poolFor('www.amiami.com')).toBe('browser');
+    expect(reg.poolFor('hobbysearch.co.jp')).toBe('fetch');
+    expect(reg.rateConfigFor('www.amiami.com')?.baseDelayMs).toBe(1000);
+  });
+
+  it('carries retrieval through to retrievalFor', () => {
+    const reg = buildProfileRegistry([
+      caps({
+        siteId: 'amiami',
+        domains: ['www.amiami.com'],
+        retrieval: { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}' } },
+      }),
+    ]);
+
+    expect(reg.retrievalFor('www.amiami.com')?.byId?.urlTemplate).toContain('{id}');
+  });
+
+  it('empty input → empty registry', () => {
+    expect(buildProfileRegistry([]).size()).toBe(0);
+  });
+});

--- a/src/driver/profileRegistry.ts
+++ b/src/driver/profileRegistry.ts
@@ -66,3 +66,14 @@ export class ProfileRegistry {
     return this.forHost(host)?.retrieval;
   }
 }
+
+/**
+ * Build a ProfileRegistry from the engine's registered stores (ExtractionRegistryImpl.allStores()).
+ * Every store is indexed — pool + rate from the SiteConfig base make it schedulable; retrieval
+ * rides through for stores whose profile carries it. This is the driver's single population seam.
+ */
+export function buildProfileRegistry(stores: Iterable<StoreCapabilities>): ProfileRegistry {
+  const registry = new ProfileRegistry();
+  for (const caps of stores) registry.register(caps);
+  return registry;
+}

--- a/src/services/extractionRegistry.ts
+++ b/src/services/extractionRegistry.ts
@@ -11,11 +11,15 @@
 import {
   ExtractionRegistry,
   SiteConfig,
+  StoreCapabilities,
   ExtractionRuleset,
 } from '@figurecollecting/scraper-plugin-contract';
 
 export class ExtractionRegistryImpl implements ExtractionRegistry {
-  private readonly sites = new Map<string, SiteConfig>();
+  // Stored as StoreCapabilities (SiteConfig + optional retrieval): a plain SiteConfig registered
+  // via registerSite is a valid StoreCapabilities, and a retrieval-bearing one rides through
+  // unchanged — so allStores() can seed the driver's ProfileRegistry without a second registry.
+  private readonly sites = new Map<string, StoreCapabilities>();
   private readonly rulesets = new Map<string, ExtractionRuleset>();
   /** hostname (lowercased) -> siteId */
   private readonly hostnameIndex = new Map<string, string>();
@@ -34,6 +38,15 @@ export class ExtractionRegistryImpl implements ExtractionRegistry {
   getSiteConfigForUrl(url: string): SiteConfig | undefined {
     const siteId = this.resolveSiteId(url);
     return siteId ? this.sites.get(siteId) : undefined;
+  }
+
+  /**
+   * Every registered store as public StoreCapabilities — the source the crawl driver builds its
+   * ProfileRegistry from (all stores, no subset). `retrieval` is present for stores whose plugin
+   * registered a retrieval-bearing capability, absent (enumeration-only) otherwise.
+   */
+  allStores(): StoreCapabilities[] {
+    return [...this.sites.values()];
   }
 
   getRulesetForUrl(url: string): ExtractionRuleset | undefined {


### PR DESCRIPTION
## What

The engine-side consumer that populates the driver's `ProfileRegistry` from the plugin's registered stores — **all 26, no subset**.

Two small additions, **no contract change, no new `registerSite` calls** (so the plugin's `plugin.test.ts` count stays 26):

- **`ExtractionRegistryImpl.allStores(): StoreCapabilities[]`** — the registry's internal `sites` map is widened from `SiteConfig` to `StoreCapabilities` (a plain `SiteConfig` *is* a valid `StoreCapabilities` with `retrieval` absent; a retrieval-bearing one rides through unchanged). `allStores()` returns them all. This reuses the map the registry already keeps — no second registry, no moat leak (`StoreCapabilities` is the public shape).
- **`buildProfileRegistry(stores): ProfileRegistry`** — the driver's single population seam: indexes every store by host so it's schedulable (pool from `requiresBrowser`, rate from `rateLimit`), carrying `retrieval` through when present.

## All stores vs retrieval

`allStores()` enumerates the whole map, so **every** registered store becomes schedulable. Targeted `retrieval` (byId/search) is currently populated for **amiami only** (the one profile with a `retrieval` axis); the other 25 are enumeration-only until their templates are backfilled per-store. That's data authoring, not a wiring limit — this consumer handles all 26 the moment their profiles carry retrieval.

## Sequencing

This is **#1** of the remaining I3 work (order 1→3→2). Next: **#1b** (plugin registers retrieval-bearing `StoreCapabilities` so `retrievalFor` populates for more than amiami), then **#2** the runtime instantiation (discover plugins → register → `buildProfileRegistry(reg.allStores())` → `assembleScheduler` → `CrawlLoop.run()` with `assembleCrawlWorker`), gated on the on-cluster **R12** check.

## Tests

TDD (RED: `allStores`/`buildProfileRegistry` undefined → GREEN). 6 new tests (all-stores enumeration, empty, retrieval-preservation; ProfileRegistry pool/rate/retrieval indexing, empty). **`profileRegistry.ts` 100%**; `extractionRegistry.ts` new code 100% (file 95.45% — the one uncovered line is a pre-existing subdomain-fallback branch, untouched here). Full driver + unit regression **507 passed / 3 todo, 41 suites**; `tsc --noEmit` clean.