### PR TITLE
Add SearchCandidate + ExtractionRuleset.extractCandidates (contract 0.3.0)

### DIFF
--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figurecollecting/scraper-plugin-contract",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -257,6 +257,19 @@ export interface ExtractionRuleset {
    */
   extract(html: string, url: string, ctx?: ExtractContext): ExtractedData | Promise<ExtractedData>;
   validate(data: ExtractedData): ValidationResult;
+  /**
+   * OPTIONAL: parse a SEARCH-results response body (fetched from the store's `retrieval.bySearch`
+   * endpoint) into candidate items for cross-store lookup — the buy-decision fan-out. Distinct
+   * from `extract()`, which parses ONE product page: this turns a results LIST (Shopify predictive
+   * `suggest.json`, a WooCommerce Store API product array, or an HTML results grid) into
+   * `SearchCandidate[]`. Stores that support targeted search implement it; search-less stores omit
+   * it. Async-capable like `extract()` — the engine always awaits the result.
+   */
+  extractCandidates?(
+    body: string,
+    url: string,
+    ctx?: ExtractContext,
+  ): SearchCandidate[] | Promise<SearchCandidate[]>;
 }
 
 /**
@@ -281,6 +294,20 @@ export interface ValidationResult {
   valid: boolean;
   errors: string[];
   warnings: string[];
+}
+
+/**
+ * A single hit from a store's SEARCH (`bySearch`) results — the cross-store buy-decision entry.
+ * Carries just enough to (a) show/compare and (b) re-fetch the full record: `itemId` feeds the
+ * store's `retrieval.byId`, `name` drives name/ER matching, `url` links the product page. A JAN is
+ * deliberately NOT required here — search hits are often title-indexed, so the barcode is resolved
+ * by the follow-up `byId` fetch. `priceRaw` is the price string when the hit carries one (Shopify).
+ */
+export interface SearchCandidate {
+  itemId: string;
+  name: string;
+  url?: string;
+  priceRaw?: string;
 }
 
 export interface RuntimeConfig {


### PR DESCRIPTION
## What

Extends the plugin contract so search-result parsing becomes a **first-class ruleset capability** (the moat home, not engine glue) — the foundation for the cross-store buy-decision lookup.

- **`ExtractionRuleset.extractCandidates?(body, url, ctx?)`** — OPTIONAL, async-capable. Parses a **search-results** body (Shopify `suggest.json`, a Woo Store API product array, or an HTML results grid) into `SearchCandidate[]`. Distinct from `extract()` (one product page). Search-less stores simply omit it.
- **`SearchCandidate { itemId, name, url?, priceRaw? }`** — a search hit carrying just enough to (a) compare and (b) re-fetch the full record: `itemId` feeds the store's `retrieval.byId`, `name` drives name/ER matching. A JAN is deliberately *not* required — search hits are often title-indexed, so the barcode resolves on the follow-up `byId`.

**Additive + optional** → non-breaking; stays `ingest.v1`-compatible. Version bumped **0.2.0 → 0.3.0**.

## Verified
Contract builds clean; `SearchCandidate`/`extractCandidates` present in `dist/index.d.ts`; the engine (`file:`-linked) typechecks against it (`tsc` exit 0).

## Why it matters / next
Unblocks: (2) rulesets implement `extractCandidates` for the live-verified Tier-1 stores (one Shopify parser, one Woo parser, reused across the 5), (3) the engine `assembleLookup` runtime (`planRetrieval(lookup)` → fetch → `extractCandidates` → candidates). **Merging this auto-publishes 0.3.0**, which the ruleset PR needs.