### PR TITLE
POST /resolve: byId confirm → full ExtractedData incl gtin14 (B step 2)

### DIFF
--- a/src/__tests__/unit/engineResolve.test.ts
+++ b/src/__tests__/unit/engineResolve.test.ts
@@ -1,0 +1,32 @@
+/**
+ * createEngineResolve — builds a Resolve from the engine registry (allStores → ProfileRegistry) + a
+ * detail fetch, and byId-confirms an id into full ExtractedData.
+ */
+import { createEngineResolve } from '../../services/engineResolve';
+import type { LookupRegistry } from '../../services/engineLookup';
+import type { ExtractionRuleset, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+
+const STORE: StoreCapabilities = {
+  siteId: 'amiami', name: 'AmiAmi', domains: ['api.amiami.com'], requiresBrowser: false, allowedCookies: [],
+  rateLimit: { domain: 'api.amiami.com', baseDelayMs: 0, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+  retrieval: { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } },
+};
+
+const RULESET: ExtractionRuleset = {
+  siteId: 'amiami', version: '1.0.0',
+  extract: () => ({ source: { site: 'amiami', itemId: 'x', extractedAt: '2026-08-11T00:00:00.000Z' }, fields: { gtin14: '04570232591424' }, warnings: [] }),
+  validate: () => ({ valid: true, errors: [], warnings: [] }),
+};
+
+describe('createEngineResolve', () => {
+  it('builds a Resolve from the registry that byId-confirms via the injected fetchDetail', async () => {
+    const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => RULESET };
+    const fetchDetail = jest.fn(async () => ({ html: '<html/>', statusCode: 200 }));
+
+    const out = await createEngineResolve(registry, fetchDetail).resolve('amiami', ['FIGURE-206235']);
+
+    expect(fetchDetail).toHaveBeenCalledWith('https://www.amiami.com/eng/detail/?gcode=FIGURE-206235');
+    expect(out.unsupported).toBe(false);
+    expect(out.results[0]?.data?.fields.gtin14).toBe('04570232591424');
+  });
+});

--- a/src/__tests__/unit/resolveRoute.test.ts
+++ b/src/__tests__/unit/resolveRoute.test.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /resolve route — parses { site, ids }, calls the injected Resolve, returns the result;
+ * 400 on missing/empty, 502 on throw.
+ */
+import express from 'express';
+import request from 'supertest';
+import { createResolveRoute } from '../../routes/resolve';
+import type { Resolve, ResolveResult } from '../../driver/assembleResolve';
+
+const result = (over: Partial<ResolveResult> = {}): ResolveResult => ({
+  site: 'amiami', results: [], unsupported: false, failed: [], ...over,
+});
+
+const appWith = (resolve: Resolve) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createResolveRoute(resolve));
+  return app;
+};
+
+describe('POST /resolve', () => {
+  it('parses { site, ids } and returns the resolve result', async () => {
+    const resolve: Resolve = {
+      resolve: jest.fn(async (site, ids) => result({ site, results: ids.map((itemId) => ({ itemId, url: `u/${itemId}` })) })),
+    };
+
+    const res = await request(appWith(resolve)).post('/resolve').send({ site: 'amiami', ids: ['FIGURE-1', 'FIGURE-2'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.site).toBe('amiami');
+    expect(res.body.results.map((r: { itemId: string }) => r.itemId)).toEqual(['FIGURE-1', 'FIGURE-2']);
+    expect(resolve.resolve).toHaveBeenCalledWith('amiami', ['FIGURE-1', 'FIGURE-2']);
+  });
+
+  it('trims + drops non-string ids', async () => {
+    const resolve: Resolve = { resolve: jest.fn(async () => result()) };
+    await request(appWith(resolve)).post('/resolve').send({ site: 'amiami', ids: [' FIGURE-1 ', 3, '', 'FIGURE-2'] });
+    expect(resolve.resolve).toHaveBeenCalledWith('amiami', ['FIGURE-1', 'FIGURE-2']);
+  });
+
+  it('400 when site or ids are missing/empty', async () => {
+    const resolve: Resolve = { resolve: jest.fn() };
+    expect((await request(appWith(resolve)).post('/resolve').send({ ids: ['x'] })).status).toBe(400);
+    expect((await request(appWith(resolve)).post('/resolve').send({ site: 'amiami' })).status).toBe(400);
+    expect((await request(appWith(resolve)).post('/resolve').send({ site: 'amiami', ids: [] })).status).toBe(400);
+    expect((await request(appWith(resolve)).post('/resolve').send({ site: 'amiami', ids: [' ', 3] })).status).toBe(400);
+    expect(resolve.resolve).not.toHaveBeenCalled();
+  });
+
+  it('400 when ids exceeds the per-call cap (pool protection)', async () => {
+    const resolve: Resolve = { resolve: jest.fn() };
+    const ids = Array.from({ length: 26 }, (_, i) => `FIGURE-${i}`);
+    const res = await request(appWith(resolve)).post('/resolve').send({ site: 'amiami', ids });
+    expect(res.status).toBe(400);
+    expect(resolve.resolve).not.toHaveBeenCalled();
+  });
+
+  it('502 when resolve throws', async () => {
+    const resolve: Resolve = { resolve: jest.fn(async () => { throw new Error('pool dead'); }) };
+    const res = await request(appWith(resolve)).post('/resolve').send({ site: 'amiami', ids: ['x'] });
+    expect(res.status).toBe(502);
+    expect(res.body.detail).toBe('pool dead');
+  });
+});

--- a/src/driver/__tests__/assembleResolve.test.ts
+++ b/src/driver/__tests__/assembleResolve.test.ts
@@ -1,0 +1,117 @@
+/**
+ * assembleResolve — byId CONFIRM: fetch each id's detail page + run the store ruleset's extract() →
+ * full ExtractedData (incl fields.gtin14). Returns the data, never emits. Fakes model the fetch +
+ * ruleset so the composition (resolveByIdUrl → fetchDetail → extract, per-id failure isolation) is
+ * deterministic.
+ */
+import { assembleResolve, type ResolveServices } from '../assembleResolve';
+import { buildProfileRegistry } from '../profileRegistry';
+import type { ExtractedData, ExtractionRuleset, RetrievalCapability, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+
+const caps = (siteId: string, host: string, retrieval?: RetrievalCapability): StoreCapabilities => ({
+  siteId, name: siteId, domains: [host], requiresBrowser: false, allowedCookies: [],
+  rateLimit: { domain: host, baseDelayMs: 0, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+  retrieval,
+});
+
+const extracted = (gtin14: string): ExtractedData => ({
+  source: { site: 'amiami', itemId: 'x', extractedAt: '2026-08-11T00:00:00.000Z' },
+  fields: { gtin14, name: 'Gyaru Tomie x Hello Kitty' },
+  warnings: [],
+});
+
+const stub = (extract: ExtractionRuleset['extract']): ExtractionRuleset => ({
+  siteId: 'amiami', version: '1.0.0', extract, validate: () => ({ valid: true, errors: [], warnings: [] }),
+});
+
+const AMIAMI = caps('amiami', 'api.amiami.com', { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } });
+
+describe('assembleResolve — byId confirm', () => {
+  it('fetches each id detail + extracts full ExtractedData (incl fields.gtin14)', async () => {
+    const fetchDetail = jest.fn(async (url: string) => ({ html: `<html>${url}</html>`, statusCode: 200 }));
+    const services: ResolveServices = {
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => stub(() => extracted('04570232591424')),
+      fetchDetail,
+    };
+
+    const out = await assembleResolve(services).resolve('amiami', ['FIGURE-206235']);
+
+    expect(fetchDetail).toHaveBeenCalledWith('https://www.amiami.com/eng/detail/?gcode=FIGURE-206235');
+    expect(out.unsupported).toBe(false);
+    expect(out.results[0]?.itemId).toBe('FIGURE-206235');
+    expect(out.results[0]?.url).toBe('https://www.amiami.com/eng/detail/?gcode=FIGURE-206235');
+    expect(out.results[0]?.data?.fields.gtin14).toBe('04570232591424');
+    expect(out.results[0]?.gtin14).toBe('04570232591424'); // surfaced for the matcher
+    expect(out.failed).toEqual([]);
+  });
+
+  it('gates on HTTP status — a 4xx/5xx detail page is a failure, not an empty "confirm"', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // A CF challenge / 404 page returns a body a contract-compliant extract() parses to empty fields
+    // WITHOUT throwing — so without the status gate it would land in results with no gtin14.
+    const fetchDetail = jest.fn(async () => ({ html: '<html>Just a moment...</html>', statusCode: 403 }));
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => stub(() => ({ source: { site: 'amiami', itemId: 'x', extractedAt: 'z' }, fields: {}, warnings: ['empty'] })),
+      fetchDetail,
+    }).resolve('amiami', ['FIGURE-1']);
+
+    expect(out.results).toEqual([]);
+    expect(out.failed).toEqual(['FIGURE-1']);
+    warn.mockRestore();
+  });
+
+  it('a 200 confirm with no barcode surfaces gtin14: undefined (confirmed-but-unanchored, not a failure)', async () => {
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => stub(() => ({ source: { site: 'amiami', itemId: 'x', extractedAt: 'z' }, fields: { name: 'WLOP Statue' }, warnings: [] })),
+      fetchDetail: jest.fn(async () => ({ html: 'ok', statusCode: 200 })),
+    }).resolve('amiami', ['STATUE-1']);
+
+    expect(out.results[0]?.gtin14).toBeUndefined();
+    expect(out.results[0]?.data?.fields.name).toBe('WLOP Statue'); // still a real confirm
+    expect(out.failed).toEqual([]);
+  });
+
+  it('a site with no byId axis is unsupported — nothing fetched', async () => {
+    const noById = caps('shopify', 'shopify.com', { bySearch: { urlTemplate: 'https://x/s?q={q}' } });
+    const fetchDetail = jest.fn(async () => ({ html: 'x' }));
+    const out = await assembleResolve({ profiles: buildProfileRegistry([noById]), getRulesetForUrl: () => stub(() => extracted('1')), fetchDetail })
+      .resolve('shopify', ['h1']);
+
+    expect(out.unsupported).toBe(true);
+    expect(out.results).toEqual([]);
+    expect(fetchDetail).not.toHaveBeenCalled();
+  });
+
+  it('an id whose fetch/extract throws is reported failed; the rest still resolve', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchDetail = jest.fn(async (url: string) => {
+      if (url.includes('BAD')) throw new Error('CF wall');
+      return { html: 'ok' };
+    });
+    const services: ResolveServices = {
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => stub(() => extracted('123')),
+      fetchDetail,
+    };
+
+    const out = await assembleResolve(services).resolve('amiami', ['GOOD', 'BAD']);
+
+    expect(out.results.map((r) => r.itemId)).toEqual(['GOOD']);
+    expect(out.failed).toEqual(['BAD']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('BAD'));
+    warn.mockRestore();
+  });
+
+  it('an id with no matching ruleset is failed (not fetched)', async () => {
+    const fetchDetail = jest.fn(async () => ({ html: 'x' }));
+    const out = await assembleResolve({ profiles: buildProfileRegistry([AMIAMI]), getRulesetForUrl: () => undefined, fetchDetail })
+      .resolve('amiami', ['x']);
+
+    expect(out.failed).toEqual(['x']);
+    expect(out.results).toEqual([]);
+    expect(fetchDetail).not.toHaveBeenCalled();
+  });
+});

--- a/src/driver/assembleResolve.ts
+++ b/src/driver/assembleResolve.ts
@@ -1,0 +1,91 @@
+/**
+ * assembleResolve — the byId CONFIRM runtime (the matcher's pass-2 bridge, and /resolve's engine).
+ * Given a store + item ids (e.g. the `resolveTargets` a record-mode lookup surfaced, or a candidate
+ * the caller picked), it fetches each item's DETAIL page and runs the store's `ruleset.extract` →
+ * full `ExtractedData` (whose `fields.gtin14` the private byId ruleset populates). Unlike the crawl
+ * worker, it RETURNS the data and NEVER emits to the spine or touches a ledger.
+ *
+ * Composed from three existing primitives — `resolveByIdUrl` + an injected detail fetch + the
+ * ruleset's `extract` — so it reuses the same substrate the crawl worker is built from, one layer
+ * down, without the spine/ledger coupling. Everything injected → deterministic in tests.
+ */
+import { resolveByIdUrl } from './retrievalPlanner.js';
+import { sanitizeForLog } from '../utils/security.js';
+import type { ProfileRegistry } from './profileRegistry.js';
+import type { ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+
+export interface ResolveServices {
+  /** The store registry (built from the engine's registered capabilities). */
+  profiles: ProfileRegistry;
+  /** URL → ruleset (engine ExtractionRegistryImpl.getRulesetForUrl); the ruleset's extract() confirms. */
+  getRulesetForUrl: (url: string) => ExtractionRuleset | undefined;
+  /** Fetch a detail page's body (the pooled ScrapingService's scrapePage at the mount). */
+  fetchDetail: (url: string) => Promise<{ html: string; statusCode?: number }>;
+}
+
+export interface ResolveItem {
+  itemId: string;
+  url: string;
+  /** The confirmed record when fetch + extract succeeded. */
+  data?: ExtractedData;
+  /**
+   * The gtin14 the byId extract recovered, surfaced for the matcher. UNDEFINED means the confirm did
+   * NOT yield a barcode (a no-JAN statue, OR an SPA/CF page the browser fetch under-extracted) — so
+   * "confirmed but unanchored" is visible rather than a silent empty success.
+   */
+  gtin14?: string;
+}
+
+export interface ResolveResult {
+  site: string;
+  results: ResolveItem[];
+  /** The site has no byId axis (or is unknown) — none of the ids can be resolved. */
+  unsupported: boolean;
+  /** Item ids whose detail fetch or extract errored (transparency, not silent drop). */
+  failed: string[];
+}
+
+export interface Resolve {
+  resolve(site: string, ids: string[]): Promise<ResolveResult>;
+}
+
+export function assembleResolve(services: ResolveServices): Resolve {
+  return {
+    async resolve(site, ids) {
+      const caps = services.profiles.forSite(site);
+      if (!caps?.retrieval?.byId) {
+        return { site, results: [], unsupported: true, failed: [] };
+      }
+
+      const failed: string[] = [];
+      const settled = await Promise.all(
+        ids.map(async (itemId): Promise<ResolveItem | null> => {
+          const url = resolveByIdUrl(caps.retrieval, itemId);
+          const ruleset = url ? services.getRulesetForUrl(url) : undefined;
+          if (!url || !ruleset) {
+            failed.push(itemId);
+            return null;
+          }
+          try {
+            const { html, statusCode } = await services.fetchDetail(url);
+            // A 4xx/5xx page (CF challenge / gone / error) is NOT a confirm — extract would happily
+            // parse the error body into empty fields WITHOUT throwing, so gate on status explicitly.
+            if (statusCode !== undefined && statusCode >= 400) {
+              throw new Error(`detail fetch returned HTTP ${statusCode}`);
+            }
+            const data = await ruleset.extract(html, url);
+            const gtin14 = typeof data.fields.gtin14 === 'string' ? data.fields.gtin14 : undefined;
+            return { itemId, url, data, gtin14 };
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.warn(`[resolve] ${sanitizeForLog(site)}/${sanitizeForLog(itemId)} failed: ${sanitizeForLog(err instanceof Error ? err.message : String(err))}`);
+            failed.push(itemId);
+            return null;
+          }
+        }),
+      );
+
+      return { site, results: settled.filter((r): r is ResolveItem => r !== null), unsupported: false, failed };
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import scraperRoutes from './routes/scraper.js';
 import ingestRoutes from './routes/ingest.js';
 import { createLookupRoute } from './routes/lookup.js';
 import { createEngineLookup } from './services/engineLookup.js';
+import { createResolveRoute } from './routes/resolve.js';
+import { createEngineResolve } from './services/engineResolve.js';
 import { createScrapingService } from './services/engineServices/scrapingService.js';
 import { scraperDebug } from './utils/logger.js';
 
@@ -106,6 +108,9 @@ async function startServer(): Promise<void> {
     app.use('/', createLookupRoute(createEngineLookup(registry, {
       browser: (url, opts) => lookupScraping.browserFetch(url, opts),
     })));
+    // POST /resolve — byId confirm (detail fetch + ruleset.extract → full ExtractedData incl gtin14),
+    // the matcher pass-2 bridge. Detail fetch shares the same pooled ScrapingService as /lookup.
+    app.use('/', createResolveRoute(createEngineResolve(registry, (url) => lookupScraping.scrapePage(url))));
     if (plugins.length > 0) {
       console.log(`[PAGE-SCRAPER] Loaded ${plugins.length} plugin(s): ${plugins.map(p => `${p.name}@${p.version}`).join(', ')}`);
     }

--- a/src/routes/resolve.ts
+++ b/src/routes/resolve.ts
@@ -1,0 +1,38 @@
+/**
+ * POST /resolve { site, ids: [...] } — the byId CONFIRM endpoint. Fetches each id's detail page and
+ * runs the store ruleset's extract() → full ExtractedData (incl fields.gtin14), returning per-id
+ * results + `failed`/`unsupported`. The matcher's pass-2 bridge: turns a record-mode lookup's
+ * `resolveTargets` (or a picked candidate) into confirmed records. Never emits to the spine. Injected.
+ */
+import { Router, type Request, type Response } from 'express';
+import type { Resolve } from '../driver/assembleResolve.js';
+
+/** Cap ids per call: each id is a pooled browser detail fetch, shared with /lookup + the crawl queue. */
+const MAX_IDS = 25;
+
+export function createResolveRoute(resolve: Resolve): Router {
+  const router = Router();
+
+  router.post('/resolve', async (req: Request, res: Response) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const site = typeof b.site === 'string' ? b.site.trim() : '';
+    const ids = Array.isArray(b.ids)
+      ? b.ids.filter((x): x is string => typeof x === 'string' && x.trim().length > 0).map((x) => x.trim())
+      : [];
+    if (!site || ids.length === 0) {
+      res.status(400).json({ error: 'resolve needs { site, ids: [non-empty string, ...] }' });
+      return;
+    }
+    if (ids.length > MAX_IDS) {
+      res.status(400).json({ error: `too many ids (max ${MAX_IDS} per call)` });
+      return;
+    }
+    try {
+      res.json(await resolve.resolve(site, ids));
+    } catch (error) {
+      res.status(502).json({ error: 'resolve failed', detail: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  return router;
+}

--- a/src/services/engineResolve.ts
+++ b/src/services/engineResolve.ts
@@ -1,0 +1,18 @@
+/**
+ * engineResolve — wires the byId CONFIRM runtime (assembleResolve) to the engine's registry + a
+ * detail fetch. Mirrors createEngineLookup: the ProfileRegistry is built from the plugin-populated
+ * `allStores()`, rulesets resolve via `getRulesetForUrl`, and `fetchDetail` is the pooled
+ * ScrapingService's scrapePage (wired at the mount). Result: a ready `Resolve` the /resolve route calls.
+ */
+import { buildProfileRegistry } from '../driver/profileRegistry.js';
+import { assembleResolve, type Resolve } from '../driver/assembleResolve.js';
+import type { LookupRegistry } from './engineLookup.js';
+
+/** Build the byId-confirm Resolve from the engine's registered stores + a detail fetch. */
+export function createEngineResolve(
+  registry: LookupRegistry,
+  fetchDetail: (url: string) => Promise<{ html: string; statusCode?: number }>,
+): Resolve {
+  const profiles = buildProfileRegistry(registry.allStores());
+  return assembleResolve({ profiles, getRulesetForUrl: (url) => registry.getRulesetForUrl(url), fetchDetail });
+}


### PR DESCRIPTION
## What (build B, step 2)

The **byId CONFIRM** endpoint — the matcher's pass-2 bridge. Given a store + item ids (the `resolveTargets` a record-mode `/lookup` surfaced, or a candidate the caller picked), it fetches each item's DETAIL page and runs the store ruleset's `extract()` → full `ExtractedData` whose `fields.gtin14` the private byId ruleset populates.

- **`assembleResolve`** (`src/driver/assembleResolve.ts`) — composes three existing primitives: `resolveByIdUrl` + an injected detail fetch + `ruleset.extract`. Per-id failure isolation (`failed[]`); a site with no byId axis → `unsupported`. **Returns the data, never emits** — deliberately NOT `crawlWorker` (that emits to the spine + returns an Outcome).
- **`createEngineResolve`** (`src/services/engineResolve.ts`) — mirrors `createEngineLookup`: `allStores()` → ProfileRegistry, `getRulesetForUrl`, `fetchDetail`.
- **POST `/resolve` {site, ids}`** (`src/routes/resolve.ts`) — trims/drops non-string ids; 400 on missing/empty; 502 on throw. Mounted in `index.ts`, `fetchDetail` = the same pooled `ScrapingService.scrapePage` as `/lookup`.

Dovetails with step 1: record-mode `/lookup` surfaces barcode-byId direct-hits in `resolveTargets`; `/resolve` confirms them (and any picked candidate) into a full record carrying `gtin14` — the matcher pass-2 input.

## Tests
TDD. `assembleResolve` (fetch+extract, unsupported site, per-id failure isolation, no-ruleset), the route (parse/trim/400/502), and `createEngineResolve`. **100% line coverage** on all three; `tsc` clean; full suite **608 passed / 3 todo** (sole failure = the pre-existing `backendCommunication` flake).

## Note (transport)
`fetchDetail` uses the pooled browser `scrapePage` (mirrors the crawl worker's byId fetch). SPA/API stores whose detail needs the impersonate/api-client transport (amiami's Nuxt detail) are a follow-on refinement; the generic HTML path covers the majority.

## Next
Step 3: the spine ER matcher (wire `detectBarcodeMatches` in fc-aggregation) — pass-2 gtin14 lane consumes `/resolve` output.