### PR TITLE
Record-mode /lookup: typed IdentityQuery → server-side per-store query (B step 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12297,7 +12297,7 @@
     },
     "packages/plugin-contract": {
       "name": "@figurecollecting/scraper-plugin-contract",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^6.0.3"

--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figurecollecting/scraper-plugin-contract",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -236,8 +236,11 @@ export interface RetrievalCapability {
    * (some stores' predictive endpoints, e.g. a Shopify `suggest.json` config, silently hide
    * sold-out). Absent scope defaults to `listed`. A `listed` endpoint + `SearchCandidate.available`
    * serves BOTH buy-decision modes; an `orderable`-only endpoint cannot answer the `listed` view.
+   * `acceptsGtin` = the endpoint full-texts a GTIN/barcode as the `{q}` (amiami/Woo/PrestaShop), so
+   * record-mode can substitute a JAN for a JAN-EXACT hit; absent = title-only (Shopify suggest), so
+   * record-mode falls back to a composed name/ER query. Filled by the plugin from `identity.keys`.
    */
-  bySearch?: { urlTemplate: string; scope?: 'listed' | 'orderable' };
+  bySearch?: { urlTemplate: string; scope?: 'listed' | 'orderable'; acceptsGtin?: boolean };
 }
 
 export type SearchTransport = 'http' | 'impersonate' | 'browser';
@@ -370,6 +373,26 @@ export interface SearchCandidate {
    * history).
    */
   available?: boolean;
+}
+
+/**
+ * A typed cross-store identity for RECORD-MODE lookup (POST /lookup) — the caller has a catalogued
+ * figure and wants current cross-store price/availability. The engine's per-store query composer
+ * turns this into each store's search query: a JAN-exact `{q}` where the store's bySearch
+ * `acceptsGtin` (or a barcode-byId detail plan), else a composed name/ER string from the remaining
+ * fields. All optional; a valid query needs at least a `gtin14` or a `name` (or studio+character/series).
+ */
+export interface IdentityQuery {
+  /** Canonical GTIN-14 (JAN/UPC/EAN folded) — the strongest cross-store anchor; used JAN-exact where supported. */
+  gtin14?: string;
+  studio?: string;
+  character?: string;
+  series?: string;
+  scale?: string;
+  figureType?: string;
+  version?: string;
+  /** Display name / title — the fallback query for title-indexed stores (Shopify) and no-JAN statues. */
+  name?: string;
 }
 
 export interface RuntimeConfig {

--- a/src/__tests__/unit/lookupRoute.test.ts
+++ b/src/__tests__/unit/lookupRoute.test.ts
@@ -7,18 +7,25 @@ import { createLookupRoute } from '../../routes/lookup';
 import type { Lookup, LookupResult } from '../../driver/assembleLookup';
 
 const result = (over: Partial<LookupResult> = {}): LookupResult => ({
-  query: 'tomie', mode: 'listed', results: [], unsupported: [], orderableOnly: [], failed: [], ...over,
+  query: 'tomie', mode: 'listed', results: [], unsupported: [], orderableOnly: [], failed: [], resolveTargets: [], ...over,
 });
 
 const appWith = (lookup: Lookup) => {
   const app = express();
+  app.use(express.json());
   app.use('/', createLookupRoute(lookup));
   return app;
 };
 
-describe('GET /lookup', () => {
+const mkLookup = (over: Partial<Lookup> = {}): Lookup => ({
+  lookup: jest.fn(async () => result()),
+  lookupByIdentity: jest.fn(async () => result()),
+  ...over,
+});
+
+describe('GET /lookup (discovery)', () => {
   it('returns the lookup result and passes q + mode through', async () => {
-    const lookup: Lookup = { lookup: jest.fn(async (q, opts) => result({ query: q, mode: opts?.mode ?? 'listed' })) };
+    const lookup = mkLookup({ lookup: jest.fn(async (q, opts) => result({ query: q, mode: opts?.mode ?? 'listed' })) });
 
     const res = await request(appWith(lookup)).get('/lookup?q=tomie&mode=orderable');
 
@@ -29,28 +36,73 @@ describe('GET /lookup', () => {
   });
 
   it('defaults mode to listed', async () => {
-    const lookup: Lookup = { lookup: jest.fn(async () => result()) };
+    const lookup = mkLookup();
     await request(appWith(lookup)).get('/lookup?q=tomie');
     expect(lookup.lookup).toHaveBeenCalledWith('tomie', { mode: 'listed' });
   });
 
   it('400 when q is missing or blank', async () => {
-    const lookup: Lookup = { lookup: jest.fn() };
+    const lookup = mkLookup();
     expect((await request(appWith(lookup)).get('/lookup')).status).toBe(400);
     expect((await request(appWith(lookup)).get('/lookup?q=%20')).status).toBe(400);
     expect(lookup.lookup).not.toHaveBeenCalled();
   });
 
   it('502 when the lookup throws (Error and non-Error alike)', async () => {
-    const errLookup: Lookup = { lookup: jest.fn(async () => { throw new Error('CF wall'); }) };
+    const errLookup = mkLookup({ lookup: jest.fn(async () => { throw new Error('CF wall'); }) });
     const errRes = await request(appWith(errLookup)).get('/lookup?q=tomie');
     expect(errRes.status).toBe(502);
     expect(errRes.body.error).toBe('lookup failed');
     expect(errRes.body.detail).toBe('CF wall');
 
-    const strLookup: Lookup = { lookup: jest.fn(async () => { throw 'boom-string'; }) };
+    const strLookup = mkLookup({ lookup: jest.fn(async () => { throw 'boom-string'; }) });
     const strRes = await request(appWith(strLookup)).get('/lookup?q=tomie');
     expect(strRes.status).toBe(502);
     expect(strRes.body.detail).toBe('boom-string');
+  });
+});
+
+describe('POST /lookup (record-mode)', () => {
+  it('parses the IdentityQuery body + mode and calls lookupByIdentity', async () => {
+    const lookup = mkLookup({
+      lookupByIdentity: jest.fn(async (id, opts) => result({ query: id.gtin14 ?? '', mode: opts?.mode ?? 'listed' })),
+    });
+
+    const res = await request(appWith(lookup)).post('/lookup').send({ gtin14: '4570232591424', name: 'Tomie', mode: 'orderable' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe('orderable');
+    expect(lookup.lookupByIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({ gtin14: '4570232591424', name: 'Tomie' }),
+      { mode: 'orderable' },
+    );
+  });
+
+  it('coerces a numeric gtin14 (JSON number) to a string instead of dropping it', async () => {
+    const lookup = mkLookup({ lookupByIdentity: jest.fn(async () => result()) });
+    const res = await request(appWith(lookup)).post('/lookup').send({ gtin14: 4570232591424, name: 'Tomie' });
+    expect(res.status).toBe(200);
+    expect(lookup.lookupByIdentity).toHaveBeenCalledWith(expect.objectContaining({ gtin14: '4570232591424' }), expect.anything());
+  });
+
+  it('400 when no usable key (scale/figureType alone, or studio without character/series)', async () => {
+    const lookup = mkLookup();
+    expect((await request(appWith(lookup)).post('/lookup').send({ scale: '1/7' })).status).toBe(400);
+    expect((await request(appWith(lookup)).post('/lookup').send({ studio: 'GSC' })).status).toBe(400); // manufacturer alone too broad
+    expect(lookup.lookupByIdentity).not.toHaveBeenCalled();
+  });
+
+  it('accepts studio paired with character or series', async () => {
+    const lookup = mkLookup();
+    const res = await request(appWith(lookup)).post('/lookup').send({ studio: 'GSC', character: 'Reze' });
+    expect(res.status).toBe(200);
+    expect(lookup.lookupByIdentity).toHaveBeenCalledWith(expect.objectContaining({ studio: 'GSC', character: 'Reze' }), expect.anything());
+  });
+
+  it('502 when lookupByIdentity throws', async () => {
+    const lookup = mkLookup({ lookupByIdentity: jest.fn(async () => { throw new Error('boom'); }) });
+    const res = await request(appWith(lookup)).post('/lookup').send({ name: 'Tomie' });
+    expect(res.status).toBe(502);
+    expect(res.body.detail).toBe('boom');
   });
 });

--- a/src/driver/__tests__/assembleLookup.test.ts
+++ b/src/driver/__tests__/assembleLookup.test.ts
@@ -169,3 +169,49 @@ describe('assembleLookup — cross-store buy-decision search, listed + orderable
     expect(out.results[0]?.siteId).toBe('woo');
   });
 });
+
+describe('lookupByIdentity — record mode (typed identity → per-store query)', () => {
+  const JAN = '4570232591424';
+  // amiami full-texts the JAN (acceptsGtin); plazajapan resolves the JAN straight to a detail page.
+  const AMIAMI = caps('amiami', 'api.amiami.com', { bySearch: { urlTemplate: 'https://api.amiami.com/items?s_keywords={q}', acceptsGtin: true } });
+  const PLAZA = caps('plazajapan', 'plazajapan.com', { byId: { urlTemplate: 'https://plazajapan.com/{id}', idKind: 'barcode' } });
+
+  it('routes JAN-exact / name / barcode-byId per store from one IdentityQuery', async () => {
+    const fetchSearch = jest.fn(async () => '[]');
+    const services: LookupServices = {
+      profiles: buildProfileRegistry([AMIAMI, GOODSMILEUS, PLAZA]),
+      getRulesetForUrl: (url) =>
+        url.includes('amiami') ? stub('amiami', () => [{ itemId: 'a1', name: 'Tomie', available: true }])
+        : url.includes('goodsmileus') ? stub('goodsmileus', () => GSUS_CANDIDATES)
+        : undefined,
+      fetchSearch,
+    };
+
+    const out = await assembleLookup(services).lookupByIdentity({ gtin14: JAN, name: 'Gyaru Tomie x Hello Kitty' });
+
+    // amiami: JAN-exact search (the JAN is in the fetched URL).
+    expect(fetchSearch).toHaveBeenCalledWith(expect.stringContaining(JAN), expect.anything());
+    // goodsmileus (title-index, no acceptsGtin): name search — the NAME is in the URL, not the JAN.
+    expect(fetchSearch).toHaveBeenCalledWith(expect.stringContaining('Gyaru'), expect.anything());
+    expect(fetchSearch).not.toHaveBeenCalledWith(expect.stringContaining('goodsmileus.com/search?q=' + JAN), expect.anything());
+    // plazajapan: barcode-byId → a RESOLVE TARGET (segregated), NOT a phantom candidate in results.
+    expect(out.results.find((r) => r.siteId === 'plazajapan')).toBeUndefined();
+    expect(out.resolveTargets).toContainEqual({ siteId: 'plazajapan', host: 'plazajapan.com', itemId: JAN, url: `https://plazajapan.com/${JAN}` });
+    expect(out.query).toBe(JAN); // the result's query label is the JAN
+  });
+
+  it('a name-only identity searches by name and skips JAN-only stores gracefully', async () => {
+    const fetchSearch = jest.fn(async () => JSON.stringify(GSUS_CANDIDATES));
+    const services: LookupServices = {
+      profiles: buildProfileRegistry([GOODSMILEUS, PLAZA]), // PLAZA is barcode-byId only → no name path
+      getRulesetForUrl: () => stub('goodsmileus', () => GSUS_CANDIDATES),
+      fetchSearch,
+    };
+
+    const out = await assembleLookup(services).lookupByIdentity({ name: 'Tomie' });
+
+    expect(out.results.map((r) => r.siteId)).toContain('goodsmileus');
+    expect(out.unsupported).toContain('plazajapan'); // no name search + no gtin14 for its byId
+    expect(out.query).toBe('Tomie');
+  });
+});

--- a/src/driver/__tests__/retrievalPlanner.test.ts
+++ b/src/driver/__tests__/retrievalPlanner.test.ts
@@ -3,9 +3,9 @@
  * templates. Covers by-id detail plans, single-store search, the cross-store `lookup` fan-out
  * (the buy-decision seam), and the `unsupported` coverage-gap report.
  */
-import type { RetrievalCapability, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import type { IdentityQuery, RetrievalCapability, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
 import { ProfileRegistry } from '../profileRegistry';
-import { planRetrieval, resolveByIdUrl, resolveSearchUrl } from '../retrievalPlanner';
+import { planRetrieval, resolveByIdUrl, resolveSearchUrl, composeStoreQuery, composeNameQuery } from '../retrievalPlanner';
 
 const caps = (siteId: string, host: string, retrieval?: RetrievalCapability): StoreCapabilities => ({
   siteId, name: siteId, domains: [host], requiresBrowser: false, allowedCookies: [],
@@ -65,5 +65,62 @@ describe('planRetrieval', () => {
     expect(p.plans.map((x) => x.host)).toEqual(['hlj.com']); // only hlj supports search
     expect(p.plans[0].url).toContain('4571245296726');
     expect(p.unsupported.sort()).toEqual(['amiami', 'nogo']); // no bySearch → coverage gap
+  });
+});
+
+describe('composeNameQuery', () => {
+  it('prefers the display name; else studio + character|series + scale', () => {
+    expect(composeNameQuery({ name: 'Gyaru Tomie x Hello Kitty', studio: 'GSC' })).toBe('Gyaru Tomie x Hello Kitty');
+    expect(composeNameQuery({ studio: 'WLOP', character: 'Aria', scale: '1/4' })).toBe('WLOP Aria 1/4');
+    expect(composeNameQuery({ studio: 'WLOP', series: 'Wings', scale: '1/4' })).toBe('WLOP Wings 1/4'); // character||series fallback
+    expect(composeNameQuery({})).toBeUndefined();
+  });
+});
+
+describe('composeStoreQuery', () => {
+  const JAN = '4570232591424';
+  const amiami = caps('amiami', 'amiami.com', { bySearch: { urlTemplate: 'https://api.amiami.com/items?s_keywords={q}', acceptsGtin: true } });
+  const shopify = caps('goodsmileus', 'goodsmileus.com', { bySearch: { urlTemplate: 'https://gsus/suggest.json?q={q}' } }); // acceptsGtin absent
+  const plaza = caps('plazajapan', 'plazajapan.com', { byId: { urlTemplate: 'https://plazajapan.com/{id}', idKind: 'barcode' } });
+  const nogo = caps('nogo', 'nogo.com', undefined);
+
+  it('JAN-exact search where the store bySearch acceptsGtin', () => {
+    expect(composeStoreQuery(amiami, { gtin14: JAN, name: 'Tomie' })).toEqual({ kind: 'search', q: JAN });
+  });
+  it('barcode-byId store resolves the JAN straight to a detail plan', () => {
+    expect(composeStoreQuery(plaza, { gtin14: JAN })).toEqual({ kind: 'detail', id: JAN });
+  });
+  it('title-index store (no acceptsGtin) ignores the JAN and searches by the composed name', () => {
+    expect(composeStoreQuery(shopify, { gtin14: JAN, name: 'Gyaru Tomie' })).toEqual({ kind: 'search', q: 'Gyaru Tomie' });
+  });
+  it('undefined when there is no usable query (no retrieval, or empty identity)', () => {
+    expect(composeStoreQuery(nogo, { gtin14: JAN, name: 'x' })).toBeUndefined(); // no retrieval axis
+    expect(composeStoreQuery(amiami, {})).toBeUndefined(); // no gtin, no name → nothing to search by
+  });
+});
+
+describe('planRetrieval record mode', () => {
+  const reg = () => {
+    const r = new ProfileRegistry();
+    r.register(caps('amiami', 'amiami.com', { bySearch: { urlTemplate: 'https://api.amiami.com/items?s_keywords={q}', acceptsGtin: true } }));
+    r.register(caps('goodsmileus', 'goodsmileus.com', { bySearch: { urlTemplate: 'https://gsus/suggest.json?q={q}' } }));
+    r.register(caps('plazajapan', 'plazajapan.com', { byId: { urlTemplate: 'https://plazajapan.com/{id}', idKind: 'barcode' } }));
+    r.register(caps('nogo', 'nogo.com', undefined));
+    return r;
+  };
+
+  it('composes each store query server-side: JAN-exact / name / barcode-byId / unsupported', () => {
+    const identity: IdentityQuery = { gtin14: '4570232591424', name: 'Gyaru Tomie x Hello Kitty' };
+    const p = planRetrieval(reg(), { mode: 'record', identity });
+    const bySite = Object.fromEntries(p.plans.map((x) => [x.siteId, x]));
+
+    expect(bySite.amiami.kind).toBe('search');
+    expect(bySite.amiami.url).toContain('4570232591424'); // JAN-exact
+    expect(bySite.goodsmileus.kind).toBe('search');
+    expect(bySite.goodsmileus.url).toContain('Gyaru'); // name, not the JAN
+    expect(bySite.goodsmileus.url).not.toContain('4570232591424');
+    expect(bySite.plazajapan.kind).toBe('detail');
+    expect(bySite.plazajapan.itemId).toBe('4570232591424'); // barcode-byId
+    expect(p.unsupported).toEqual(['nogo']);
   });
 });

--- a/src/driver/assembleLookup.ts
+++ b/src/driver/assembleLookup.ts
@@ -1,27 +1,19 @@
 /**
- * assembleLookup — the cross-store SEARCH runtime: the buy-decision fan-out. Given a query (a JAN,
- * or a studio+character/name(+ver)+scale combo when there's no JAN), it fans across every store
- * with a `retrieval.bySearch` axis, fetches each store's search endpoint, and parses the results
- * into `SearchCandidate[]` via that store's ruleset `extractCandidates` (contract 0.3.1).
+ * assembleLookup — the cross-store SEARCH runtime: the buy-decision fan-out. Two entrypoints over
+ * one shared fan-out:
+ *   - `lookup(query)`            — DISCOVERY: a free-text query fanned across every store's bySearch.
+ *   - `lookupByIdentity(identity)` — RECORD-MODE: a typed IdentityQuery (the caller has a catalogued
+ *     figure); the planner composes EACH store's query server-side — JAN-exact where the store's
+ *     bySearch `acceptsGtin`, a barcode-byId detail plan (plazajapan), else a composed name/ER query.
  *
- * TWO MODES over ONE fetch (no double-searching):
- *   - `listed`    — every item the store carries, incl. sold-out ("which stores have this?").
- *   - `orderable` — only in-stock/buyable items ("what can I buy right now?"), i.e. drop
- *     candidates whose `available === false`.
- * The store's `bySearch` should target the LISTED (complete) endpoint + each `SearchCandidate`
- * carries `available`, so both modes are views over the same result. Where a store's ONLY search
- * is `orderable`-scope (a predictive endpoint that hides sold-out), a `listed` query can't confirm
- * its sold-out items — that store is reported in `orderableOnly` rather than silently
- * under-counted (the false-negative that hid a sold-out solaris figure).
- *
- * Distinct from the byId currency crawl (assembleCrawlDriver): search DISCOVERS on demand. The
- * next stage (a follow-on) matches candidates by JAN-equality / ER and byId-fetches the full
- * record. Everything is injected so the fan-out is deterministic in tests.
+ * TWO MODES over ONE fetch: `listed` (all, incl. sold-out) vs `orderable` (drop `available === false`).
+ * A barcode-byId store yields a single "direct-hit" candidate (itemId = the gtin14) the caller
+ * confirms via /resolve — no search/parse. Everything is injected so the fan-out is deterministic.
  */
-import { planRetrieval } from './retrievalPlanner.js';
+import { planRetrieval, composeNameQuery } from './retrievalPlanner.js';
 import { sanitizeForLog } from '../utils/security.js';
 import type { ProfileRegistry } from './profileRegistry.js';
-import type { ExtractionRuleset, SearchCandidate, SearchFetch } from '@figurecollecting/scraper-plugin-contract';
+import type { ExtractionRuleset, IdentityQuery, SearchCandidate, SearchFetch } from '@figurecollecting/scraper-plugin-contract';
 
 export type LookupMode = 'listed' | 'orderable';
 
@@ -45,6 +37,18 @@ export interface StoreLookupResult {
   candidates: SearchCandidate[];
 }
 
+/**
+ * A barcode-byId direct hit (record-mode): a store whose byId URL IS the barcode, so a JAN resolves
+ * straight to a product page. It is NOT a screen candidate — it is UNVERIFIED (never fetched), so it
+ * is segregated here rather than surfaced as a phantom candidate; the caller confirms it via /resolve.
+ */
+export interface ResolveTarget {
+  siteId: string;
+  host: string;
+  itemId: string;
+  url: string;
+}
+
 export interface LookupResult {
   query: string;
   mode: LookupMode;
@@ -52,62 +56,90 @@ export interface LookupResult {
   /** Stores that cannot serve the search: no `bySearch` axis, or no `extractCandidates` parser. */
   unsupported: string[];
   /**
-   * Stores that DID return results but whose search is `orderable`-scope — so a `listed` query
-   * can't confirm their sold-out items (coverage caveat, not a failure). Always empty in
-   * `orderable` mode (where that scope is exactly what's wanted).
+   * Stores that DID return results but whose search is `orderable`-scope — a `listed` query can't
+   * confirm their sold-out items (coverage caveat, not a failure). Always empty in `orderable` mode.
    */
   orderableOnly: string[];
   /** Stores whose search fetch or parse errored (transparency, not silent drop). */
   failed: string[];
+  /**
+   * Barcode-byId direct hits (record-mode only): stores where the JAN resolves straight to a byId
+   * URL. UNVERIFIED — the caller confirms each via /resolve (which returns the full record incl
+   * price/availability). Kept OUT of `results` so an unfetched hit never poses as a real candidate.
+   */
+  resolveTargets: ResolveTarget[];
 }
 
 export interface Lookup {
+  /** DISCOVERY: fan a free-text query across every store's bySearch. */
   lookup(query: string, opts?: { mode?: LookupMode }): Promise<LookupResult>;
+  /** RECORD-MODE: fan a typed identity across stores, composing each store's query server-side. */
+  lookupByIdentity(identity: IdentityQuery, opts?: { mode?: LookupMode }): Promise<LookupResult>;
 }
 
+/** Representative `query` label for a record-mode result: the JAN if present, else the composed name. */
+const identityLabel = (identity: IdentityQuery): string => identity.gtin14 ?? composeNameQuery(identity) ?? '';
+
 export function assembleLookup(services: LookupServices): Lookup {
+  const runFanout = async (
+    plan: ReturnType<typeof planRetrieval>,
+    mode: LookupMode,
+    query: string,
+  ): Promise<LookupResult> => {
+    const unsupported = [...plan.unsupported];
+    const orderableOnly: string[] = [];
+    const failed: string[] = [];
+    const resolveTargets: ResolveTarget[] = [];
+
+    const settled = await Promise.all(
+      plan.plans.map(async (p): Promise<StoreLookupResult | null> => {
+        // Barcode-byId direct hit (record-mode): a RESOLVE TARGET, not a screen candidate. It is
+        // UNVERIFIED (we haven't fetched it), so segregate it into resolveTargets — never surface it
+        // as a phantom candidate (no name=barcode into the matcher, no unfetched hit in orderable mode).
+        if (p.kind === 'detail') {
+          resolveTargets.push({ siteId: p.siteId, host: p.host, itemId: p.itemId ?? '', url: p.url });
+          return null;
+        }
+
+        const ruleset = services.getRulesetForUrl(p.url);
+        if (!ruleset?.extractCandidates) {
+          unsupported.push(p.siteId); // has a bySearch URL but no parser yet
+          return null;
+        }
+        const scope = services.profiles.retrievalFor(p.host)?.bySearch?.scope ?? 'listed';
+        if (mode === 'listed' && scope === 'orderable') orderableOnly.push(p.siteId);
+        try {
+          const body = await services.fetchSearch(p.url, services.profiles.searchTransportFor(p.host));
+          let candidates = await ruleset.extractCandidates(body, p.url);
+          if (mode === 'orderable') candidates = candidates.filter((c) => c.available !== false);
+          return { siteId: p.siteId, host: p.host, url: p.url, candidates };
+        } catch (err) {
+          // Surface WHY a store dropped out (CF block / invalid impersonation profile / parse error).
+          // eslint-disable-next-line no-console
+          console.warn(`[lookup] ${sanitizeForLog(p.siteId)} search failed: ${sanitizeForLog(err instanceof Error ? err.message : String(err))}`);
+          failed.push(p.siteId);
+          return null;
+        }
+      }),
+    );
+
+    return {
+      query,
+      mode,
+      results: settled.filter((r): r is StoreLookupResult => r !== null),
+      unsupported,
+      orderableOnly,
+      failed,
+      resolveTargets,
+    };
+  };
+
   return {
     async lookup(query, opts = {}) {
-      const mode: LookupMode = opts.mode ?? 'listed';
-      const plan = planRetrieval(services.profiles, { mode: 'lookup', query });
-      const unsupported = [...plan.unsupported];
-      const orderableOnly: string[] = [];
-      const failed: string[] = [];
-
-      const settled = await Promise.all(
-        plan.plans.map(async (p): Promise<StoreLookupResult | null> => {
-          const ruleset = services.getRulesetForUrl(p.url);
-          if (!ruleset?.extractCandidates) {
-            unsupported.push(p.siteId); // has a bySearch URL but no parser yet
-            return null;
-          }
-          const scope = services.profiles.retrievalFor(p.host)?.bySearch?.scope ?? 'listed';
-          if (mode === 'listed' && scope === 'orderable') orderableOnly.push(p.siteId);
-          try {
-            // Fetch via the store's resolved transport (http / impersonate / browser + its headers).
-            const body = await services.fetchSearch(p.url, services.profiles.searchTransportFor(p.host));
-            let candidates = await ruleset.extractCandidates(body, p.url);
-            if (mode === 'orderable') candidates = candidates.filter((c) => c.available !== false);
-            return { siteId: p.siteId, host: p.host, url: p.url, candidates };
-          } catch (err) {
-            // Surface WHY a store dropped out (CF block / invalid impersonation profile / parse
-            // error) — otherwise every failure collapses into an indistinguishable `failed` entry.
-            // eslint-disable-next-line no-console
-            console.warn(`[lookup] ${sanitizeForLog(p.siteId)} search failed: ${sanitizeForLog(err instanceof Error ? err.message : String(err))}`);
-            failed.push(p.siteId);
-            return null;
-          }
-        }),
-      );
-
-      return {
-        query,
-        mode,
-        results: settled.filter((r): r is StoreLookupResult => r !== null),
-        unsupported,
-        orderableOnly,
-        failed,
-      };
+      return runFanout(planRetrieval(services.profiles, { mode: 'lookup', query }), opts.mode ?? 'listed', query);
+    },
+    async lookupByIdentity(identity, opts = {}) {
+      return runFanout(planRetrieval(services.profiles, { mode: 'record', identity }), opts.mode ?? 'listed', identityLabel(identity));
     },
   };
 }

--- a/src/driver/retrievalPlanner.ts
+++ b/src/driver/retrievalPlanner.ts
@@ -10,8 +10,40 @@
  * Search returns candidates, not final items — the two-stage `search → candidate ids → byId`
  * refinement is the caller's next step (a follow-on increment). Pure and synchronous.
  */
-import type { RetrievalCapability } from '@figurecollecting/scraper-plugin-contract';
+import type { IdentityQuery, RetrievalCapability, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
 import type { ProfileRegistry } from './profileRegistry.js';
+
+/** A store's targeted query, composed from an IdentityQuery per its capabilities. */
+export type ComposedQuery = { kind: 'search'; q: string } | { kind: 'detail'; id: string };
+
+/**
+ * Build a name/ER query string from the identity: prefer the display `name` (most likely to match a
+ * store's title index), else compose `studio character|series scale` (no-JAN statues / GK). Undefined
+ * when there's nothing to search by.
+ */
+export function composeNameQuery(identity: IdentityQuery): string | undefined {
+  if (identity.name?.trim()) return identity.name.trim();
+  const parts = [identity.studio, identity.character || identity.series, identity.scale]
+    .map((s) => (s ?? '').trim())
+    .filter((s) => s.length > 0);
+  return parts.length ? parts.join(' ') : undefined;
+}
+
+/**
+ * Compose ONE store's targeted query from a cross-store IdentityQuery, branching on its capabilities:
+ *   - `bySearch.acceptsGtin` + a gtin14  → JAN-exact search (amiami/Woo/PrestaShop).
+ *   - `byId.idKind === 'barcode'` + a gtin14 → the JAN resolves straight to a detail page (plazajapan).
+ *   - else a composed name/ER search where the store has bySearch (Shopify title-index, GK statues).
+ *   - else undefined → the store can't serve this identity (→ unsupported).
+ */
+export function composeStoreQuery(caps: StoreCapabilities, identity: IdentityQuery): ComposedQuery | undefined {
+  const r = caps.retrieval;
+  if (identity.gtin14 && r?.bySearch?.acceptsGtin) return { kind: 'search', q: identity.gtin14 };
+  if (identity.gtin14 && r?.byId?.idKind === 'barcode') return { kind: 'detail', id: identity.gtin14 };
+  const composed = composeNameQuery(identity);
+  if (composed && r?.bySearch) return { kind: 'search', q: composed };
+  return undefined;
+}
 
 /** Build an item detail URL from the byId template, `{id}` url-encoded. */
 export function resolveByIdUrl(retrieval: RetrievalCapability | undefined, itemId: string): string | undefined {
@@ -28,7 +60,8 @@ export function resolveSearchUrl(retrieval: RetrievalCapability | undefined, que
 export type RetrievalRequest =
   | { mode: 'byId'; host: string; itemIds: string[] }
   | { mode: 'search'; host: string; query: string }
-  | { mode: 'lookup'; query: string };
+  | { mode: 'lookup'; query: string }
+  | { mode: 'record'; identity: IdentityQuery };
 
 export interface FetchPlan {
   host: string;
@@ -63,6 +96,25 @@ export function planRetrieval(registry: ProfileRegistry, req: RetrievalRequest):
     const url = resolveSearchUrl(caps?.retrieval, req.query);
     if (url) plans.push({ host: req.host, siteId: caps?.siteId ?? '', url, kind: 'search' });
     else unsupported.push(caps?.siteId ?? req.host);
+    return { plans, unsupported };
+  }
+
+  if (req.mode === 'record') {
+    // record: fan a TYPED identity across every store, composing each store's query server-side
+    // (JAN-exact search / barcode-byId detail / composed name search) per its capabilities.
+    for (const caps of registry.all()) {
+      const composed = composeStoreQuery(caps, req.identity);
+      if (!composed) { unsupported.push(caps.siteId); continue; }
+      const url = composed.kind === 'search'
+        ? resolveSearchUrl(caps.retrieval, composed.q)
+        : resolveByIdUrl(caps.retrieval, composed.id);
+      if (url) {
+        plans.push({
+          host: caps.domains[0], siteId: caps.siteId, url, kind: composed.kind === 'search' ? 'search' : 'detail',
+          ...(composed.kind === 'detail' ? { itemId: composed.id } : {}),
+        });
+      } else unsupported.push(caps.siteId);
+    }
     return { plans, unsupported };
   }
 

--- a/src/routes/lookup.ts
+++ b/src/routes/lookup.ts
@@ -1,11 +1,16 @@
 /**
- * GET /lookup?q=<query>&mode=<listed|orderable> — the cross-store buy-decision search endpoint.
- * Fans the query across every store with a bySearch axis and returns per-store candidates plus the
- * coverage envelope (unsupported / orderableOnly / failed). `mode` defaults to `listed` (superset,
- * incl. sold-out); `orderable` filters to in-stock. The Lookup is injected so the route is testable.
+ * The cross-store buy-decision search endpoint, two shapes over one Lookup:
+ *   - GET  /lookup?q=<query>&mode=  — DISCOVERY: free-text fanned across every bySearch store.
+ *   - POST /lookup {IdentityQuery, mode?} — RECORD-MODE: a typed identity (JAN/name/studio/…) whose
+ *     per-store query is composed server-side (JAN-exact where supported, else name/ER).
+ * Both return per-store candidates + the coverage envelope (unsupported / orderableOnly / failed).
+ * `mode` defaults to `listed` (superset, incl. sold-out); `orderable` filters to in-stock. Injected.
  */
 import { Router, type Request, type Response } from 'express';
 import type { Lookup, LookupMode } from '../driver/assembleLookup.js';
+import type { IdentityQuery } from '@figurecollecting/scraper-plugin-contract';
+
+const parseMode = (m: unknown): LookupMode => (m === 'orderable' ? 'orderable' : 'listed');
 
 export function createLookupRoute(lookup: Lookup): Router {
   const router = Router();
@@ -16,9 +21,32 @@ export function createLookupRoute(lookup: Lookup): Router {
       res.status(400).json({ error: "query parameter 'q' is required" });
       return;
     }
-    const mode: LookupMode = req.query.mode === 'orderable' ? 'orderable' : 'listed';
     try {
-      res.json(await lookup.lookup(q, { mode }));
+      res.json(await lookup.lookup(q, { mode: parseMode(req.query.mode) }));
+    } catch (error) {
+      res.status(502).json({ error: 'lookup failed', detail: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  router.post('/lookup', async (req: Request, res: Response) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const str = (v: unknown): string | undefined => (typeof v === 'string' && v.trim() ? v.trim() : undefined);
+    // gtin14 is frequently sent as a JSON number — accept a finite number (14 digits is within the
+    // safe-integer range) rather than silently dropping it to the name-only fallback.
+    const gtin = (v: unknown): string | undefined => (typeof v === 'number' && Number.isFinite(v) ? String(v) : str(v));
+    const identity: IdentityQuery = {
+      gtin14: gtin(b.gtin14), studio: str(b.studio), character: str(b.character), series: str(b.series),
+      scale: str(b.scale), figureType: str(b.figureType), version: str(b.version), name: str(b.name),
+    };
+    // Require a query with real recall: a JAN, a name, or studio PAIRED with character/series. Studio
+    // (a manufacturer) alone would fan a near-empty query to every store — rejected.
+    const usable = !!(identity.gtin14 || identity.name || (identity.studio && (identity.character || identity.series)));
+    if (!usable) {
+      res.status(400).json({ error: 'a record-mode lookup needs a gtin14, a name, or studio + character/series' });
+      return;
+    }
+    try {
+      res.json(await lookup.lookupByIdentity(identity, { mode: parseMode(b.mode) }));
     } catch (error) {
       res.status(502).json({ error: 'lookup failed', detail: error instanceof Error ? error.message : String(error) });
     }


### PR DESCRIPTION
## What (build B, step 1)

Adds **record-mode** to the cross-store buy-decision search — the caller has a *catalogued figure* and wants current cross-store price/availability, without hand-building each store's query.

- **Contract 0.3.4**: `IdentityQuery {gtin14?, studio?, character?, series?, scale?, figureType?, version?, name?}` + `RetrievalCapability.bySearch.acceptsGtin?` (does the store full-text a GTIN as `{q}`? — filled by the private plugin from `identity.keys`).
- **`composeStoreQuery(caps, identity)`** (retrievalPlanner) — builds ONE store's query server-side: JAN-exact `{q}` where `acceptsGtin` (amiami/Woo/PrestaShop), a barcode-**byId** detail plan where `byId.idKind==='barcode'` (plazajapan), else a composed name/ER query (`composeNameQuery`: prefer name, else `studio character|series scale`) for title-index stores (Shopify) + no-JAN statues.
- **`planRetrieval` `record` mode** + **`assembleLookup.lookupByIdentity(identity, opts)`** — same fan-out as discovery; a barcode-byId plan yields a single direct-hit candidate (`itemId = gtin14`) the caller confirms via `/resolve` (step 2).
- **POST `/lookup`** (record-mode) alongside GET `/lookup?q=` (discovery) — 400 without a usable identity key; same envelope, same 502 wrapper.

The engine mount is unchanged (the route uses the injected `Lookup`; `express.json()` is already global). Why server-side: the per-store query DIFFERS by store (JAN vs name), so the branch must see each store's capabilities — only the planner's `registry.all()` loop does.

## Tests
TDD. `composeNameQuery`/`composeStoreQuery`/`planRetrieval record`/`lookupByIdentity`/POST route. 100% on assembleLookup + lookup.ts, 96.6% retrievalPlanner; `tsc` clean; full suite **598 passed / 3 todo** (sole failure = the pre-existing `import.meta` `backendCommunication` flake).

## Next
Step 2: POST `/resolve` (byId confirm → full ExtractedData incl `fields.gtin14`) — the matcher pass-2 bridge. Step 3: the spine ER matcher (wire `detectBarcodeMatches`).