### PR TITLE
A: /lookup entrypoint — wire the cross-store search runtime into the engine

### DIFF
--- a/src/__tests__/unit/engineLookup.test.ts
+++ b/src/__tests__/unit/engineLookup.test.ts
@@ -1,0 +1,71 @@
+/**
+ * createEngineLookup — the entrypoint factory: builds a cross-store Lookup from the engine's
+ * registry (allStores → ProfileRegistry) + a fetch, and fans a query to parse candidates.
+ */
+import { createEngineLookup, httpFetchBody, type LookupRegistry } from '../../services/engineLookup';
+import type { ExtractionRuleset, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+
+const STORE: StoreCapabilities = {
+  siteId: 'goodsmileus',
+  name: 'GSUS',
+  domains: ['www.goodsmileus.com'],
+  rateLimit: { domain: 'www.goodsmileus.com', baseDelayMs: 0, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+  requiresBrowser: false,
+  allowedCookies: [],
+  retrieval: { bySearch: { urlTemplate: 'https://www.goodsmileus.com/search/suggest.json?q={q}', scope: 'listed' } },
+};
+
+const RULESET: ExtractionRuleset = {
+  siteId: 'goodsmileus',
+  version: '1.0.0',
+  extract: () => ({ source: { site: 'goodsmileus', itemId: 'x', extractedAt: '2026-08-09T00:00:00.000Z' }, fields: {}, warnings: [] }),
+  validate: () => ({ valid: true, errors: [], warnings: [] }),
+  extractCandidates: (body) =>
+    (JSON.parse(body) as Array<{ h: string; t: string }>).map((p) => ({ itemId: p.h, name: p.t, available: true })),
+};
+
+describe('createEngineLookup', () => {
+  it('builds a Lookup from the registry that fans search and parses candidates', async () => {
+    const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => RULESET };
+    const fetchBody = jest.fn(async () => JSON.stringify([{ h: 'gyaru-tomie-hk', t: 'Gyaru Tomie x Hello Kitty' }]));
+
+    const lookup = createEngineLookup(registry, fetchBody);
+    const out = await lookup.lookup('tomie', { mode: 'listed' });
+
+    expect(fetchBody).toHaveBeenCalledWith('https://www.goodsmileus.com/search/suggest.json?q=tomie');
+    expect(out.results[0]?.siteId).toBe('goodsmileus');
+    expect(out.results[0]?.candidates[0]?.name).toBe('Gyaru Tomie x Hello Kitty');
+  });
+
+  it('defaults fetchBody to httpFetchBody when not provided', async () => {
+    const orig = global.fetch;
+    global.fetch = jest.fn(async () => ({ text: async () => JSON.stringify([{ h: 'x', t: 'X' }]) })) as unknown as typeof fetch;
+    try {
+      const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => RULESET };
+      const out = await createEngineLookup(registry).lookup('tomie'); // no fetchBody → uses httpFetchBody
+      expect(out.results[0]?.candidates[0]?.name).toBe('X');
+    } finally {
+      global.fetch = orig;
+    }
+  });
+
+  it('a store with no ruleset parser is unsupported', async () => {
+    const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => undefined };
+    const out = await createEngineLookup(registry, jest.fn(async () => '[]')).lookup('miku');
+    expect(out.unsupported).toContain('goodsmileus');
+    expect(out.results).toEqual([]);
+  });
+});
+
+describe('httpFetchBody', () => {
+  it('GETs the url and returns the raw response body text', async () => {
+    const orig = global.fetch;
+    global.fetch = jest.fn(async () => ({ text: async () => '{"ok":true}' })) as unknown as typeof fetch;
+    try {
+      expect(await httpFetchBody('https://x.test/search?q=tomie')).toBe('{"ok":true}');
+      expect(global.fetch).toHaveBeenCalledWith('https://x.test/search?q=tomie', expect.objectContaining({ headers: expect.anything() }));
+    } finally {
+      global.fetch = orig;
+    }
+  });
+});

--- a/src/__tests__/unit/lookupRoute.test.ts
+++ b/src/__tests__/unit/lookupRoute.test.ts
@@ -1,0 +1,56 @@
+/**
+ * GET /lookup route — parses q + mode, calls the injected Lookup, returns the result envelope.
+ */
+import express from 'express';
+import request from 'supertest';
+import { createLookupRoute } from '../../routes/lookup';
+import type { Lookup, LookupResult } from '../../driver/assembleLookup';
+
+const result = (over: Partial<LookupResult> = {}): LookupResult => ({
+  query: 'tomie', mode: 'listed', results: [], unsupported: [], orderableOnly: [], failed: [], ...over,
+});
+
+const appWith = (lookup: Lookup) => {
+  const app = express();
+  app.use('/', createLookupRoute(lookup));
+  return app;
+};
+
+describe('GET /lookup', () => {
+  it('returns the lookup result and passes q + mode through', async () => {
+    const lookup: Lookup = { lookup: jest.fn(async (q, opts) => result({ query: q, mode: opts?.mode ?? 'listed' })) };
+
+    const res = await request(appWith(lookup)).get('/lookup?q=tomie&mode=orderable');
+
+    expect(res.status).toBe(200);
+    expect(res.body.query).toBe('tomie');
+    expect(res.body.mode).toBe('orderable');
+    expect(lookup.lookup).toHaveBeenCalledWith('tomie', { mode: 'orderable' });
+  });
+
+  it('defaults mode to listed', async () => {
+    const lookup: Lookup = { lookup: jest.fn(async () => result()) };
+    await request(appWith(lookup)).get('/lookup?q=tomie');
+    expect(lookup.lookup).toHaveBeenCalledWith('tomie', { mode: 'listed' });
+  });
+
+  it('400 when q is missing or blank', async () => {
+    const lookup: Lookup = { lookup: jest.fn() };
+    expect((await request(appWith(lookup)).get('/lookup')).status).toBe(400);
+    expect((await request(appWith(lookup)).get('/lookup?q=%20')).status).toBe(400);
+    expect(lookup.lookup).not.toHaveBeenCalled();
+  });
+
+  it('502 when the lookup throws (Error and non-Error alike)', async () => {
+    const errLookup: Lookup = { lookup: jest.fn(async () => { throw new Error('CF wall'); }) };
+    const errRes = await request(appWith(errLookup)).get('/lookup?q=tomie');
+    expect(errRes.status).toBe(502);
+    expect(errRes.body.error).toBe('lookup failed');
+    expect(errRes.body.detail).toBe('CF wall');
+
+    const strLookup: Lookup = { lookup: jest.fn(async () => { throw 'boom-string'; }) };
+    const strRes = await request(appWith(strLookup)).get('/lookup?q=tomie');
+    expect(strRes.status).toBe(502);
+    expect(strRes.body.detail).toBe('boom-string');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import dotenv from 'dotenv';
 import { createRequire } from 'module';
 import scraperRoutes from './routes/scraper.js';
 import ingestRoutes from './routes/ingest.js';
+import { createLookupRoute } from './routes/lookup.js';
+import { createEngineLookup } from './services/engineLookup.js';
 import { scraperDebug } from './utils/logger.js';
 
 // Import browser pool functionality
@@ -95,6 +97,9 @@ async function startServer(): Promise<void> {
     // is configured). The engine carries no extraction fallback — items with
     // no matching ruleset fail cleanly through the queue's failure handling.
     getScrapeQueue().setPluginRegistry(registry);
+    // Mount the cross-store buy-decision search (GET /lookup) now that the registry is populated:
+    // buildProfileRegistry(registry.allStores()) → assembleLookup, fetching via plain HTTP (Tier-1).
+    app.use('/', createLookupRoute(createEngineLookup(registry)));
     if (plugins.length > 0) {
       console.log(`[PAGE-SCRAPER] Loaded ${plugins.length} plugin(s): ${plugins.map(p => `${p.name}@${p.version}`).join(', ')}`);
     }

--- a/src/routes/lookup.ts
+++ b/src/routes/lookup.ts
@@ -1,0 +1,28 @@
+/**
+ * GET /lookup?q=<query>&mode=<listed|orderable> — the cross-store buy-decision search endpoint.
+ * Fans the query across every store with a bySearch axis and returns per-store candidates plus the
+ * coverage envelope (unsupported / orderableOnly / failed). `mode` defaults to `listed` (superset,
+ * incl. sold-out); `orderable` filters to in-stock. The Lookup is injected so the route is testable.
+ */
+import { Router, type Request, type Response } from 'express';
+import type { Lookup, LookupMode } from '../driver/assembleLookup.js';
+
+export function createLookupRoute(lookup: Lookup): Router {
+  const router = Router();
+
+  router.get('/lookup', async (req: Request, res: Response) => {
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (!q) {
+      res.status(400).json({ error: "query parameter 'q' is required" });
+      return;
+    }
+    const mode: LookupMode = req.query.mode === 'orderable' ? 'orderable' : 'listed';
+    try {
+      res.json(await lookup.lookup(q, { mode }));
+    } catch (error) {
+      res.status(502).json({ error: 'lookup failed', detail: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  return router;
+}

--- a/src/services/engineLookup.ts
+++ b/src/services/engineLookup.ts
@@ -1,0 +1,42 @@
+/**
+ * engineLookup — the entrypoint (A) that wires the driver's cross-store SEARCH runtime
+ * (assembleLookup) to the ENGINE's real registry + a fetch. It builds the driver ProfileRegistry
+ * from the plugin-populated ExtractionRegistry (`allStores()`) and resolves rulesets +
+ * candidate-parsers through `getRulesetForUrl`. The result is a ready `Lookup` the HTTP route calls.
+ *
+ * `httpFetchBody` is the default fetch: a plain HTTP GET returning the RAW body — correct for the
+ * Tier-1 cookieless JSON stores (Shopify suggest.json, Woo Store API). CF-gated stores (amiami, the
+ * HTML-search stores) need a browser context; that `browserFetch` is a follow-on that swaps in as
+ * the `fetchBody` for `requiresBrowser` hosts without changing this wiring.
+ */
+import { buildProfileRegistry } from '../driver/profileRegistry.js';
+import { assembleLookup, type Lookup } from '../driver/assembleLookup.js';
+import type { ExtractionRuleset, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+
+/** The slice of the engine ExtractionRegistry the lookup needs. */
+export interface LookupRegistry {
+  allStores(): StoreCapabilities[];
+  getRulesetForUrl(url: string): ExtractionRuleset | undefined;
+}
+
+const DESKTOP_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36';
+
+/** Raw response body of a search URL via plain HTTP (Tier-1 cookieless JSON). */
+export async function httpFetchBody(url: string): Promise<string> {
+  const res = await fetch(url, { headers: { 'user-agent': DESKTOP_UA, accept: 'application/json, text/html' } });
+  return res.text();
+}
+
+/** Build the cross-store Lookup from the engine's registered stores + a fetch (default: plain HTTP). */
+export function createEngineLookup(
+  registry: LookupRegistry,
+  fetchBody: (url: string) => Promise<string> = httpFetchBody,
+): Lookup {
+  const profiles = buildProfileRegistry(registry.allStores());
+  return assembleLookup({
+    profiles,
+    getRulesetForUrl: (url) => registry.getRulesetForUrl(url),
+    fetchBody,
+  });
+}


### PR DESCRIPTION
## What

The first slice of **A (the entrypoint)** — makes the cross-store buy-decision search runnable in-cluster:

- **`createEngineLookup(registry, fetchBody?)`** — builds a `Lookup` by feeding the plugin-populated `ExtractionRegistry` (`allStores()` → `buildProfileRegistry`, `getRulesetForUrl` → the candidate parsers) into `assembleLookup`. Default `fetchBody = httpFetchBody` (plain HTTP GET → raw body), correct for the Tier-1 cookieless JSON stores.
- **`GET /lookup?q=<query>&mode=<listed|orderable>`** — the buy-decision endpoint: fans the query across the bySearch stores and returns per-store candidates + the coverage envelope (`unsupported`/`orderableOnly`/`failed`). `mode` defaults to `listed`.
- **Wired into `src/index.ts`** — mounted in `startServer` right after the registry is populated (so `allStores()` has the stores), before `listen`.

## browserFetch hook (next in A)

`httpFetchBody` is the plain-HTTP default. CF-gated stores (amiami's API, the HTML-search stores) need a browser context — that `browserFetch` swaps in as the `fetchBody` for `requiresBrowser` hosts **without changing this wiring**. That's the next increment (and the shared unlock for amiami Tier-2 + the CF stores).

## Tests
TDD. 8 tests: factory fans search + parses candidates / no-parser → unsupported / default-fetchBody path (fetch mocked) / `httpFetchBody` returns raw body; route passes q+mode / defaults to listed / 400 on blank q / 502 on throw (Error + non-Error). **100% coverage** on `engineLookup.ts` + `lookup.ts`; `tsc` clean.

*(Note: the one failing suite in a full run — `backendCommunication.test.ts` — is a pre-existing WSL2 browser-pool `context.close()` flake; verified it fails identically on clean `develop`, and it doesn't touch this route.)*