### PR TITLE
Crawl driver runtime (#2): assembleCrawlDriver — the end-to-end crawl

### DIFF
--- a/src/driver/__tests__/assembleCrawlDriver.test.ts
+++ b/src/driver/__tests__/assembleCrawlDriver.test.ts
@@ -1,0 +1,109 @@
+/**
+ * assembleCrawlDriver — the crawl driver's end-to-end runtime. These tests drive the WHOLE chain
+ * with fakes (ProfileRegistry ← allStores → scheduler → ledger → worker → loop → emit) and assert
+ * the composition runs a site's items through fetch → extract → emit and records coverage. The
+ * loop/throttle mechanics themselves are covered by crawlLoop.test.ts; a zero-delay rate config
+ * keeps these deterministic and focused on wiring.
+ */
+import { assembleCrawlDriver, type CrawlDriverServices } from '../assembleCrawlDriver';
+import type {
+  ExtractedData,
+  ExtractionRuleset,
+  ScrapePageResult,
+  StoreCapabilities,
+} from '@figurecollecting/scraper-plugin-contract';
+
+const AMIAMI: StoreCapabilities = {
+  siteId: 'amiami',
+  name: 'AmiAmi',
+  domains: ['www.amiami.com'],
+  // zero-delay: the assembly test is about wiring, not throttle timing.
+  rateLimit: {
+    domain: 'www.amiami.com',
+    baseDelayMs: 0,
+    minDelayMs: 0,
+    maxDelayMs: 100,
+    backoffMultiplier: 2,
+    recoveryDivisor: 2,
+    successThreshold: 3,
+  },
+  requiresBrowser: false,
+  allowedCookies: [],
+  retrieval: { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } },
+};
+
+const gcodeOf = (url: string) => new URL(url).searchParams.get('gcode') as string;
+
+const extracted = (id: string): ExtractedData => ({
+  source: { site: 'amiami', itemId: id, extractedAt: '2026-08-09T00:00:00.000Z' },
+  fields: { name: `fig-${id}` },
+  warnings: [],
+});
+
+const ruleset = (extract: ExtractionRuleset['extract']): ExtractionRuleset => ({
+  siteId: 'amiami',
+  version: '1.0.0',
+  extract,
+  validate: () => ({ valid: true, errors: [], warnings: [] }),
+});
+
+const build = (over: Partial<CrawlDriverServices> = {}) => {
+  const sends: ExtractedData[] = [];
+  const services: CrawlDriverServices = {
+    extraction: {
+      allStores: () => [AMIAMI],
+      getRulesetForUrl: () => ruleset((_html, url) => extracted(gcodeOf(url))),
+    },
+    scrape: jest.fn(async (url: string): Promise<ScrapePageResult> => ({ html: '<html/>', url, title: '', statusCode: 200 })),
+    emit: jest.fn(async (e: ExtractedData) => { sends.push(e); return {}; }),
+    now: () => 0,
+    sleep: async () => {},
+    capacity: { browser: 1, fetch: 2 },
+    ...over,
+  };
+  return { services, sends, driver: assembleCrawlDriver(services) };
+};
+
+describe('assembleCrawlDriver — end-to-end crawl runtime', () => {
+  it('crawls a site: resolves byId, fetches, extracts, emits, marks coverage complete', async () => {
+    const { services, sends, driver } = build();
+
+    const result = await driver.crawlSite('amiami', ['A1', 'A2', 'A3']);
+
+    expect(services.scrape).toHaveBeenCalledTimes(3);
+    expect(services.scrape).toHaveBeenCalledWith('https://www.amiami.com/eng/detail/?gcode=A1');
+    expect(sends.map((e) => e.source.itemId).sort()).toEqual(['A1', 'A2', 'A3']);
+    expect(result.coverage.done).toBe(3);
+    expect(result.coverage.total).toBe(3);
+    expect(result.complete).toBe(true);
+    expect(result.stats.dispatched).toBe(3);
+  });
+
+  it('a failed extract marks that item failed (coverage incomplete); the others still emit', async () => {
+    const rs = ruleset((_html, url) => {
+      const id = gcodeOf(url);
+      if (id === 'A2') throw new Error('parse fail');
+      return extracted(id);
+    });
+    const { sends, driver } = build({
+      extraction: { allStores: () => [AMIAMI], getRulesetForUrl: () => rs },
+    });
+
+    const result = await driver.crawlSite('amiami', ['A1', 'A2', 'A3']);
+
+    expect(sends.map((e) => e.source.itemId).sort()).toEqual(['A1', 'A3']);
+    expect(result.coverage.done).toBe(2);
+    expect(result.coverage.failed).toBe(1);
+    expect(result.complete).toBe(false);
+  });
+
+  it('throws for a site with no registered profile', async () => {
+    const { driver } = build();
+    await expect(driver.crawlSite('nope', ['x'])).rejects.toThrow(/nope/);
+  });
+
+  it('exposes the ProfileRegistry built from allStores()', () => {
+    const { driver } = build();
+    expect(driver.profiles.retrievalFor('www.amiami.com')?.byId?.urlTemplate).toContain('{id}');
+  });
+});

--- a/src/driver/assembleCrawlDriver.ts
+++ b/src/driver/assembleCrawlDriver.ts
@@ -1,0 +1,102 @@
+/**
+ * assembleCrawlDriver — the crawl driver's top-level RUNTIME (2b I3/#2). It composes every merged
+ * primitive into a runnable crawl:
+ *
+ *   allStores() → buildProfileRegistry → assembleScheduler (per-host throttle + per-pool capacity)
+ *   CoverageLedger(siteId) seeded with the item ids → the task source
+ *   assembleCrawlWorker (fetch → catch-gated extract → emit) bound to that ledger
+ *   CrawlLoop.run() drains the scheduler, settling each outcome back for backoff/recovery
+ *
+ * `crawlSite(siteId, itemIds)` is the atomic unit — ONE store, ONE ledger, ONE loop (the
+ * currency/backfill "cover store X's frontier" shape). Multi-site is a sequential wrapper over it
+ * (shared-nothing pool budgets); the cross-store SEARCH runtime is a separate composition over the
+ * retrievalPlanner. All effects are injected (scrape/emit/now/sleep) so the runtime is testable
+ * with fakes and a virtual clock — the real ScrapingService / ExtractionRegistryImpl /
+ * IngestEmitter wire in at the engine entrypoint.
+ *
+ * NOTE (scoped follow-ons): a single pass does not re-dispatch a rate-limited task — it stays
+ * pending in the ledger for a resume pass (CoverageLedger.remaining()); and `scrape` here is one
+ * fetch fn — per-pool stealth selection (browser pool → scrapePageStealth) and per-site
+ * ExtractContext are later refinements.
+ */
+import { buildProfileRegistry, type ProfileRegistry } from './profileRegistry.js';
+import { assembleScheduler } from './assembleScheduler.js';
+import { assembleCrawlWorker } from './assembleCrawlWorker.js';
+import { CrawlLoop, type CrawlLoopStats } from './crawlLoop.js';
+import { CoverageLedger, type CoverageCounts } from './coverageLedger.js';
+import type { PoolCapacity } from './poolRouter.js';
+import type {
+  ExtractedData,
+  ExtractionRuleset,
+  ScrapePageResult,
+  StoreCapabilities,
+} from '@figurecollecting/scraper-plugin-contract';
+
+export interface CrawlDriverServices {
+  /** Engine registry: the registered stores (→ ProfileRegistry) + URL→ruleset lookup. */
+  extraction: {
+    allStores: () => StoreCapabilities[];
+    getRulesetForUrl: (url: string) => ExtractionRuleset | undefined;
+  };
+  /** Page fetch — scrapingService.scrapePage (or .scrapePageStealth for browser-pool stores). */
+  scrape: (url: string) => Promise<ScrapePageResult>;
+  /** Deliver an extraction to the spine (IngestEmitter.send). */
+  emit: (extracted: ExtractedData) => Promise<unknown>;
+  /** Injected clock + sleep (real: Date.now / setTimeout); keeps the loop deterministic in tests. */
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  /** Per-pool worker capacity (browser/fetch), sized vs the crawl-rate budget. */
+  capacity: PoolCapacity;
+}
+
+export interface CrawlSiteResult {
+  siteId: string;
+  stats: CrawlLoopStats;
+  coverage: CoverageCounts;
+  complete: boolean;
+  ledger: CoverageLedger;
+}
+
+export interface CrawlDriver {
+  /** The ProfileRegistry built from the engine's registered stores. */
+  readonly profiles: ProfileRegistry;
+  /** Crawl one store's items end-to-end (fetch → extract → emit), returning coverage. */
+  crawlSite(siteId: string, itemIds: string[]): Promise<CrawlSiteResult>;
+}
+
+export function assembleCrawlDriver(services: CrawlDriverServices): CrawlDriver {
+  const profiles = buildProfileRegistry(services.extraction.allStores());
+
+  return {
+    profiles,
+
+    async crawlSite(siteId, itemIds) {
+      const caps = profiles.forSite(siteId);
+      if (!caps) throw new Error(`assembleCrawlDriver: no registered profile for site '${siteId}'`);
+      const host = caps.domains[0];
+
+      const ledger = new CoverageLedger(siteId);
+      ledger.add(itemIds);
+
+      const worker = assembleCrawlWorker({
+        scrape: services.scrape,
+        getRulesetForUrl: services.extraction.getRulesetForUrl,
+        retrievalFor: (h) => profiles.retrievalFor(h),
+        emit: services.emit,
+        ledger,
+      });
+
+      const { scheduler } = assembleScheduler(profiles, services.capacity);
+      // Seed from remaining() (pending + retryable-failed) so a restored ledger resumes cleanly.
+      for (const id of ledger.remaining()) scheduler.enqueue({ id, host });
+
+      const stats = await new CrawlLoop(scheduler, {
+        now: services.now,
+        sleep: services.sleep,
+        worker,
+      }).run();
+
+      return { siteId, stats, coverage: ledger.counts(), complete: ledger.isComplete(), ledger };
+    },
+  };
+}


### PR DESCRIPTION
## What

`assembleCrawlDriver` — the crawl driver's top-level **runtime**, composing every merged primitive into a runnable crawl:

```
allStores() → buildProfileRegistry → assembleScheduler (per-host throttle + per-pool capacity)
CoverageLedger(siteId) seeded with item ids  → the task source
assembleCrawlWorker (fetch → catch-gated extract → emit)  bound to that ledger
CrawlLoop.run()  drains the scheduler, settling each outcome for backoff/recovery
```

`crawlSite(siteId, itemIds)` is the atomic unit — **one store, one ledger, one loop** (the currency/backfill "cover store X's frontier" shape). All effects are injected (`scrape`/`emit`/`now`/`sleep`), so the runtime is deterministically testable; the real `ScrapingService`/`ExtractionRegistryImpl`/`IngestEmitter` wire in at the engine entrypoint.

## Design note — single-site is the atomic unit, not a limitation
The `CoverageLedger` is per-store and the worker marks it by bare `id`, so a *shared* multi-site loop would need the worker to route by `(host,id)` — a change to already-merged code. `crawlSite()` keeps it clean; multi-site is a thin sequential wrapper (shared-nothing pool budgets), and the cross-store **search** runtime is a separate composition over `retrievalPlanner`.

## Scoped follow-ons (noted in the header)
- A single pass doesn't re-dispatch a rate-limited task — it stays pending in the ledger for a resume pass (`remaining()`).
- `scrape` is one fetch fn; per-pool stealth selection (browser pool → `scrapePageStealth`) and per-site `ExtractContext` are later refinements.
- The **entrypoint** (wire the real engine services + a trigger route/job) + the on-cluster soak (R12 is green) is the final glue increment.

## Tests
TDD. 4 tests drive the whole chain with fakes + a zero-delay rate config (focus on wiring, not throttle timing — that's `crawlLoop.test.ts`'s job): happy-path (3 items → 3 emits → coverage complete), failed-extract (marks that item failed, others still emit), unknown-site throws, ProfileRegistry exposed. **100% stmt/branch/func/line** on `assembleCrawlDriver.ts`; full driver suite **68/68**; `tsc` clean.