### PR TITLE
A2: browserFetch capability — route requiresBrowser stores through the pooled browser

### DIFF
--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figurecollecting/scraper-plugin-contract",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -62,9 +62,25 @@ export interface PageOptions {
   userAgent?: string;
 }
 
+export interface BrowserFetchOptions {
+  /** Use the stealth browser. Defaults to true — browserFetch exists for CF-fronted / SPA hosts. */
+  stealth?: boolean;
+  userAgent?: string;
+  cookies?: Record<string, string>;
+  /** Extra request headers (e.g. an API key header for a same-origin JSON endpoint). */
+  headers?: Record<string, string>;
+}
+
 export interface ScrapingService {
   scrapePage(url: string, options?: ScrapePageOptions): Promise<ScrapePageResult>;
   scrapePageStealth(url: string, options?: ScrapePageOptions): Promise<ScrapePageResult>;
+  /**
+   * Fetch a URL's raw BODY through a managed browser page — the browser-backed counterpart to a
+   * plain HTTP GET, for CF-fronted / SPA hosts a plain fetch can't reach. Returns the raw JSON body
+   * for a JSON response (bypassing Chrome's JSON-viewer DOM) or the fully-rendered HTML otherwise.
+   * Extraction stays the caller's job (feeds the lookup's per-host `browserFetchBody`).
+   */
+  browserFetch(url: string, options?: BrowserFetchOptions): Promise<string>;
   withBrowser<T>(fn: (browser: any) => Promise<T>): Promise<T>;
   withPage<T>(fn: (page: any) => Promise<T>, options?: PageOptions): Promise<T>;
 }

--- a/src/__tests__/unit/engineLookup.test.ts
+++ b/src/__tests__/unit/engineLookup.test.ts
@@ -55,6 +55,26 @@ describe('createEngineLookup', () => {
     expect(out.unsupported).toContain('goodsmileus');
     expect(out.results).toEqual([]);
   });
+
+  it('threads browserFetch to requiresBrowser stores while plain fetchBody stays untouched', async () => {
+    const BROWSER_STORE: StoreCapabilities = {
+      ...STORE,
+      siteId: 'amiami',
+      name: 'AmiAmi',
+      domains: ['www.amiami.com'],
+      requiresBrowser: true,
+      retrieval: { bySearch: { urlTemplate: 'https://api.amiami.com/api/v1.0/items?s_keywords={q}', scope: 'listed' } },
+    };
+    const registry: LookupRegistry = { allStores: () => [BROWSER_STORE], getRulesetForUrl: () => RULESET };
+    const fetchBody = jest.fn(async () => JSON.stringify([]));
+    const browserFetch = jest.fn(async () => JSON.stringify([{ h: 'a1', t: 'Tomie' }]));
+
+    const out = await createEngineLookup(registry, fetchBody, browserFetch).lookup('tomie');
+
+    expect(browserFetch).toHaveBeenCalledWith('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
+    expect(fetchBody).not.toHaveBeenCalled();
+    expect(out.results[0]?.candidates[0]?.name).toBe('Tomie');
+  });
 });
 
 describe('httpFetchBody', () => {

--- a/src/__tests__/unit/engineServices/scrapingService.test.ts
+++ b/src/__tests__/unit/engineServices/scrapingService.test.ts
@@ -22,6 +22,7 @@ describe('createScrapingService', () => {
       setViewport: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
       setUserAgent: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
       setCookie: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+      setExtraHTTPHeaders: jest.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
       // capture hook attaches a response listener; provide no-op stubs
       on: jest.fn(),
       off: jest.fn(),
@@ -157,5 +158,57 @@ describe('createScrapingService', () => {
     });
 
     expect(result.title).toBe('Ordinary Page');
+  });
+
+  // browserFetch — the CF-fronted / SPA fetch that returns a raw BODY (not a ScrapePageResult),
+  // so it can back the lookup's `browserFetchBody` for `requiresBrowser` stores.
+  it('browserFetch returns fully-rendered HTML via page.content() for a non-JSON response', async () => {
+    const service = createScrapingService();
+
+    const body = await service.browserFetch('https://cf.example.test/search?q=tomie', { stealth: false });
+
+    expect(mockPage.goto).toHaveBeenCalledWith(
+      'https://cf.example.test/search?q=tomie',
+      expect.objectContaining({ waitUntil: 'domcontentloaded' })
+    );
+    expect(body).toBe('<html><body>mock</body></html>');
+  });
+
+  it('browserFetch returns the RAW JSON body via response.text() (not the JSON-viewer DOM) for a JSON content-type', async () => {
+    mockPage.goto.mockResolvedValue({
+      status: () => 200,
+      headers: () => ({ 'content-type': 'application/json; charset=utf-8' }),
+      text: async () => '{"items":[{"gcode":"FIG-1"}]}',
+    } as any);
+    const service = createScrapingService();
+
+    const body = await service.browserFetch('https://api.amiami.com/api/v1.0/items?s_keywords=tomie', { stealth: false });
+
+    expect(body).toBe('{"items":[{"gcode":"FIG-1"}]}');
+    expect(mockPage.content).not.toHaveBeenCalled(); // JSON read from the response, not the wrapped DOM
+  });
+
+  it('browserFetch uses the stealth browser by default (CF-fronted hosts)', async () => {
+    const service = createScrapingService();
+
+    await service.browserFetch('https://cf.example.test/search?q=tomie');
+
+    // Stealth browser is a singleton, never added to the regular pool.
+    expect(BrowserPool.getPoolSize()).toBe(0);
+  });
+
+  it('browserFetch sets extra request headers and request-scoped cookies when provided', async () => {
+    const service = createScrapingService();
+
+    await service.browserFetch('https://www.amiami.com/api/v1.0/items?s_keywords=tomie', {
+      stealth: false,
+      headers: { 'X-User-Key': 'amiami_dev' },
+      cookies: { cf_clearance: 'token123' },
+    });
+
+    expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith({ 'X-User-Key': 'amiami_dev' });
+    expect(mockPage.setCookie).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'cf_clearance', value: 'token123', domain: '.amiami.com' })
+    );
   });
 });

--- a/src/driver/__tests__/assembleLookup.test.ts
+++ b/src/driver/__tests__/assembleLookup.test.ts
@@ -122,6 +122,55 @@ describe('assembleLookup — cross-store buy-decision search, listed + orderable
     expect(out.results.map((r) => r.siteId)).toEqual(['solaris']);
   });
 
+  it('routes requiresBrowser stores through browserFetchBody and plain-fetch stores through fetchBody', async () => {
+    // amiami: CF-fronted, requiresBrowser:true → must go through the browser path, not plain HTTP.
+    const AMIAMI: StoreCapabilities = {
+      ...caps('amiami', 'www.amiami.com', {
+        bySearch: { urlTemplate: 'https://api.amiami.com/api/v1.0/items?s_keywords={q}', scope: 'listed' },
+      }),
+      requiresBrowser: true,
+    };
+    const fetchBody = jest.fn(async () => '{}');
+    const browserFetchBody = jest.fn(async () => '[]');
+    const services: LookupServices = {
+      profiles: buildProfileRegistry([GOODSMILEUS, AMIAMI]),
+      getRulesetForUrl: (url) =>
+        url.includes('goodsmileus') ? stub('goodsmileus', () => GSUS_CANDIDATES)
+        : url.includes('amiami') ? stub('amiami', () => [{ itemId: 'a1', name: 'Tomie', available: true }])
+        : undefined,
+      fetchBody,
+      browserFetchBody,
+    };
+
+    await assembleLookup(services).lookup('tomie');
+
+    // amiami (requiresBrowser) → browserFetchBody; goodsmileus (fetch) → fetchBody. No crossover.
+    expect(browserFetchBody).toHaveBeenCalledWith('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
+    expect(browserFetchBody).not.toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
+    expect(fetchBody).toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
+    expect(fetchBody).not.toHaveBeenCalledWith(expect.stringContaining('amiami'));
+  });
+
+  it('a requiresBrowser store falls back to fetchBody when no browserFetchBody is injected', async () => {
+    const AMIAMI: StoreCapabilities = {
+      ...caps('amiami', 'www.amiami.com', {
+        bySearch: { urlTemplate: 'https://api.amiami.com/api/v1.0/items?s_keywords={q}', scope: 'listed' },
+      }),
+      requiresBrowser: true,
+    };
+    const fetchBody = jest.fn(async () => '[]');
+    const services: LookupServices = {
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => stub('amiami', () => [{ itemId: 'a1', name: 'Tomie', available: true }]),
+      fetchBody, // no browserFetchBody
+    };
+
+    const out = await assembleLookup(services).lookup('tomie');
+
+    expect(fetchBody).toHaveBeenCalledWith('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
+    expect(out.results[0]?.siteId).toBe('amiami');
+  });
+
   it('a bySearch store with no explicit scope defaults to listed (not flagged orderableOnly)', async () => {
     const NOSCOPE = caps('woo', 'woo.test', { bySearch: { urlTemplate: 'https://woo.test/api?search={q}' } });
     const services: LookupServices = {

--- a/src/driver/__tests__/profileRegistry.test.ts
+++ b/src/driver/__tests__/profileRegistry.test.ts
@@ -51,6 +51,15 @@ describe('ProfileRegistry — host-indexed store capabilities', () => {
     expect(r.retrievalFor('nope.com')).toBeUndefined();
   });
 
+  it('requiresBrowserFor: true for browser hosts, false for fetch hosts, false (never routes to browser) for unknown', () => {
+    const r = new ProfileRegistry();
+    r.register(caps({ requiresBrowser: true })); // amiami → browser
+    r.register(caps({ siteId: 'hlj', name: 'HLJ', domains: ['hlj.com'], requiresBrowser: false }));
+    expect(r.requiresBrowserFor('www.amiami.com')).toBe(true);
+    expect(r.requiresBrowserFor('hlj.com')).toBe(false);
+    expect(r.requiresBrowserFor('nope.com')).toBe(false); // unknown host defaults to the cheap fetch path
+  });
+
   it('all() returns one entry per registered site', () => {
     const r = new ProfileRegistry();
     r.register(caps());

--- a/src/driver/assembleLookup.ts
+++ b/src/driver/assembleLookup.ts
@@ -31,6 +31,11 @@ export interface LookupServices {
   getRulesetForUrl: (url: string) => ExtractionRuleset | undefined;
   /** Raw response body of a search URL (JSON for Tier-1 API searches; HTML for the 2nd wave). */
   fetchBody: (url: string) => Promise<string>;
+  /**
+   * Browser-backed body fetch for `requiresBrowser` (CF-fronted / SPA) stores. When absent, those
+   * stores fall back to `fetchBody` — so existing wiring keeps working and browserFetch is additive.
+   */
+  browserFetchBody?: (url: string) => Promise<string>;
 }
 
 export interface StoreLookupResult {
@@ -79,7 +84,13 @@ export function assembleLookup(services: LookupServices): Lookup {
           const scope = services.profiles.retrievalFor(p.host)?.bySearch?.scope ?? 'listed';
           if (mode === 'listed' && scope === 'orderable') orderableOnly.push(p.siteId);
           try {
-            const body = await services.fetchBody(p.url);
+            // CF-fronted / SPA stores (requiresBrowser) go through the browser path when one is
+            // wired; everything else uses the cheap plain-HTTP fetch. Same (url)=>body contract.
+            const fetchBody =
+              services.profiles.requiresBrowserFor(p.host) && services.browserFetchBody
+                ? services.browserFetchBody
+                : services.fetchBody;
+            const body = await fetchBody(p.url);
             let candidates = await ruleset.extractCandidates(body, p.url);
             if (mode === 'orderable') candidates = candidates.filter((c) => c.available !== false);
             return { siteId: p.siteId, host: p.host, url: p.url, candidates };

--- a/src/driver/profileRegistry.ts
+++ b/src/driver/profileRegistry.ts
@@ -61,6 +61,15 @@ export class ProfileRegistry {
     return caps ? (caps.requiresBrowser ? 'browser' : 'fetch') : undefined;
   }
 
+  /**
+   * Whether a host needs the browser path (CF-fronted / SPA). Routes the lookup's search fetch
+   * (browserFetch vs plain HTTP). Unknown host → false: default to the cheap fetch path, never
+   * spin up a browser for a store we don't know needs one.
+   */
+  requiresBrowserFor(host: string): boolean {
+    return this.forHost(host)?.requiresBrowser ?? false;
+  }
+
   /** Targeted-retrieval capability for on-request fetches (undefined = enumeration-only). */
   retrievalFor(host: string): RetrievalCapability | undefined {
     return this.forHost(host)?.retrieval;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import scraperRoutes from './routes/scraper.js';
 import ingestRoutes from './routes/ingest.js';
 import { createLookupRoute } from './routes/lookup.js';
 import { createEngineLookup } from './services/engineLookup.js';
+import { createScrapingService } from './services/engineServices/scrapingService.js';
 import { scraperDebug } from './utils/logger.js';
 
 // Import browser pool functionality
@@ -98,8 +99,11 @@ async function startServer(): Promise<void> {
     // no matching ruleset fail cleanly through the queue's failure handling.
     getScrapeQueue().setPluginRegistry(registry);
     // Mount the cross-store buy-decision search (GET /lookup) now that the registry is populated:
-    // buildProfileRegistry(registry.allStores()) → assembleLookup, fetching via plain HTTP (Tier-1).
-    app.use('/', createLookupRoute(createEngineLookup(registry)));
+    // buildProfileRegistry(registry.allStores()) → assembleLookup. Tier-1 stores fetch via plain
+    // HTTP; `requiresBrowser` (CF-fronted / SPA) stores route through the pooled stealth browser.
+    // createScrapingService wraps the static BrowserPool, so this shares the same pool as the queue.
+    const lookupScraping = createScrapingService();
+    app.use('/', createLookupRoute(createEngineLookup(registry, undefined, (url) => lookupScraping.browserFetch(url))));
     if (plugins.length > 0) {
       console.log(`[PAGE-SCRAPER] Loaded ${plugins.length} plugin(s): ${plugins.map(p => `${p.name}@${p.version}`).join(', ')}`);
     }

--- a/src/services/engineLookup.ts
+++ b/src/services/engineLookup.ts
@@ -28,15 +28,21 @@ export async function httpFetchBody(url: string): Promise<string> {
   return res.text();
 }
 
-/** Build the cross-store Lookup from the engine's registered stores + a fetch (default: plain HTTP). */
+/**
+ * Build the cross-store Lookup from the engine's registered stores + fetchers. `fetchBody` is the
+ * plain-HTTP default (Tier-1 cookieless JSON); `browserFetch`, when provided, backs the
+ * `requiresBrowser` (CF-fronted / SPA) stores — the lookup routes per host without changing wiring.
+ */
 export function createEngineLookup(
   registry: LookupRegistry,
   fetchBody: (url: string) => Promise<string> = httpFetchBody,
+  browserFetch?: (url: string) => Promise<string>,
 ): Lookup {
   const profiles = buildProfileRegistry(registry.allStores());
   return assembleLookup({
     profiles,
     getRulesetForUrl: (url) => registry.getRulesetForUrl(url),
     fetchBody,
+    browserFetchBody: browserFetch,
   });
 }

--- a/src/services/engineServices/scrapingService.ts
+++ b/src/services/engineServices/scrapingService.ts
@@ -6,7 +6,7 @@
  */
 import type { Browser, Page, HTTPResponse } from 'puppeteer';
 import { BrowserPool } from '../genericScraper.js';
-import { ScrapingService, ScrapePageOptions, ScrapePageResult, PageOptions } from '@figurecollecting/scraper-plugin-contract';
+import { ScrapingService, ScrapePageOptions, ScrapePageResult, PageOptions, BrowserFetchOptions } from '@figurecollecting/scraper-plugin-contract';
 import { CaptureSink, NoopCaptureSink, buildRawCapture } from '../captureSink.js';
 import { sanitizeForLog } from '../../utils/security.js';
 
@@ -16,9 +16,58 @@ const NAV_TIMEOUT_MS = 20000;
 const MAX_WAIT_TIME_MS = 10000;
 const CHALLENGE_RECHECK_DELAY_MS = 1500;
 
+// JSON-ish content types whose body must be read from the response, not page.content():
+// Chrome wraps a navigated JSON document in a viewer DOM, so page.content() would return markup.
+const JSON_CONTENT_TYPE = /\bjson\b/i;
+
 function capWaitTime(waitTime?: number): number {
   if (!waitTime || waitTime < 0) return 0;
   return Math.min(waitTime, MAX_WAIT_TIME_MS);
+}
+
+/**
+ * Build puppeteer setCookie params for a URL's registrable host from a name→value map, dropping
+ * empty values. Shared by navigateAndCapture and browserFetchBody so cookie scoping is identical.
+ */
+function buildCookieParams(url: string, cookies: Record<string, string>): Parameters<Page['setCookie']> {
+  const hostname = new URL(url).hostname;
+  return Object.entries(cookies)
+    .filter(([, value]) => value != null && value !== '')
+    .map(([name, value]) => ({ name, value, domain: `.${hostname.replace(/^www\./, '')}`, path: '/' })) as Parameters<Page['setCookie']>;
+}
+
+/**
+ * Fetch a URL's raw body through a managed Page: navigate (domcontentloaded), then return the RAW
+ * JSON body for a JSON response (response.text(), bypassing Chrome's JSON-viewer DOM) or the
+ * fully-rendered HTML (page.content()) otherwise. No capture sink — this is a plain body fetch;
+ * `browserFetch` wraps it in the pooled `withPage` lifecycle.
+ */
+export async function browserFetchBody(
+  page: Page,
+  url: string,
+  options: Omit<BrowserFetchOptions, 'stealth'> = {}
+): Promise<string> {
+  await page.setViewport({ width: 1280, height: 720 });
+  await page.setUserAgent(options.userAgent || DEFAULT_USER_AGENT);
+
+  if (options.headers && Object.keys(options.headers).length > 0) {
+    await page.setExtraHTTPHeaders(options.headers);
+  }
+  if (options.cookies) {
+    const cookieArray = buildCookieParams(url, options.cookies);
+    if (cookieArray.length > 0) {
+      await page.setCookie(...cookieArray);
+    }
+  }
+
+  const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT_MS });
+  if (response) {
+    const contentType = response.headers?.()?.['content-type'] ?? '';
+    if (JSON_CONTENT_TYPE.test(contentType)) {
+      return await response.text();
+    }
+  }
+  return await page.content();
 }
 
 async function detectChallenge(
@@ -47,12 +96,9 @@ async function navigateAndCapture(
   await page.setUserAgent(options.userAgent || DEFAULT_USER_AGENT);
 
   if (options.cookies) {
-    const hostname = new URL(url).hostname;
-    const cookieArray = Object.entries(options.cookies)
-      .filter(([, value]) => value != null && value !== '')
-      .map(([name, value]) => ({ name, value, domain: `.${hostname.replace(/^www\./, '')}`, path: '/' }));
+    const cookieArray = buildCookieParams(url, options.cookies);
     if (cookieArray.length > 0) {
-      await page.setCookie(...(cookieArray as Parameters<Page['setCookie']>));
+      await page.setCookie(...cookieArray);
     }
   }
 
@@ -171,6 +217,10 @@ export function createScrapingService(captureSink: CaptureSink = new NoopCapture
 
     scrapePageStealth: (url: string, options?: ScrapePageOptions) =>
       withPage(page => navigateAndCapture(page, url, options, captureSink), { stealth: true }),
+
+    // browserFetch defaults to the stealth browser — it exists for CF-fronted / SPA hosts.
+    browserFetch: (url: string, options?: BrowserFetchOptions) =>
+      withPage(page => browserFetchBody(page, url, options), { stealth: options?.stealth ?? true }),
 
     withBrowser,
     withPage,


### PR DESCRIPTION
## What

**A2 (the shared unlock)** — a browser-backed body fetch so the cross-store `/lookup` search can reach CF-fronted / SPA stores that a plain HTTP GET can't.

- **`ScrapingService.browserFetch(url, options?)`** (`scrapingService.ts`) — navigates a **pooled** page via the existing `withPage` lifecycle (the safe teardown path, *not* legacy `scrapeGeneric`), then returns the **raw JSON body** (`response.text()`, bypassing Chrome's JSON-viewer DOM) for a JSON content-type, or the **fully-rendered HTML** (`page.content()`) otherwise. Stealth defaults **true** (these are CF/bot-sensitive hosts); accepts `headers`/`cookies`/`userAgent` for per-host decoration (e.g. an API-key header, `cf_clearance`). Added to the `ScrapingService` contract (**0.3.2**) + `BrowserFetchOptions`.
- **`ProfileRegistry.requiresBrowserFor(host)`** (`profileRegistry.ts`) — first-class routing seam mirroring `poolFor`; unknown host → `false` (never spin a browser for a store we don't know needs one).
- **Routing in `assembleLookup`** — at the fetch call site, `requiresBrowser` hosts go through `browserFetchBody` when one is wired, else fall back to `fetchBody`. Same `(url)=>Promise<string>` contract — no seam surgery, because the store profile is already in scope there.
- **`createEngineLookup(registry, fetchBody?, browserFetch?)`** threads the browser fetcher through as `browserFetchBody`; **`index.ts`** passes the real `scraping.browserFetch` at the mount (a `createScrapingService()` that shares the static `BrowserPool`).

## Why it's shaped this way

`browserFetch` is a **generic** capability; per-store transport (amiami's `X-User-Key`, its search endpoint) is deliberately **not** hard-coded here. amiami's search parser + `bySearch` axis is the next step — it needs a live capture to confirm the real JSON shape, so it can't be built blind. This PR is the shared unlock that step (and the CF HTML-search stores) rides on.

## Tests
TDD (red→green proven). 12 new/affected tests: browserFetch HTML vs JSON-body routing / stealth-default / headers+cookies; `requiresBrowserFor`; assembleLookup routing + fallback; createEngineLookup threading. **100%** on `assembleLookup`/`profileRegistry`/`engineLookup`; new `scrapingService` code fully line-covered (residual uncovered lines are pre-existing capture/retire branches). `tsc` clean; full suite **581 passed / 3 todo**, the sole failure `backendCommunication.test.ts` proven pre-existing (`import.meta` jest-transform, fails identically without this change).

## Follow-on (not this PR)
amiami Tier-2 search (bySearch `items?s_keywords={q}` + `parseAmiamiApiCandidates`, via browserFetch) and the CF HTML-search stores.