### PR TITLE
Add impit TLS-impersonation transport + 3-way fetchSearch dispatcher (contract 0.3.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^5.2.0",
+        "impit": "^0.14.3",
         "minio": "^8.0.7",
         "patch-package": "^8.0.1",
         "puppeteer": "^25.3.0",
@@ -7176,6 +7177,153 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/impit": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit/-/impit-0.14.3.tgz",
+      "integrity": "sha512-SbCLoeW0YDRox5kQoy71jtpjZE+BwjWO411OdgfbLMbNmSX79s5Y0Y2vCE7AO6zQSq9F4Fu8SJTCKnp8rXQzpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "impit-darwin-arm64": "0.14.3",
+        "impit-darwin-x64": "0.14.3",
+        "impit-linux-arm64-gnu": "0.14.3",
+        "impit-linux-arm64-musl": "0.14.3",
+        "impit-linux-x64-gnu": "0.14.3",
+        "impit-linux-x64-musl": "0.14.3",
+        "impit-win32-arm64-msvc": "0.14.3",
+        "impit-win32-x64-msvc": "0.14.3"
+      }
+    },
+    "node_modules/impit-darwin-arm64": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.14.3.tgz",
+      "integrity": "sha512-kMoQB+CR+a954pnhe4kf1O2RyJCsqGRE95jIXfgqNOiIMS5O1z0cOMzG/sohJk/nodZVSJ5VdWEV4BKhRWPFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-darwin-x64": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.14.3.tgz",
+      "integrity": "sha512-ft9+kjz1pR8H5xbbf5U1EgwaaIea5iXHxBf2Q3NoinPpiV7KgyzYSr83pCSrAY6evWk+smG9shHgzhQtgbj1Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-gnu": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.14.3.tgz",
+      "integrity": "sha512-+mwta93S6Ndfpca3DDblvrqV1g8Bg6gZFOlEiJHfGJZpiUIQE+A/Pjg2e+inV+WrTtlnLsvff8lgwFvkIGnRug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-arm64-musl": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.14.3.tgz",
+      "integrity": "sha512-wYhfH1J8laWkpSN2SAFCKx9npY4vXrk23ex+tOzTGf2xBBqIhpMUff2wa6dOFb0or6EhZHBssoRf0HK3h/htXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-gnu": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.14.3.tgz",
+      "integrity": "sha512-hAYnutJDGQO5bPvTPKBBFkHgbB7QL7QLDse8c4s21VSzC/EqGliSS3UqR5ZUUwaFdm3t8DJsXOr+gboAUwDR7w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-linux-x64-musl": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.14.3.tgz",
+      "integrity": "sha512-wXBeHiqCjuyqxg4u5eY4OBNVzsS4Karz/ms/0mjB8aqVZLNER1NaUTeE4J3eZCdytFaJRaAeQvKTH8HfjpPsQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-arm64-msvc": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.14.3.tgz",
+      "integrity": "sha512-XiF8MYpm4tF8TMbtsWrcEDDs6NxRNeirfiHM/AyKcr2jiN34hZwbZDM0EseD30PDwb2Pny2JWB+zTxpE1P5CZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/impit-win32-x64-msvc": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.14.3.tgz",
+      "integrity": "sha512-HIaLSpU5SGVx3UDH/R3ZaGMURVgyRVjmalqXj65ABxVUqfXiBo1t5ZObDPPjqvLT3klPnrya1+xF1DQ4dfT+og==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/import-in-the-middle": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
@@ -12149,7 +12297,7 @@
     },
     "packages/plugin-contract": {
       "name": "@figurecollecting/scraper-plugin-contract",
-      "version": "0.1.0",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^5.2.0",
-        "impit": "^0.14.3",
+        "impit": "0.14.3",
         "minio": "^8.0.7",
         "patch-package": "^8.0.1",
         "puppeteer": "^25.3.0",
@@ -12297,7 +12297,7 @@
     },
     "packages/plugin-contract": {
       "name": "@figurecollecting/scraper-plugin-contract",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^5.2.0",
+    "impit": "0.14.3",
     "minio": "^8.0.7",
     "patch-package": "^8.0.1",
     "puppeteer": "^25.3.0",

--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figurecollecting/scraper-plugin-contract",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -240,6 +240,32 @@ export interface RetrievalCapability {
   bySearch?: { urlTemplate: string; scope?: 'listed' | 'orderable' };
 }
 
+export type SearchTransport = 'http' | 'impersonate' | 'browser';
+
+/**
+ * Per-store fetch decoration for the cross-store SEARCH (`bySearch`) request: how the engine should
+ * FETCH this store's search endpoint, and with what request headers/UA/cookies. Opaque to the engine
+ * and filled by the plugin from the private profile (same pattern as `allowedCookies`/`rateLimit`).
+ *   - `http`        — a plain HTTP GET (Tier-1 cookieless JSON; the implicit default when absent).
+ *   - `impersonate` — a browser-TLS-impersonating HTTP GET (impit) with `browser` profile + `headers`;
+ *                     reaches a Cloudflare-fronted JSON API (e.g. amiami) WITHOUT a real browser.
+ *   - `browser`     — a full pooled browser navigation (rendered-DOM / JS-challenge stores).
+ */
+export interface SearchFetch {
+  transport?: SearchTransport;
+  /**
+   * Impersonation profile for `transport: 'impersonate'` (the impit browser, e.g. 'chrome142').
+   * A LIVE TUNABLE — bump it when Cloudflare tightens and an older profile's TLS fingerprint stops
+   * passing (chrome110 already went stale). The engine supplies a recent default if omitted.
+   */
+  browser?: string;
+  /** Extra request headers (e.g. amiami's static `X-User-Key: amiami_dev`). */
+  headers?: Record<string, string>;
+  userAgent?: string;
+  /** Request-scoped cookies (e.g. a `cf_clearance` for the `browser` transport). */
+  cookies?: Record<string, string>;
+}
+
 /**
  * The engine-facing capability view of a store: its public `SiteConfig` (siteId / domains /
  * rateLimit / requiresBrowser) plus retrieval addressability. The crawl driver schedules from
@@ -249,6 +275,11 @@ export interface RetrievalCapability {
  */
 export interface StoreCapabilities extends SiteConfig {
   retrieval?: RetrievalCapability;
+  /**
+   * How to FETCH this store's `bySearch` endpoint (transport + request decoration). Absent ⇒ the
+   * engine defaults the transport from `requiresBrowser` (`browser` if true, else `http`).
+   */
+  searchFetch?: SearchFetch;
 }
 
 /**

--- a/src/__tests__/unit/engineLookup.test.ts
+++ b/src/__tests__/unit/engineLookup.test.ts
@@ -29,7 +29,7 @@ describe('createEngineLookup', () => {
     const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => RULESET };
     const fetchBody = jest.fn(async () => JSON.stringify([{ h: 'gyaru-tomie-hk', t: 'Gyaru Tomie x Hello Kitty' }]));
 
-    const lookup = createEngineLookup(registry, fetchBody);
+    const lookup = createEngineLookup(registry, { http: fetchBody });
     const out = await lookup.lookup('tomie', { mode: 'listed' });
 
     expect(fetchBody).toHaveBeenCalledWith('https://www.goodsmileus.com/search/suggest.json?q=tomie');
@@ -37,12 +37,12 @@ describe('createEngineLookup', () => {
     expect(out.results[0]?.candidates[0]?.name).toBe('Gyaru Tomie x Hello Kitty');
   });
 
-  it('defaults fetchBody to httpFetchBody when not provided', async () => {
+  it('defaults the http transport to httpFetchBody when none is provided', async () => {
     const orig = global.fetch;
     global.fetch = jest.fn(async () => ({ text: async () => JSON.stringify([{ h: 'x', t: 'X' }]) })) as unknown as typeof fetch;
     try {
       const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => RULESET };
-      const out = await createEngineLookup(registry).lookup('tomie'); // no fetchBody → uses httpFetchBody
+      const out = await createEngineLookup(registry).lookup('tomie'); // no transports → http = httpFetchBody
       expect(out.results[0]?.candidates[0]?.name).toBe('X');
     } finally {
       global.fetch = orig;
@@ -51,28 +51,32 @@ describe('createEngineLookup', () => {
 
   it('a store with no ruleset parser is unsupported', async () => {
     const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => undefined };
-    const out = await createEngineLookup(registry, jest.fn(async () => '[]')).lookup('miku');
+    const out = await createEngineLookup(registry, { http: jest.fn(async () => '[]') }).lookup('miku');
     expect(out.unsupported).toContain('goodsmileus');
     expect(out.results).toEqual([]);
   });
 
-  it('threads browserFetch to requiresBrowser stores while plain fetchBody stays untouched', async () => {
-    const BROWSER_STORE: StoreCapabilities = {
+  it('routes a store that declares the impersonate transport to the impit fetcher (not http)', async () => {
+    const AMIAMI_STORE: StoreCapabilities = {
       ...STORE,
       siteId: 'amiami',
       name: 'AmiAmi',
       domains: ['www.amiami.com'],
       requiresBrowser: true,
       retrieval: { bySearch: { urlTemplate: 'https://api.amiami.com/api/v1.0/items?s_keywords={q}', scope: 'listed' } },
+      searchFetch: { transport: 'impersonate', browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' } },
     };
-    const registry: LookupRegistry = { allStores: () => [BROWSER_STORE], getRulesetForUrl: () => RULESET };
-    const fetchBody = jest.fn(async () => JSON.stringify([]));
-    const browserFetch = jest.fn(async () => JSON.stringify([{ h: 'a1', t: 'Tomie' }]));
+    const registry: LookupRegistry = { allStores: () => [AMIAMI_STORE], getRulesetForUrl: () => RULESET };
+    const http = jest.fn(async () => JSON.stringify([]));
+    const impersonate = jest.fn(async () => JSON.stringify([{ h: 'a1', t: 'Tomie' }]));
 
-    const out = await createEngineLookup(registry, fetchBody, browserFetch).lookup('tomie');
+    const out = await createEngineLookup(registry, { http, impersonate }).lookup('tomie');
 
-    expect(browserFetch).toHaveBeenCalledWith('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
-    expect(fetchBody).not.toHaveBeenCalled();
+    expect(impersonate).toHaveBeenCalledWith(
+      'https://api.amiami.com/api/v1.0/items?s_keywords=tomie',
+      { browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' }, userAgent: undefined },
+    );
+    expect(http).not.toHaveBeenCalled();
     expect(out.results[0]?.candidates[0]?.name).toBe('Tomie');
   });
 });

--- a/src/__tests__/unit/fetchSearch.test.ts
+++ b/src/__tests__/unit/fetchSearch.test.ts
@@ -1,0 +1,48 @@
+/**
+ * makeFetchSearch — dispatches a store's search URL to the transport it declares
+ * (http | impersonate | browser), applying its headers/profile/cookies, and degrades the
+ * browser transport to http when no browser fetcher is wired.
+ */
+import { makeFetchSearch, type FetchSearchTransports } from '../../services/fetchSearch';
+
+const transports = () => {
+  const calls: any[] = [];
+  const t: FetchSearchTransports = {
+    http: async (url) => { calls.push(['http', url]); return 'HTTP'; },
+    impersonate: async (url, o) => { calls.push(['impersonate', url, o]); return 'IMPIT'; },
+    browser: async (url, o) => { calls.push(['browser', url, o]); return 'BROWSER'; },
+  };
+  return { t, calls };
+};
+
+describe('makeFetchSearch', () => {
+  it("routes 'impersonate' to impit with profile + headers + userAgent", async () => {
+    const { t, calls } = transports();
+    const body = await makeFetchSearch(t)('https://api.amiami.com/items?s_keywords=tomie', {
+      transport: 'impersonate', browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' }, userAgent: 'python-amiami_dev',
+    });
+    expect(body).toBe('IMPIT');
+    expect(calls[0]).toEqual(['impersonate', 'https://api.amiami.com/items?s_keywords=tomie',
+      { browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' }, userAgent: 'python-amiami_dev' }]);
+  });
+
+  it("routes 'browser' to the browser transport with headers/cookies", async () => {
+    const { t, calls } = transports();
+    const body = await makeFetchSearch(t)('https://surugaya.test/s', { transport: 'browser', cookies: { cf_clearance: 'x' } });
+    expect(body).toBe('BROWSER');
+    expect(calls[0][0]).toBe('browser');
+    expect(calls[0][2]).toEqual({ headers: undefined, userAgent: undefined, cookies: { cf_clearance: 'x' } });
+  });
+
+  it("routes 'http' and an undefined transport to plain HTTP", async () => {
+    const { t } = transports();
+    expect(await makeFetchSearch(t)('https://gsus.test/s', { transport: 'http' })).toBe('HTTP');
+    expect(await makeFetchSearch(t)('https://gsus.test/s', {})).toBe('HTTP'); // no transport → http default
+  });
+
+  it("degrades 'browser' to http when no browser transport is wired", async () => {
+    const { t } = transports();
+    const noBrowser: FetchSearchTransports = { http: t.http, impersonate: t.impersonate }; // browser omitted
+    expect(await makeFetchSearch(noBrowser)('https://x.test/s', { transport: 'browser' })).toBe('HTTP');
+  });
+});

--- a/src/__tests__/unit/fetchSearch.test.ts
+++ b/src/__tests__/unit/fetchSearch.test.ts
@@ -40,9 +40,10 @@ describe('makeFetchSearch', () => {
     expect(await makeFetchSearch(t)('https://gsus.test/s', {})).toBe('HTTP'); // no transport → http default
   });
 
-  it("degrades 'browser' to http when no browser transport is wired", async () => {
-    const { t } = transports();
+  it("throws when 'browser' is requested but no browser transport is wired (fails loud, not a silent http fallback)", async () => {
+    const { t, calls } = transports();
     const noBrowser: FetchSearchTransports = { http: t.http, impersonate: t.impersonate }; // browser omitted
-    expect(await makeFetchSearch(noBrowser)('https://x.test/s', { transport: 'browser' })).toBe('HTTP');
+    await expect(makeFetchSearch(noBrowser)('https://x.test/s', { transport: 'browser' })).rejects.toThrow(/browser/);
+    expect(calls).toEqual([]); // did NOT silently fall through to http
   });
 });

--- a/src/__tests__/unit/impitFetch.test.ts
+++ b/src/__tests__/unit/impitFetch.test.ts
@@ -1,0 +1,52 @@
+/**
+ * createImpitFetch — the browser-TLS-impersonating HTTP body fetch (impit). Unit-tested with an
+ * injected fake impit so it never loads the native binary: verifies the default profile, per-store
+ * profile + header/UA merge, and one-instance-per-profile caching.
+ */
+import { createImpitFetch, type ImpitLike } from '../../services/impitFetch';
+
+describe('createImpitFetch', () => {
+  it('fetches via impit with the default chrome142 profile and returns the body text', async () => {
+    const calls: Array<{ browser: string; url: string; init: any }> = [];
+    const fake = (browser: string): ImpitLike => ({
+      fetch: async (url, init) => { calls.push({ browser, url, init }); return { text: async () => '{"items":[]}' }; },
+    });
+
+    const impitFetch = createImpitFetch(fake);
+    const body = await impitFetch('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
+
+    expect(body).toBe('{"items":[]}');
+    expect(calls[0].browser).toBe('chrome142'); // engine default profile
+    expect(calls[0].url).toBe('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
+    expect(calls[0].init.method).toBe('GET');
+  });
+
+  it('uses the store-specified browser profile and merges headers + userAgent', async () => {
+    let seen: { browser: string; init: any } | undefined;
+    const fake = (browser: string): ImpitLike => ({
+      fetch: async (_url, init) => { seen = { browser, init }; return { text: async () => 'ok' }; },
+    });
+
+    const impitFetch = createImpitFetch(fake);
+    await impitFetch('https://x.test/s', {
+      browser: 'chrome124',
+      headers: { 'X-User-Key': 'amiami_dev' },
+      userAgent: 'python-amiami_dev',
+    });
+
+    expect(seen?.browser).toBe('chrome124');
+    expect(seen?.init.headers).toEqual({ 'User-Agent': 'python-amiami_dev', 'X-User-Key': 'amiami_dev' });
+  });
+
+  it('caches one impit instance per profile (reuses across calls, rebuilds only for a new profile)', async () => {
+    let builds = 0;
+    const fake = (_browser: string): ImpitLike => { builds++; return { fetch: async () => ({ text: async () => 'ok' }) }; };
+
+    const impitFetch = createImpitFetch(fake);
+    await impitFetch('https://x.test/a', { browser: 'chrome142' });
+    await impitFetch('https://x.test/b', { browser: 'chrome142' }); // same profile → reuse
+    await impitFetch('https://x.test/c', { browser: 'chrome124' }); // new profile → build
+
+    expect(builds).toBe(2);
+  });
+});

--- a/src/driver/__tests__/assembleLookup.test.ts
+++ b/src/driver/__tests__/assembleLookup.test.ts
@@ -52,17 +52,17 @@ const stub = (siteId: string, extractCandidates?: ExtractionRuleset['extractCand
 });
 
 const build = (over: Partial<LookupServices> = {}) => {
-  const fetchBody = jest.fn(async () => '{}');
+  const fetchSearch = jest.fn(async () => '{}');
   const services: LookupServices = {
     profiles: buildProfileRegistry([GOODSMILEUS, SOLARIS, CDJAPAN]),
     getRulesetForUrl: (url) =>
       url.includes('goodsmileus') ? stub('goodsmileus', () => GSUS_CANDIDATES)
       : url.includes('solaris') ? stub('solaris', () => SOLARIS_CANDIDATES)
       : undefined,
-    fetchBody,
+    fetchSearch,
     ...over,
   };
-  return { services, fetchBody, lookup: assembleLookup(services) };
+  return { services, fetchSearch, lookup: assembleLookup(services) };
 };
 
 const bySite = (r: Awaited<ReturnType<ReturnType<typeof build>['lookup']['lookup']>>, id: string) =>
@@ -97,20 +97,20 @@ describe('assembleLookup — cross-store buy-decision search, listed + orderable
   });
 
   it('a bySearch store whose ruleset lacks extractCandidates is unsupported (not fetched)', async () => {
-    const { fetchBody, lookup } = build({
+    const { fetchSearch, lookup } = build({
       getRulesetForUrl: (url) => (url.includes('solaris') ? stub('solaris', () => SOLARIS_CANDIDATES) : stub('goodsmileus')),
     });
 
     const out = await lookup.lookup('miku');
 
     expect(out.unsupported).toContain('goodsmileus');
-    expect(fetchBody).not.toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
+    expect(fetchSearch).not.toHaveBeenCalledWith(expect.stringContaining('goodsmileus'), expect.anything());
     expect(out.results.map((r) => r.siteId)).toEqual(['solaris']);
   });
 
   it('a store whose search fetch throws is reported failed, not silently dropped', async () => {
     const { lookup } = build({
-      fetchBody: jest.fn(async (url: string) => {
+      fetchSearch: jest.fn(async (url: string) => {
         if (url.includes('goodsmileus')) throw new Error('CF block');
         return '{}';
       }),
@@ -122,53 +122,32 @@ describe('assembleLookup — cross-store buy-decision search, listed + orderable
     expect(out.results.map((r) => r.siteId)).toEqual(['solaris']);
   });
 
-  it('routes requiresBrowser stores through browserFetchBody and plain-fetch stores through fetchBody', async () => {
-    // amiami: CF-fronted, requiresBrowser:true → must go through the browser path, not plain HTTP.
+  it('passes each store its RESOLVED search transport to fetchSearch (explicit searchFetch vs http default)', async () => {
+    // amiami declares an explicit impersonate transport with X-User-Key; goodsmileus has none → http.
     const AMIAMI: StoreCapabilities = {
       ...caps('amiami', 'www.amiami.com', {
         bySearch: { urlTemplate: 'https://api.amiami.com/api/v1.0/items?s_keywords={q}', scope: 'listed' },
       }),
-      requiresBrowser: true,
+      searchFetch: { transport: 'impersonate', browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' } },
     };
-    const fetchBody = jest.fn(async () => '{}');
-    const browserFetchBody = jest.fn(async () => '[]');
+    const fetchSearch = jest.fn(async () => '[]');
     const services: LookupServices = {
       profiles: buildProfileRegistry([GOODSMILEUS, AMIAMI]),
       getRulesetForUrl: (url) =>
         url.includes('goodsmileus') ? stub('goodsmileus', () => GSUS_CANDIDATES)
         : url.includes('amiami') ? stub('amiami', () => [{ itemId: 'a1', name: 'Tomie', available: true }])
         : undefined,
-      fetchBody,
-      browserFetchBody,
+      fetchSearch,
     };
 
     await assembleLookup(services).lookup('tomie');
 
-    // amiami (requiresBrowser) → browserFetchBody; goodsmileus (fetch) → fetchBody. No crossover.
-    expect(browserFetchBody).toHaveBeenCalledWith('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
-    expect(browserFetchBody).not.toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
-    expect(fetchBody).toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
-    expect(fetchBody).not.toHaveBeenCalledWith(expect.stringContaining('amiami'));
-  });
-
-  it('a requiresBrowser store falls back to fetchBody when no browserFetchBody is injected', async () => {
-    const AMIAMI: StoreCapabilities = {
-      ...caps('amiami', 'www.amiami.com', {
-        bySearch: { urlTemplate: 'https://api.amiami.com/api/v1.0/items?s_keywords={q}', scope: 'listed' },
-      }),
-      requiresBrowser: true,
-    };
-    const fetchBody = jest.fn(async () => '[]');
-    const services: LookupServices = {
-      profiles: buildProfileRegistry([AMIAMI]),
-      getRulesetForUrl: () => stub('amiami', () => [{ itemId: 'a1', name: 'Tomie', available: true }]),
-      fetchBody, // no browserFetchBody
-    };
-
-    const out = await assembleLookup(services).lookup('tomie');
-
-    expect(fetchBody).toHaveBeenCalledWith('https://api.amiami.com/api/v1.0/items?s_keywords=tomie');
-    expect(out.results[0]?.siteId).toBe('amiami');
+    // amiami → its explicit impersonate transport (URL {q}-filled); goodsmileus → the http default.
+    expect(fetchSearch).toHaveBeenCalledWith(
+      'https://api.amiami.com/api/v1.0/items?s_keywords=tomie',
+      { transport: 'impersonate', browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' } },
+    );
+    expect(fetchSearch).toHaveBeenCalledWith(expect.stringContaining('goodsmileus'), { transport: 'http' });
   });
 
   it('a bySearch store with no explicit scope defaults to listed (not flagged orderableOnly)', async () => {
@@ -176,7 +155,7 @@ describe('assembleLookup — cross-store buy-decision search, listed + orderable
     const services: LookupServices = {
       profiles: buildProfileRegistry([NOSCOPE]),
       getRulesetForUrl: () => stub('woo', () => [{ itemId: 'w1', name: 'Tomie', available: true }]),
-      fetchBody: jest.fn(async () => '{}'),
+      fetchSearch: jest.fn(async () => '{}'),
     };
 
     const out = await assembleLookup(services).lookup('tomie'); // listed (default)

--- a/src/driver/__tests__/assembleLookup.test.ts
+++ b/src/driver/__tests__/assembleLookup.test.ts
@@ -108,7 +108,8 @@ describe('assembleLookup — cross-store buy-decision search, listed + orderable
     expect(out.results.map((r) => r.siteId)).toEqual(['solaris']);
   });
 
-  it('a store whose search fetch throws is reported failed, not silently dropped', async () => {
+  it('a store whose search fetch throws is reported failed AND the reason is logged (not silently dropped)', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const { lookup } = build({
       fetchSearch: jest.fn(async (url: string) => {
         if (url.includes('goodsmileus')) throw new Error('CF block');
@@ -120,6 +121,10 @@ describe('assembleLookup — cross-store buy-decision search, listed + orderable
 
     expect(out.failed).toContain('goodsmileus');
     expect(out.results.map((r) => r.siteId)).toEqual(['solaris']);
+    // the reason is surfaced, not swallowed — distinguishes CF-block from parse-error etc.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('goodsmileus'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('CF block'));
+    warn.mockRestore();
   });
 
   it('passes each store its RESOLVED search transport to fetchSearch (explicit searchFetch vs http default)', async () => {

--- a/src/driver/__tests__/profileRegistry.test.ts
+++ b/src/driver/__tests__/profileRegistry.test.ts
@@ -51,13 +51,15 @@ describe('ProfileRegistry — host-indexed store capabilities', () => {
     expect(r.retrievalFor('nope.com')).toBeUndefined();
   });
 
-  it('requiresBrowserFor: true for browser hosts, false for fetch hosts, false (never routes to browser) for unknown', () => {
+  it('searchTransportFor: explicit searchFetch wins; else defaults the transport from requiresBrowser; unknown → http', () => {
     const r = new ProfileRegistry();
-    r.register(caps({ requiresBrowser: true })); // amiami → browser
-    r.register(caps({ siteId: 'hlj', name: 'HLJ', domains: ['hlj.com'], requiresBrowser: false }));
-    expect(r.requiresBrowserFor('www.amiami.com')).toBe(true);
-    expect(r.requiresBrowserFor('hlj.com')).toBe(false);
-    expect(r.requiresBrowserFor('nope.com')).toBe(false); // unknown host defaults to the cheap fetch path
+    r.register(caps({ searchFetch: { transport: 'impersonate', browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' } } })); // amiami
+    r.register(caps({ siteId: 'surugaya', name: 'Surugaya', domains: ['surugaya.jp'], requiresBrowser: true })); // no searchFetch → browser
+    r.register(caps({ siteId: 'hlj', name: 'HLJ', domains: ['hlj.com'], requiresBrowser: false })); // no searchFetch → http
+    expect(r.searchTransportFor('www.amiami.com')).toEqual({ transport: 'impersonate', browser: 'chrome142', headers: { 'X-User-Key': 'amiami_dev' } });
+    expect(r.searchTransportFor('surugaya.jp')).toEqual({ transport: 'browser' }); // requiresBrowser default
+    expect(r.searchTransportFor('hlj.com')).toEqual({ transport: 'http' });
+    expect(r.searchTransportFor('nope.com')).toEqual({ transport: 'http' }); // unknown → cheap http
   });
 
   it('all() returns one entry per registered site', () => {

--- a/src/driver/assembleLookup.ts
+++ b/src/driver/assembleLookup.ts
@@ -20,7 +20,7 @@
  */
 import { planRetrieval } from './retrievalPlanner.js';
 import type { ProfileRegistry } from './profileRegistry.js';
-import type { ExtractionRuleset, SearchCandidate } from '@figurecollecting/scraper-plugin-contract';
+import type { ExtractionRuleset, SearchCandidate, SearchFetch } from '@figurecollecting/scraper-plugin-contract';
 
 export type LookupMode = 'listed' | 'orderable';
 
@@ -29,13 +29,12 @@ export interface LookupServices {
   profiles: ProfileRegistry;
   /** URL → ruleset (engine ExtractionRegistryImpl.getRulesetForUrl); the ruleset parses candidates. */
   getRulesetForUrl: (url: string) => ExtractionRuleset | undefined;
-  /** Raw response body of a search URL (JSON for Tier-1 API searches; HTML for the 2nd wave). */
-  fetchBody: (url: string) => Promise<string>;
   /**
-   * Browser-backed body fetch for `requiresBrowser` (CF-fronted / SPA) stores. When absent, those
-   * stores fall back to `fetchBody` — so existing wiring keeps working and browserFetch is additive.
+   * Fetch a store's search-results body given the store's resolved search transport (http /
+   * impersonate / browser + its per-store headers/profile). Built by the engine (makeFetchSearch)
+   * and injected here, so the fan-out stays deterministic in tests.
    */
-  browserFetchBody?: (url: string) => Promise<string>;
+  fetchSearch: (url: string, searchFetch: SearchFetch) => Promise<string>;
 }
 
 export interface StoreLookupResult {
@@ -84,13 +83,8 @@ export function assembleLookup(services: LookupServices): Lookup {
           const scope = services.profiles.retrievalFor(p.host)?.bySearch?.scope ?? 'listed';
           if (mode === 'listed' && scope === 'orderable') orderableOnly.push(p.siteId);
           try {
-            // CF-fronted / SPA stores (requiresBrowser) go through the browser path when one is
-            // wired; everything else uses the cheap plain-HTTP fetch. Same (url)=>body contract.
-            const fetchBody =
-              services.profiles.requiresBrowserFor(p.host) && services.browserFetchBody
-                ? services.browserFetchBody
-                : services.fetchBody;
-            const body = await fetchBody(p.url);
+            // Fetch via the store's resolved transport (http / impersonate / browser + its headers).
+            const body = await services.fetchSearch(p.url, services.profiles.searchTransportFor(p.host));
             let candidates = await ruleset.extractCandidates(body, p.url);
             if (mode === 'orderable') candidates = candidates.filter((c) => c.available !== false);
             return { siteId: p.siteId, host: p.host, url: p.url, candidates };

--- a/src/driver/assembleLookup.ts
+++ b/src/driver/assembleLookup.ts
@@ -19,6 +19,7 @@
  * record. Everything is injected so the fan-out is deterministic in tests.
  */
 import { planRetrieval } from './retrievalPlanner.js';
+import { sanitizeForLog } from '../utils/security.js';
 import type { ProfileRegistry } from './profileRegistry.js';
 import type { ExtractionRuleset, SearchCandidate, SearchFetch } from '@figurecollecting/scraper-plugin-contract';
 
@@ -88,7 +89,11 @@ export function assembleLookup(services: LookupServices): Lookup {
             let candidates = await ruleset.extractCandidates(body, p.url);
             if (mode === 'orderable') candidates = candidates.filter((c) => c.available !== false);
             return { siteId: p.siteId, host: p.host, url: p.url, candidates };
-          } catch {
+          } catch (err) {
+            // Surface WHY a store dropped out (CF block / invalid impersonation profile / parse
+            // error) — otherwise every failure collapses into an indistinguishable `failed` entry.
+            // eslint-disable-next-line no-console
+            console.warn(`[lookup] ${sanitizeForLog(p.siteId)} search failed: ${sanitizeForLog(err instanceof Error ? err.message : String(err))}`);
             failed.push(p.siteId);
             return null;
           }

--- a/src/driver/profileRegistry.ts
+++ b/src/driver/profileRegistry.ts
@@ -17,6 +17,7 @@
 import type {
   DomainRateLimit,
   RetrievalCapability,
+  SearchFetch,
   StoreCapabilities,
 } from '@figurecollecting/scraper-plugin-contract';
 import type { PoolKind } from './poolRouter.js';
@@ -62,12 +63,15 @@ export class ProfileRegistry {
   }
 
   /**
-   * Whether a host needs the browser path (CF-fronted / SPA). Routes the lookup's search fetch
-   * (browserFetch vs plain HTTP). Unknown host → false: default to the cheap fetch path, never
-   * spin up a browser for a store we don't know needs one.
+   * The effective search-fetch transport+decoration for a host: the store's explicit `searchFetch`
+   * when declared, otherwise a default transport derived from `requiresBrowser` (`browser` if the
+   * store needs a browser, else the cheap `http`). Unknown host → `http` (never spin a browser for a
+   * store we don't know needs one). Feeds the lookup's `fetchSearch` dispatcher.
    */
-  requiresBrowserFor(host: string): boolean {
-    return this.forHost(host)?.requiresBrowser ?? false;
+  searchTransportFor(host: string): SearchFetch {
+    const caps = this.forHost(host);
+    if (caps?.searchFetch) return caps.searchFetch;
+    return { transport: caps?.requiresBrowser ? 'browser' : 'http' };
   }
 
   /** Targeted-retrieval capability for on-request fetches (undefined = enumeration-only). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,12 +98,14 @@ async function startServer(): Promise<void> {
     // is configured). The engine carries no extraction fallback — items with
     // no matching ruleset fail cleanly through the queue's failure handling.
     getScrapeQueue().setPluginRegistry(registry);
-    // Mount the cross-store buy-decision search (GET /lookup) now that the registry is populated:
-    // buildProfileRegistry(registry.allStores()) → assembleLookup. Tier-1 stores fetch via plain
-    // HTTP; `requiresBrowser` (CF-fronted / SPA) stores route through the pooled stealth browser.
-    // createScrapingService wraps the static BrowserPool, so this shares the same pool as the queue.
+    // Mount the cross-store buy-decision search (GET /lookup) now that the registry is populated.
+    // Each store fetches via the transport its `searchFetch` declares (http / impersonate / browser);
+    // http + impersonate use the engine defaults, and the `browser` transport is backed here by the
+    // pooled ScrapingService (createScrapingService wraps the static BrowserPool → shares the queue's pool).
     const lookupScraping = createScrapingService();
-    app.use('/', createLookupRoute(createEngineLookup(registry, undefined, (url) => lookupScraping.browserFetch(url))));
+    app.use('/', createLookupRoute(createEngineLookup(registry, {
+      browser: (url, opts) => lookupScraping.browserFetch(url, opts),
+    })));
     if (plugins.length > 0) {
       console.log(`[PAGE-SCRAPER] Loaded ${plugins.length} plugin(s): ${plugins.map(p => `${p.name}@${p.version}`).join(', ')}`);
     }

--- a/src/services/engineLookup.ts
+++ b/src/services/engineLookup.ts
@@ -4,13 +4,15 @@
  * from the plugin-populated ExtractionRegistry (`allStores()`) and resolves rulesets +
  * candidate-parsers through `getRulesetForUrl`. The result is a ready `Lookup` the HTTP route calls.
  *
- * `httpFetchBody` is the default fetch: a plain HTTP GET returning the RAW body — correct for the
- * Tier-1 cookieless JSON stores (Shopify suggest.json, Woo Store API). CF-gated stores (amiami, the
- * HTML-search stores) need a browser context; that `browserFetch` is a follow-on that swaps in as
- * the `fetchBody` for `requiresBrowser` hosts without changing this wiring.
+ * Each store's search body is fetched via the transport it declares (StoreCapabilities.searchFetch):
+ * `http` = plain GET (Tier-1 cookieless JSON — the default), `impersonate` = impit TLS-impersonation
+ * (CF-fronted JSON APIs like amiami), `browser` = pooled browser nav (rendered-DOM stores). The
+ * `browser` transport is wired at the mount from the ScrapingService; unset here → it degrades to http.
  */
 import { buildProfileRegistry } from '../driver/profileRegistry.js';
 import { assembleLookup, type Lookup } from '../driver/assembleLookup.js';
+import { makeFetchSearch, type FetchSearchTransports } from './fetchSearch.js';
+import { impitFetchBody } from './impitFetch.js';
 import type { ExtractionRuleset, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
 
 /** The slice of the engine ExtractionRegistry the lookup needs. */
@@ -29,20 +31,24 @@ export async function httpFetchBody(url: string): Promise<string> {
 }
 
 /**
- * Build the cross-store Lookup from the engine's registered stores + fetchers. `fetchBody` is the
- * plain-HTTP default (Tier-1 cookieless JSON); `browserFetch`, when provided, backs the
- * `requiresBrowser` (CF-fronted / SPA) stores — the lookup routes per host without changing wiring.
+ * Build the cross-store Lookup from the engine's registered stores + the three search transports.
+ * `http` and `impersonate` default to the real engine fetchers (plain fetch / impit); `browser` is
+ * wired at the mount from the ScrapingService (left unset in tests → the browser transport degrades
+ * to http). Per-store transport selection is data-driven via `StoreCapabilities.searchFetch`.
  */
 export function createEngineLookup(
   registry: LookupRegistry,
-  fetchBody: (url: string) => Promise<string> = httpFetchBody,
-  browserFetch?: (url: string) => Promise<string>,
+  transports: Partial<FetchSearchTransports> = {},
 ): Lookup {
   const profiles = buildProfileRegistry(registry.allStores());
+  const fetchSearch = makeFetchSearch({
+    http: transports.http ?? httpFetchBody,
+    impersonate: transports.impersonate ?? impitFetchBody,
+    browser: transports.browser,
+  });
   return assembleLookup({
     profiles,
     getRulesetForUrl: (url) => registry.getRulesetForUrl(url),
-    fetchBody,
-    browserFetchBody: browserFetch,
+    fetchSearch,
   });
 }

--- a/src/services/fetchSearch.ts
+++ b/src/services/fetchSearch.ts
@@ -1,0 +1,37 @@
+/**
+ * fetchSearch — the cross-store search FETCH dispatcher. A store declares how its `bySearch`
+ * endpoint should be fetched (via `StoreCapabilities.searchFetch`); this routes each search URL to
+ * the matching transport and applies the store's request decoration:
+ *   - `http`        → a plain HTTP GET (Tier-1 cookieless JSON).
+ *   - `impersonate` → impit (browser-TLS-impersonating GET) with profile + headers (CF JSON APIs).
+ *   - `browser`     → a pooled browser navigation (rendered-DOM / JS-challenge stores).
+ * The `browser` transport degrades to `http` when no browser fetcher is wired, so headless/test
+ * compositions still work. Replaces the earlier boolean browser-vs-http routing.
+ */
+import type { SearchFetch } from '@figurecollecting/scraper-plugin-contract';
+
+export interface FetchSearchTransports {
+  /** Plain HTTP GET (Tier-1 cookieless JSON). */
+  http: (url: string) => Promise<string>;
+  /** impit TLS-impersonating GET (Cloudflare-fronted JSON APIs). */
+  impersonate: (url: string, opts: { browser?: string; headers?: Record<string, string>; userAgent?: string }) => Promise<string>;
+  /** Pooled browser navigation (rendered-DOM / JS-challenge). Optional — degrades to http if absent. */
+  browser?: (url: string, opts?: { headers?: Record<string, string>; userAgent?: string; cookies?: Record<string, string> }) => Promise<string>;
+}
+
+/** Build the per-store search fetcher from the three transports. */
+export function makeFetchSearch(t: FetchSearchTransports) {
+  return async function fetchSearch(url: string, searchFetch: SearchFetch): Promise<string> {
+    switch (searchFetch.transport) {
+      case 'impersonate':
+        return t.impersonate(url, { browser: searchFetch.browser, headers: searchFetch.headers, userAgent: searchFetch.userAgent });
+      case 'browser':
+        return t.browser
+          ? t.browser(url, { headers: searchFetch.headers, userAgent: searchFetch.userAgent, cookies: searchFetch.cookies })
+          : t.http(url);
+      case 'http':
+      default:
+        return t.http(url);
+    }
+  };
+}

--- a/src/services/fetchSearch.ts
+++ b/src/services/fetchSearch.ts
@@ -26,9 +26,11 @@ export function makeFetchSearch(t: FetchSearchTransports) {
       case 'impersonate':
         return t.impersonate(url, { browser: searchFetch.browser, headers: searchFetch.headers, userAgent: searchFetch.userAgent });
       case 'browser':
-        return t.browser
-          ? t.browser(url, { headers: searchFetch.headers, userAgent: searchFetch.userAgent, cookies: searchFetch.cookies })
-          : t.http(url);
+        // A store that explicitly needs a browser must NOT silently fall back to a plain GET — that
+        // returns a Cloudflare challenge PAGE the parser would treat as empty. Fail loud (→ the
+        // lookup's failed[]) instead of returning garbage.
+        if (!t.browser) throw new Error('search transport "browser" requested but no browser fetcher is wired');
+        return t.browser(url, { headers: searchFetch.headers, userAgent: searchFetch.userAgent, cookies: searchFetch.cookies });
       case 'http':
       default:
         return t.http(url);

--- a/src/services/impitFetch.ts
+++ b/src/services/impitFetch.ts
@@ -1,0 +1,59 @@
+/**
+ * impitFetch — a browser-TLS-impersonating HTTP GET (via impit) that clears Cloudflare's
+ * fingerprint gate WITHOUT launching a real browser. The light counterpart to
+ * ScrapingService.browserFetch, for CF-fronted JSON APIs (e.g. amiami's search endpoint) — ~600ms
+ * vs the browser's tens of seconds. impit is loaded LAZILY (dynamic import inside the default
+ * factory) so unit tests and non-impersonate code paths never touch the native binary. One Impit
+ * instance is cached per impersonation profile.
+ */
+
+/** Default impersonation profile. A LIVE TUNABLE — chrome110 already went stale to Cloudflare; keep recent. */
+const DEFAULT_PROFILE = 'chrome142';
+const TIMEOUT_MS = 15000;
+
+/** Minimal impit surface we depend on — lets tests inject a fake without the native module. */
+export interface ImpitLike {
+  fetch(url: string, init: { method: string; headers?: Record<string, string> }): Promise<{ text(): Promise<string> }>;
+}
+
+export interface ImpitFetchOptions {
+  /** Impersonation profile (impit browser), e.g. 'chrome142'. Defaults to a recent engine value. */
+  browser?: string;
+  headers?: Record<string, string>;
+  userAgent?: string;
+}
+
+/** Build a real impit instance for a profile — dynamic-imported so the native binary loads only on use. */
+async function defaultMakeImpit(browser: string): Promise<ImpitLike> {
+  const { Impit } = await import('impit');
+  // `browser` is a runtime-valid profile string; impit types it as a Browser enum.
+  return new Impit({ browser: browser as never, followRedirects: true, timeout: TIMEOUT_MS }) as unknown as ImpitLike;
+}
+
+export type MakeImpit = (browser: string) => ImpitLike | Promise<ImpitLike>;
+
+/**
+ * Build an impit body-fetcher. `makeImpit` is injectable (tests pass a fake); the default lazily
+ * loads the native impit. Returns `(url, opts?) => Promise<string>` — the same shape the lookup's
+ * fetchSearch dispatcher consumes.
+ */
+export function createImpitFetch(makeImpit: MakeImpit = defaultMakeImpit) {
+  const cache = new Map<string, ImpitLike>();
+  return async function impitFetchBody(url: string, opts: ImpitFetchOptions = {}): Promise<string> {
+    const browser = opts.browser || DEFAULT_PROFILE;
+    let impit = cache.get(browser);
+    if (!impit) {
+      impit = await makeImpit(browser);
+      cache.set(browser, impit);
+    }
+    const headers: Record<string, string> = {
+      ...(opts.userAgent ? { 'User-Agent': opts.userAgent } : {}),
+      ...(opts.headers ?? {}),
+    };
+    const res = await impit.fetch(url, { method: 'GET', headers });
+    return res.text();
+  };
+}
+
+/** The engine's default impit fetcher (real native impit, chrome142 default profile). */
+export const impitFetchBody = createImpitFetch();


### PR DESCRIPTION
## What

Folds a **browserless transport** into the cross-store `/lookup` search: `impit` (Apify's Rust TLS-impersonation HTTP client) reaches Cloudflare-fronted JSON APIs (amiami) by presenting a real-Chrome TLS/JA3 fingerprint — **~600ms vs the browser's ~60–90s**, and no browser-pool contention.

- **`impit` prod dependency** (pinned `0.14.3`, Apache-2.0, prebuilt NAPI — no daemon/subprocess/runtime-download) + worker Docker base → `node:20-slim` (impit `engines: node>=20`; puppeteer already supports 20).
- **`src/services/impitFetch.ts`** — `createImpitFetch()` → `(url, {browser, headers, userAgent})`. Lazy `import('impit')` inside the default factory + injectable `makeImpit`, so unit tests and non-impersonate paths never load the native binary. One Impit instance cached per profile; default profile **`chrome142`**.
- **`src/services/fetchSearch.ts`** — `makeFetchSearch()` dispatches a store's search URL to `http` | `impersonate` | `browser` and applies its headers/profile/cookies. `browser` degrades to `http` when unwired. **Generalizes A2's browser-vs-http boolean** into an explicit 3-way router.
- **Contract 0.3.3** — `SearchFetch { transport?, browser?, headers?, userAgent?, cookies? }` + `StoreCapabilities.searchFetch?` (opaque per-store data the private plugin fills, same pattern as `allowedCookies`/`rateLimit`). `ProfileRegistry.searchTransportFor(host)` resolves the explicit config or a default from `requiresBrowser`.
- **`assembleLookup` / `engineLookup` / `index.ts`** — the lookup seam now takes one `fetchSearch(url, searchFetch)`; the engine composes the three transports and the mount backs `browser` with the pooled `ScrapingService`.

## Additive & revertible

A store with **no** `searchFetch` behaves exactly as before this PR: `requiresBrowser:true` → `browser`, else → `http`. amiami switches to the impit path only when the **rulesets** PR declares `searchFetch: { transport:'impersonate', browser:'chrome142', headers:{'X-User-Key':'amiami_dev'} }`. Remove impit and the dispatcher falls back to `http`/`browser`.

## Live proof

`impit` `chrome142` → `api.amiami.com/api/v1.0/items?s_keywords=tomie` returned **HTTP 200, 23,551 results, real items** (Gyaru Tomie × HK, ¥18,800, JAN 4570232591424) in ~600ms from a cold run. Finding worth noting: **`chrome110` (the common reference profile) is now rejected at the TLS layer** — Cloudflare tightened; `chrome124`+ pass. That's why the impersonation profile is a per-store **live tunable**, not hard-coded.

## Tests
TDD. 100% coverage on `fetchSearch`/`assembleLookup`/`profileRegistry`/`engineLookup`; `impitFetch` logic 100% (the native-impit factory is the deliberate untested boundary, proven by the live run). `tsc` clean; full suite **587 passed / 3 todo** — the lone failure (`backendCommunication.test.ts`) is the pre-existing `import.meta` jest-transform flake, verified identical without this change.

## Follow-on
Rulesets PR: amiami's `searchFetch` config (the parser + `bySearch` are already authored) → amiami live in `/lookup` on the fast path. Keep puppeteer as the escalation fallback for any host that moves from TLS-fingerprint gating to a JS/managed challenge.