### PR TITLE
Cross-store search runtime with orderable/listed modes (contract 0.3.1)

### DIFF
--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figurecollecting/scraper-plugin-contract",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -213,8 +213,15 @@ export interface RetrievalCapability {
   byRange?: boolean;
   /** One endpoint returns up to `maxBatch` items per call (cheaper than N by-id fetches). */
   byBatch?: { maxBatch: number };
-  /** Map a free-text query (name/keyword) to candidate items; `{q}` is substituted. */
-  bySearch?: { urlTemplate: string };
+  /**
+   * Map a free-text query (name/keyword) to candidate items; `{q}` is substituted. `scope`
+   * declares what the endpoint returns: `listed` = ALL matching items incl. sold-out (the
+   * superset — answers "which stores carry this"); `orderable` = only in-stock/buyable items
+   * (some stores' predictive endpoints, e.g. a Shopify `suggest.json` config, silently hide
+   * sold-out). Absent scope defaults to `listed`. A `listed` endpoint + `SearchCandidate.available`
+   * serves BOTH buy-decision modes; an `orderable`-only endpoint cannot answer the `listed` view.
+   */
+  bySearch?: { urlTemplate: string; scope?: 'listed' | 'orderable' };
 }
 
 /**
@@ -308,6 +315,14 @@ export interface SearchCandidate {
   name: string;
   url?: string;
   priceRaw?: string;
+  /**
+   * Orderable status of this hit: `true` = in-stock/buyable, `false` = sold-out, `undefined` =
+   * unknown (the endpoint didn't say). Drives the lookup's two modes — `orderable` keeps
+   * `available !== false`, `listed` keeps all. Distinct from mere presence: a listed store may
+   * carry an item that's currently sold-out (still valuable signal: restock / secondhand / price
+   * history).
+   */
+  available?: boolean;
 }
 
 export interface RuntimeConfig {

--- a/src/driver/__tests__/assembleLookup.test.ts
+++ b/src/driver/__tests__/assembleLookup.test.ts
@@ -1,0 +1,124 @@
+/**
+ * assembleLookup — the cross-store SEARCH (buy-decision) fan-out. Drives it with fakes shaped like
+ * the live-verified Tier-1 responses (Shopify predictive suggest.json + Woo Store API array) and
+ * asserts it fans across the bySearch stores, parses candidates via each ruleset's
+ * extractCandidates, and reports honest coverage gaps (no-search / no-parser / errored).
+ */
+import { assembleLookup, type LookupServices } from '../assembleLookup';
+import { buildProfileRegistry } from '../profileRegistry';
+import type {
+  ExtractionRuleset,
+  SearchCandidate,
+  StoreCapabilities,
+} from '@figurecollecting/scraper-plugin-contract';
+
+const caps = (siteId: string, host: string, retrieval: StoreCapabilities['retrieval']): StoreCapabilities => ({
+  siteId,
+  name: siteId,
+  domains: [host],
+  rateLimit: { domain: host, baseDelayMs: 0, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+  requiresBrowser: false,
+  allowedCookies: [],
+  retrieval,
+});
+
+const GOODSMILEUS = caps('goodsmileus', 'www.goodsmileus.com', {
+  bySearch: { urlTemplate: 'https://www.goodsmileus.com/search/suggest.json?q={q}&resources[type]=product' },
+});
+const SUGOTOYS = caps('sugotoys', 'sugotoys.com.au', {
+  bySearch: { urlTemplate: 'https://sugotoys.com.au/wp-json/wc/store/v1/products?search={q}&per_page=20' },
+});
+const CDJAPAN = caps('cdjapan', 'www.cdjapan.co.jp', {
+  byId: { urlTemplate: 'https://www.cdjapan.co.jp/product/{id}', idKind: 'store-internal' },
+});
+
+const stub = (siteId: string, extractCandidates?: ExtractionRuleset['extractCandidates']): ExtractionRuleset => ({
+  siteId,
+  version: '1.0.0',
+  extract: () => ({ source: { site: siteId, itemId: 'x', extractedAt: '2026-08-09T00:00:00.000Z' }, fields: {}, warnings: [] }),
+  validate: () => ({ valid: true, errors: [], warnings: [] }),
+  ...(extractCandidates ? { extractCandidates } : {}),
+});
+
+// Shopify predictive suggest.json shape → candidates.
+const shopifyParse: ExtractionRuleset['extractCandidates'] = (body): SearchCandidate[] =>
+  (JSON.parse(body).resources.results.products as Array<{ handle: string; title: string; url: string; price: string }>)
+    .map((p) => ({ itemId: p.handle, name: p.title, url: p.url, priceRaw: p.price }));
+
+// Woo Store API product array → candidates.
+const wooParse: ExtractionRuleset['extractCandidates'] = (body): SearchCandidate[] =>
+  (JSON.parse(body) as Array<{ id: number; name: string; permalink: string }>)
+    .map((p) => ({ itemId: String(p.id), name: p.name, url: p.permalink }));
+
+const build = (over: Partial<LookupServices> = {}) => {
+  const fetchBody = jest.fn(async (url: string): Promise<string> => {
+    if (url.includes('goodsmileus')) {
+      return JSON.stringify({ resources: { results: { products: [
+        { handle: 'gs-collection-gyaru-tomie-x-hello-kitty', title: 'GS Collection Gyaru Tomie x Hello Kitty', url: '/products/gs-collection-gyaru-tomie-x-hello-kitty', price: '5800' },
+      ] } } });
+    }
+    if (url.includes('sugotoys')) {
+      return JSON.stringify([{ id: 1118911, name: 'Tomie Figure', permalink: 'https://sugotoys.com.au/product/tomie' }]);
+    }
+    return '[]';
+  });
+  const services: LookupServices = {
+    profiles: buildProfileRegistry([GOODSMILEUS, SUGOTOYS, CDJAPAN]),
+    getRulesetForUrl: (url) =>
+      url.includes('goodsmileus') ? stub('goodsmileus', shopifyParse)
+      : url.includes('sugotoys') ? stub('sugotoys', wooParse)
+      : undefined,
+    fetchBody,
+    ...over,
+  };
+  return { services, fetchBody, lookup: assembleLookup(services) };
+};
+
+describe('assembleLookup — cross-store buy-decision search', () => {
+  it('fans across bySearch stores, parses candidates, and lists no-search stores as unsupported', async () => {
+    const { services, fetchBody, lookup } = build();
+
+    const out = await lookup.lookup('tomie');
+
+    // Fanned to both bySearch stores (query url-encoded into {q}); cdjapan (byId only) not fetched.
+    expect(fetchBody).toHaveBeenCalledWith('https://www.goodsmileus.com/search/suggest.json?q=tomie&resources[type]=product');
+    expect(fetchBody).toHaveBeenCalledWith('https://sugotoys.com.au/wp-json/wc/store/v1/products?search=tomie&per_page=20');
+
+    const gs = out.results.find((r) => r.siteId === 'goodsmileus');
+    expect(gs?.candidates[0]).toEqual({
+      itemId: 'gs-collection-gyaru-tomie-x-hello-kitty',
+      name: 'GS Collection Gyaru Tomie x Hello Kitty',
+      url: '/products/gs-collection-gyaru-tomie-x-hello-kitty',
+      priceRaw: '5800',
+    });
+    expect(out.results.find((r) => r.siteId === 'sugotoys')?.candidates[0].name).toBe('Tomie Figure');
+    expect(out.unsupported).toContain('cdjapan');
+    expect(out.failed).toEqual([]);
+  });
+
+  it('a bySearch store whose ruleset lacks extractCandidates is unsupported (not fetched)', async () => {
+    const { fetchBody, lookup } = build({
+      getRulesetForUrl: (url) => (url.includes('sugotoys') ? stub('sugotoys', wooParse) : stub('goodsmileus')), // no shopify parser
+    });
+
+    const out = await lookup.lookup('miku');
+
+    expect(out.unsupported).toContain('goodsmileus');
+    expect(fetchBody).not.toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
+    expect(out.results.map((r) => r.siteId)).toEqual(['sugotoys']);
+  });
+
+  it('a store whose search fetch throws is reported failed, not silently dropped', async () => {
+    const { lookup } = build({
+      fetchBody: jest.fn(async (url: string) => {
+        if (url.includes('goodsmileus')) throw new Error('CF block');
+        return JSON.stringify([{ id: 1, name: 'Tomie', permalink: 'u' }]);
+      }),
+    });
+
+    const out = await lookup.lookup('tomie');
+
+    expect(out.failed).toContain('goodsmileus');
+    expect(out.results.map((r) => r.siteId)).toEqual(['sugotoys']);
+  });
+});

--- a/src/driver/__tests__/assembleLookup.test.ts
+++ b/src/driver/__tests__/assembleLookup.test.ts
@@ -1,8 +1,8 @@
 /**
- * assembleLookup — the cross-store SEARCH (buy-decision) fan-out. Drives it with fakes shaped like
- * the live-verified Tier-1 responses (Shopify predictive suggest.json + Woo Store API array) and
- * asserts it fans across the bySearch stores, parses candidates via each ruleset's
- * extractCandidates, and reports honest coverage gaps (no-search / no-parser / errored).
+ * assembleLookup — the cross-store SEARCH (buy-decision) fan-out, in both modes. `listed` returns
+ * every carried item (incl. sold-out) with a coverage caveat for orderable-scope stores;
+ * `orderable` filters to in-stock. Fakes model the two shapes: a listed store with a sold-out hit,
+ * and an orderable-scope store (predictive endpoint that hides sold-out — the solaris case).
  */
 import { assembleLookup, type LookupServices } from '../assembleLookup';
 import { buildProfileRegistry } from '../profileRegistry';
@@ -22,15 +22,26 @@ const caps = (siteId: string, host: string, retrieval: StoreCapabilities['retrie
   retrieval,
 });
 
+// goodsmileus: LISTED full-search — carries an in-stock item AND a sold-out one.
 const GOODSMILEUS = caps('goodsmileus', 'www.goodsmileus.com', {
-  bySearch: { urlTemplate: 'https://www.goodsmileus.com/search/suggest.json?q={q}&resources[type]=product' },
+  bySearch: { urlTemplate: 'https://www.goodsmileus.com/search?q={q}&type=product', scope: 'listed' },
 });
-const SUGOTOYS = caps('sugotoys', 'sugotoys.com.au', {
-  bySearch: { urlTemplate: 'https://sugotoys.com.au/wp-json/wc/store/v1/products?search={q}&per_page=20' },
+// solaris: ORDERABLE-scope predictive endpoint — hides sold-out (returns only in-stock).
+const SOLARIS = caps('solaris', 'solarisjapan.com', {
+  bySearch: { urlTemplate: 'https://solarisjapan.com/search/suggest.json?q={q}&resources[type]=product', scope: 'orderable' },
 });
+// cdjapan: byId only, no search.
 const CDJAPAN = caps('cdjapan', 'www.cdjapan.co.jp', {
   byId: { urlTemplate: 'https://www.cdjapan.co.jp/product/{id}', idKind: 'store-internal' },
 });
+
+const GSUS_CANDIDATES: SearchCandidate[] = [
+  { itemId: 'junji-ito-nendoroid-tomie', name: 'Junji Ito Maniac Nendoroid Tomie', url: '/products/nendo', priceRaw: '47.99', available: true },
+  { itemId: 'gs-collection-gyaru-tomie-x-hello-kitty', name: 'GS Collection Gyaru Tomie x Hello Kitty Figure', url: '/products/gyaru', priceRaw: '149.99', available: false },
+];
+const SOLARIS_CANDIDATES: SearchCandidate[] = [
+  { itemId: 'kawakami-tomie-nendoroid', name: 'Itou Junji: Maniac - Kawakami Tomie - Nendoroid', available: true },
+];
 
 const stub = (siteId: string, extractCandidates?: ExtractionRuleset['extractCandidates']): ExtractionRuleset => ({
   siteId,
@@ -40,33 +51,13 @@ const stub = (siteId: string, extractCandidates?: ExtractionRuleset['extractCand
   ...(extractCandidates ? { extractCandidates } : {}),
 });
 
-// Shopify predictive suggest.json shape → candidates.
-const shopifyParse: ExtractionRuleset['extractCandidates'] = (body): SearchCandidate[] =>
-  (JSON.parse(body).resources.results.products as Array<{ handle: string; title: string; url: string; price: string }>)
-    .map((p) => ({ itemId: p.handle, name: p.title, url: p.url, priceRaw: p.price }));
-
-// Woo Store API product array → candidates.
-const wooParse: ExtractionRuleset['extractCandidates'] = (body): SearchCandidate[] =>
-  (JSON.parse(body) as Array<{ id: number; name: string; permalink: string }>)
-    .map((p) => ({ itemId: String(p.id), name: p.name, url: p.permalink }));
-
 const build = (over: Partial<LookupServices> = {}) => {
-  const fetchBody = jest.fn(async (url: string): Promise<string> => {
-    if (url.includes('goodsmileus')) {
-      return JSON.stringify({ resources: { results: { products: [
-        { handle: 'gs-collection-gyaru-tomie-x-hello-kitty', title: 'GS Collection Gyaru Tomie x Hello Kitty', url: '/products/gs-collection-gyaru-tomie-x-hello-kitty', price: '5800' },
-      ] } } });
-    }
-    if (url.includes('sugotoys')) {
-      return JSON.stringify([{ id: 1118911, name: 'Tomie Figure', permalink: 'https://sugotoys.com.au/product/tomie' }]);
-    }
-    return '[]';
-  });
+  const fetchBody = jest.fn(async () => '{}');
   const services: LookupServices = {
-    profiles: buildProfileRegistry([GOODSMILEUS, SUGOTOYS, CDJAPAN]),
+    profiles: buildProfileRegistry([GOODSMILEUS, SOLARIS, CDJAPAN]),
     getRulesetForUrl: (url) =>
-      url.includes('goodsmileus') ? stub('goodsmileus', shopifyParse)
-      : url.includes('sugotoys') ? stub('sugotoys', wooParse)
+      url.includes('goodsmileus') ? stub('goodsmileus', () => GSUS_CANDIDATES)
+      : url.includes('solaris') ? stub('solaris', () => SOLARIS_CANDIDATES)
       : undefined,
     fetchBody,
     ...over,
@@ -74,51 +65,74 @@ const build = (over: Partial<LookupServices> = {}) => {
   return { services, fetchBody, lookup: assembleLookup(services) };
 };
 
-describe('assembleLookup — cross-store buy-decision search', () => {
-  it('fans across bySearch stores, parses candidates, and lists no-search stores as unsupported', async () => {
-    const { services, fetchBody, lookup } = build();
+const bySite = (r: Awaited<ReturnType<ReturnType<typeof build>['lookup']['lookup']>>, id: string) =>
+  r.results.find((x) => x.siteId === id);
+
+describe('assembleLookup — cross-store buy-decision search, listed + orderable modes', () => {
+  it('listed mode (default): returns sold-out items too, and flags orderable-scope stores', async () => {
+    const { lookup } = build();
 
     const out = await lookup.lookup('tomie');
 
-    // Fanned to both bySearch stores (query url-encoded into {q}); cdjapan (byId only) not fetched.
-    expect(fetchBody).toHaveBeenCalledWith('https://www.goodsmileus.com/search/suggest.json?q=tomie&resources[type]=product');
-    expect(fetchBody).toHaveBeenCalledWith('https://sugotoys.com.au/wp-json/wc/store/v1/products?search=tomie&per_page=20');
-
-    const gs = out.results.find((r) => r.siteId === 'goodsmileus');
-    expect(gs?.candidates[0]).toEqual({
-      itemId: 'gs-collection-gyaru-tomie-x-hello-kitty',
-      name: 'GS Collection Gyaru Tomie x Hello Kitty',
-      url: '/products/gs-collection-gyaru-tomie-x-hello-kitty',
-      priceRaw: '5800',
-    });
-    expect(out.results.find((r) => r.siteId === 'sugotoys')?.candidates[0].name).toBe('Tomie Figure');
+    expect(out.mode).toBe('listed');
+    // goodsmileus (listed) returns BOTH — including the sold-out Gyaru Tomie x Hello Kitty.
+    expect(bySite(out, 'goodsmileus')?.candidates.map((c) => c.available)).toEqual([true, false]);
+    // solaris returned results but is orderable-scope → can't confirm its sold-out items.
+    expect(out.orderableOnly).toEqual(['solaris']);
+    expect(bySite(out, 'solaris')?.candidates).toHaveLength(1);
     expect(out.unsupported).toContain('cdjapan');
-    expect(out.failed).toEqual([]);
+  });
+
+  it('orderable mode: filters out sold-out; no orderableOnly caveat', async () => {
+    const { lookup } = build();
+
+    const out = await lookup.lookup('tomie', { mode: 'orderable' });
+
+    expect(out.mode).toBe('orderable');
+    // the sold-out Gyaru Tomie x Hello Kitty is dropped — only the in-stock Nendoroid remains.
+    const gs = bySite(out, 'goodsmileus');
+    expect(gs?.candidates.map((c) => c.itemId)).toEqual(['junji-ito-nendoroid-tomie']);
+    expect(gs?.candidates.every((c) => c.available !== false)).toBe(true);
+    expect(out.orderableOnly).toEqual([]);
   });
 
   it('a bySearch store whose ruleset lacks extractCandidates is unsupported (not fetched)', async () => {
     const { fetchBody, lookup } = build({
-      getRulesetForUrl: (url) => (url.includes('sugotoys') ? stub('sugotoys', wooParse) : stub('goodsmileus')), // no shopify parser
+      getRulesetForUrl: (url) => (url.includes('solaris') ? stub('solaris', () => SOLARIS_CANDIDATES) : stub('goodsmileus')),
     });
 
     const out = await lookup.lookup('miku');
 
     expect(out.unsupported).toContain('goodsmileus');
     expect(fetchBody).not.toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
-    expect(out.results.map((r) => r.siteId)).toEqual(['sugotoys']);
+    expect(out.results.map((r) => r.siteId)).toEqual(['solaris']);
   });
 
   it('a store whose search fetch throws is reported failed, not silently dropped', async () => {
     const { lookup } = build({
       fetchBody: jest.fn(async (url: string) => {
         if (url.includes('goodsmileus')) throw new Error('CF block');
-        return JSON.stringify([{ id: 1, name: 'Tomie', permalink: 'u' }]);
+        return '{}';
       }),
     });
 
     const out = await lookup.lookup('tomie');
 
     expect(out.failed).toContain('goodsmileus');
-    expect(out.results.map((r) => r.siteId)).toEqual(['sugotoys']);
+    expect(out.results.map((r) => r.siteId)).toEqual(['solaris']);
+  });
+
+  it('a bySearch store with no explicit scope defaults to listed (not flagged orderableOnly)', async () => {
+    const NOSCOPE = caps('woo', 'woo.test', { bySearch: { urlTemplate: 'https://woo.test/api?search={q}' } });
+    const services: LookupServices = {
+      profiles: buildProfileRegistry([NOSCOPE]),
+      getRulesetForUrl: () => stub('woo', () => [{ itemId: 'w1', name: 'Tomie', available: true }]),
+      fetchBody: jest.fn(async () => '{}'),
+    };
+
+    const out = await assembleLookup(services).lookup('tomie'); // listed (default)
+
+    expect(out.orderableOnly).toEqual([]);
+    expect(out.results[0]?.siteId).toBe('woo');
   });
 });

--- a/src/driver/assembleLookup.ts
+++ b/src/driver/assembleLookup.ts
@@ -2,21 +2,27 @@
  * assembleLookup — the cross-store SEARCH runtime: the buy-decision fan-out. Given a query (a JAN,
  * or a studio+character/name(+ver)+scale combo when there's no JAN), it fans across every store
  * with a `retrieval.bySearch` axis, fetches each store's search endpoint, and parses the results
- * into `SearchCandidate[]` via that store's ruleset `extractCandidates`. The output is a per-store
- * candidate map plus honest coverage gaps (which stores can't search, which errored).
+ * into `SearchCandidate[]` via that store's ruleset `extractCandidates` (contract 0.3.1).
  *
- * This is DISTINCT from the byId currency crawl (assembleCrawlDriver): search DISCOVERS items on
- * demand — it reaches any figure the moment you ask, independent of the slow full-catalog walk.
- * The next stage (a follow-on) matches candidates by JAN-equality / ER (studio+character+scale)
- * and then `byId`-fetches the full record for price + barcode.
+ * TWO MODES over ONE fetch (no double-searching):
+ *   - `listed`    — every item the store carries, incl. sold-out ("which stores have this?").
+ *   - `orderable` — only in-stock/buyable items ("what can I buy right now?"), i.e. drop
+ *     candidates whose `available === false`.
+ * The store's `bySearch` should target the LISTED (complete) endpoint + each `SearchCandidate`
+ * carries `available`, so both modes are views over the same result. Where a store's ONLY search
+ * is `orderable`-scope (a predictive endpoint that hides sold-out), a `listed` query can't confirm
+ * its sold-out items — that store is reported in `orderableOnly` rather than silently
+ * under-counted (the false-negative that hid a sold-out solaris figure).
  *
- * Everything is injected (profiles / getRulesetForUrl / fetchBody) so the fan-out is deterministic
- * in tests; `fetchBody` returns the RAW response body (JSON for the Tier-1 API searches, HTML for
- * the 2nd wave) so the ruleset parses exactly what the endpoint served.
+ * Distinct from the byId currency crawl (assembleCrawlDriver): search DISCOVERS on demand. The
+ * next stage (a follow-on) matches candidates by JAN-equality / ER and byId-fetches the full
+ * record. Everything is injected so the fan-out is deterministic in tests.
  */
 import { planRetrieval } from './retrievalPlanner.js';
 import type { ProfileRegistry } from './profileRegistry.js';
 import type { ExtractionRuleset, SearchCandidate } from '@figurecollecting/scraper-plugin-contract';
+
+export type LookupMode = 'listed' | 'orderable';
 
 export interface LookupServices {
   /** The store registry (built from the engine's registered capabilities). */
@@ -36,22 +42,31 @@ export interface StoreLookupResult {
 
 export interface LookupResult {
   query: string;
+  mode: LookupMode;
   results: StoreLookupResult[];
   /** Stores that cannot serve the search: no `bySearch` axis, or no `extractCandidates` parser. */
   unsupported: string[];
+  /**
+   * Stores that DID return results but whose search is `orderable`-scope — so a `listed` query
+   * can't confirm their sold-out items (coverage caveat, not a failure). Always empty in
+   * `orderable` mode (where that scope is exactly what's wanted).
+   */
+  orderableOnly: string[];
   /** Stores whose search fetch or parse errored (transparency, not silent drop). */
   failed: string[];
 }
 
 export interface Lookup {
-  lookup(query: string): Promise<LookupResult>;
+  lookup(query: string, opts?: { mode?: LookupMode }): Promise<LookupResult>;
 }
 
 export function assembleLookup(services: LookupServices): Lookup {
   return {
-    async lookup(query) {
+    async lookup(query, opts = {}) {
+      const mode: LookupMode = opts.mode ?? 'listed';
       const plan = planRetrieval(services.profiles, { mode: 'lookup', query });
       const unsupported = [...plan.unsupported];
+      const orderableOnly: string[] = [];
       const failed: string[] = [];
 
       const settled = await Promise.all(
@@ -61,9 +76,12 @@ export function assembleLookup(services: LookupServices): Lookup {
             unsupported.push(p.siteId); // has a bySearch URL but no parser yet
             return null;
           }
+          const scope = services.profiles.retrievalFor(p.host)?.bySearch?.scope ?? 'listed';
+          if (mode === 'listed' && scope === 'orderable') orderableOnly.push(p.siteId);
           try {
             const body = await services.fetchBody(p.url);
-            const candidates = await ruleset.extractCandidates(body, p.url);
+            let candidates = await ruleset.extractCandidates(body, p.url);
+            if (mode === 'orderable') candidates = candidates.filter((c) => c.available !== false);
             return { siteId: p.siteId, host: p.host, url: p.url, candidates };
           } catch {
             failed.push(p.siteId);
@@ -74,8 +92,10 @@ export function assembleLookup(services: LookupServices): Lookup {
 
       return {
         query,
+        mode,
         results: settled.filter((r): r is StoreLookupResult => r !== null),
         unsupported,
+        orderableOnly,
         failed,
       };
     },

--- a/src/driver/assembleLookup.ts
+++ b/src/driver/assembleLookup.ts
@@ -1,0 +1,83 @@
+/**
+ * assembleLookup — the cross-store SEARCH runtime: the buy-decision fan-out. Given a query (a JAN,
+ * or a studio+character/name(+ver)+scale combo when there's no JAN), it fans across every store
+ * with a `retrieval.bySearch` axis, fetches each store's search endpoint, and parses the results
+ * into `SearchCandidate[]` via that store's ruleset `extractCandidates`. The output is a per-store
+ * candidate map plus honest coverage gaps (which stores can't search, which errored).
+ *
+ * This is DISTINCT from the byId currency crawl (assembleCrawlDriver): search DISCOVERS items on
+ * demand — it reaches any figure the moment you ask, independent of the slow full-catalog walk.
+ * The next stage (a follow-on) matches candidates by JAN-equality / ER (studio+character+scale)
+ * and then `byId`-fetches the full record for price + barcode.
+ *
+ * Everything is injected (profiles / getRulesetForUrl / fetchBody) so the fan-out is deterministic
+ * in tests; `fetchBody` returns the RAW response body (JSON for the Tier-1 API searches, HTML for
+ * the 2nd wave) so the ruleset parses exactly what the endpoint served.
+ */
+import { planRetrieval } from './retrievalPlanner.js';
+import type { ProfileRegistry } from './profileRegistry.js';
+import type { ExtractionRuleset, SearchCandidate } from '@figurecollecting/scraper-plugin-contract';
+
+export interface LookupServices {
+  /** The store registry (built from the engine's registered capabilities). */
+  profiles: ProfileRegistry;
+  /** URL → ruleset (engine ExtractionRegistryImpl.getRulesetForUrl); the ruleset parses candidates. */
+  getRulesetForUrl: (url: string) => ExtractionRuleset | undefined;
+  /** Raw response body of a search URL (JSON for Tier-1 API searches; HTML for the 2nd wave). */
+  fetchBody: (url: string) => Promise<string>;
+}
+
+export interface StoreLookupResult {
+  siteId: string;
+  host: string;
+  url: string;
+  candidates: SearchCandidate[];
+}
+
+export interface LookupResult {
+  query: string;
+  results: StoreLookupResult[];
+  /** Stores that cannot serve the search: no `bySearch` axis, or no `extractCandidates` parser. */
+  unsupported: string[];
+  /** Stores whose search fetch or parse errored (transparency, not silent drop). */
+  failed: string[];
+}
+
+export interface Lookup {
+  lookup(query: string): Promise<LookupResult>;
+}
+
+export function assembleLookup(services: LookupServices): Lookup {
+  return {
+    async lookup(query) {
+      const plan = planRetrieval(services.profiles, { mode: 'lookup', query });
+      const unsupported = [...plan.unsupported];
+      const failed: string[] = [];
+
+      const settled = await Promise.all(
+        plan.plans.map(async (p): Promise<StoreLookupResult | null> => {
+          const ruleset = services.getRulesetForUrl(p.url);
+          if (!ruleset?.extractCandidates) {
+            unsupported.push(p.siteId); // has a bySearch URL but no parser yet
+            return null;
+          }
+          try {
+            const body = await services.fetchBody(p.url);
+            const candidates = await ruleset.extractCandidates(body, p.url);
+            return { siteId: p.siteId, host: p.host, url: p.url, candidates };
+          } catch {
+            failed.push(p.siteId);
+            return null;
+          }
+        }),
+      );
+
+      return {
+        query,
+        results: settled.filter((r): r is StoreLookupResult => r !== null),
+        unsupported,
+        failed,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## What

`assembleLookup` — the cross-store SEARCH (buy-decision) fan-out, in **two modes over one fetch**:
- **`listed`** — every item a store carries, incl. sold-out ("which stores have this?").
- **`orderable`** — only in-stock/buyable ("what can I buy right now?"): drops candidates whose `available === false`.

```
planRetrieval(lookup, query) → per-store search URLs
  → fetchBody(url) → ruleset.extractCandidates(body, url) → SearchCandidate[]
  → filter by mode → { results[], unsupported[], orderableOnly[], failed[] }
```

## Why two modes (a real catch)

Testing the live run, a **sold-out** Gyaru Tomie × Hello Kitty figure at solaris was a **false-negative** — solaris's predictive `suggest.json` silently hides sold-out items (verified: solaris 10/10 `available=true` vs goodsmileus 4/10). Sold-out is *signal* (restock / secondhand / price history), not noise. So:
- The store's `bySearch` targets the **listed** (complete) endpoint; each `SearchCandidate` carries **`available`** → both modes are views over one result.
- Where a store's only search is `orderable`-scope (hides sold-out), a `listed` query reports it in **`orderableOnly`** rather than silently under-counting — honest coverage.

## Contract 0.3.1 (additive)
- `SearchCandidate.available?: boolean` — in-stock / sold-out / unknown.
- `RetrievalCapability.bySearch.scope?: 'listed' | 'orderable'` — what the endpoint returns (default `listed`).

## Proven live
The base fan-out (this PR's first commit) run against the live Tier-1 endpoints for `q=tomie` returned the real cross-store comparison — Gyaru Tomie × Hello Kitty at goodsmileus ($149.99) + sugotoys (¥24,995). The two-mode logic makes solaris's sold-out copies visible in `listed` mode instead of dropped.

## Tests
TDD. `listed` returns sold-out + flags orderable-scope stores; `orderable` filters sold-out with no caveat; no-parser store `unsupported` (not fetched); fetch error `failed`; no-scope defaults to `listed`. **100% coverage** on `assembleLookup.ts`; full driver suite **73/73**; `tsc` clean. **Merging auto-publishes contract 0.3.1**, which the ruleset `extractCandidates` parsers need next.