### PR TITLE
Honor ruleset transport in ingest raw fetch, capture every lane

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -59,6 +59,25 @@ ignore:
       of the built image). The vendored x/net is internal to esbuild and never in the runtime attack
       surface. esbuild 0.28.1 is the latest release and still vendors x/net v0.40.0, so no bump removes it.
 
+  # 2026-08-14: GO-2026-5026 ALSO matches the Go STDLIB (go1.26.5) of the SAME esbuild binary
+  # covered by the x/net entry above — esbuild 0.28.1 is compiled with go1.26.5, and the finding
+  # was surfacing under package "stdlib" (not "golang.org/x/net"), so the entry above did not cover it.
+  # The stdlib fix is go1.26.6 (current stable per context7/grype; 1.25.13 is the 1.25 backport,
+  # 1.27.0-rc.3 is a release candidate, not stable). Identical containment: esbuild is dev/build-only
+  # (tsx devDependency, used only by the `dev` hot-reload; `npm run build` uses tsc, not esbuild),
+  # pruned from the production image by `npm ci --omit=dev`, and present ONLY in the multi-stage
+  # BUILDER layer — never in the shipped runtime. No esbuild release ships a go1.26.6 build yet, so
+  # there is nothing to bump to. REVIEW: remove when esbuild ships a build compiled with go >= 1.26.6.
+  - vulnerability: GO-2026-5026
+    package:
+      name: stdlib
+      type: go-module
+    reason: |
+      Same esbuild build-only binary as the golang.org/x/net entry above (dev/tsx, pruned from prod
+      by `npm ci --omit=dev`, builder-layer-only, absent from the shipped runtime). esbuild 0.28.1 is
+      compiled with go1.26.5; the stdlib fix is go1.26.6, not yet in any esbuild release, so no bump
+      removes it. Not runtime-reachable. Dated 2026-08-14; remove when esbuild rebuilds on go>=1.26.6.
+
   # 2026-08-08: brace-expansion / ip-address flagged by grype come from the Node runtime's
   # BUNDLED npm (/usr/local/lib/node_modules/npm/...), NOT this app's dependencies. Our app
   # deps are fixed (brace-expansion 5.0.9, ip-address 10.4.0) and pass NPM Audit + Trivy +

--- a/src/__tests__/unit/engineServices/capturingFetch.test.ts
+++ b/src/__tests__/unit/engineServices/capturingFetch.test.ts
@@ -1,0 +1,125 @@
+/**
+ * createCapturingFetch — the ingest path's transport-aware raw fetch. Dispatches on a store's
+ * declared SearchFetch transport (impersonate | http | browser | undeclared) exactly like
+ * fetchSearch's dispatcher, but ALWAYS captures the fetched bytes to the sink (today only the
+ * browser lane's navigateAndCapture does that) and returns the ingest path's `{ html }` shape.
+ */
+import { createCapturingFetch, type CapturingFetchTransports } from '../../../services/engineServices/capturingFetch';
+import { CollectingCaptureSink } from '../../../services/captureSink';
+
+function makeTransports() {
+  const calls: any[] = [];
+  const t: CapturingFetchTransports = {
+    http: jest.fn(async (url: string) => {
+      calls.push(['http', url]);
+      return 'HTTP-BODY';
+    }),
+    impersonate: jest.fn(async (url: string, opts: any) => {
+      calls.push(['impersonate', url, opts]);
+      return '{"json":"BODY"}';
+    }),
+    browser: {
+      scrapePage: jest.fn(async (url: string) => {
+        calls.push(['scrapePage', url]);
+        return { html: '<html>BROWSER</html>', url, title: 'T', statusCode: 200 };
+      }),
+      scrapePageStealth: jest.fn(async (url: string, opts: any) => {
+        calls.push(['scrapePageStealth', url, opts]);
+        return { html: '<html>STEALTH</html>', url, title: 'T', statusCode: 200 };
+      }),
+    },
+  };
+  return { t, calls };
+}
+
+describe('createCapturingFetch', () => {
+  it("routes 'impersonate' to the impit transport and captures the raw body under the 'api' lane", async () => {
+    const { t, calls } = makeTransports();
+    const sink = new CollectingCaptureSink();
+    const fetch = createCapturingFetch(t, sink);
+
+    const result = await fetch('https://api.sentai.example.test/item/1', {
+      transport: 'impersonate',
+      browser: 'chrome142',
+      headers: { 'X-User-Key': 'x' },
+    });
+
+    expect(result).toEqual({ html: '{"json":"BODY"}' });
+    expect(calls[0]).toEqual([
+      'impersonate',
+      'https://api.sentai.example.test/item/1',
+      { browser: 'chrome142', headers: { 'X-User-Key': 'x' }, userAgent: undefined },
+    ]);
+    // the browser was NEVER touched for an impersonate-transport store
+    expect(t.browser.scrapePage).not.toHaveBeenCalled();
+    expect(t.browser.scrapePageStealth).not.toHaveBeenCalled();
+    // raw bytes reached the sink
+    expect(sink.captures).toHaveLength(1);
+    expect(sink.captures[0]).toMatchObject({
+      url: 'https://api.sentai.example.test/item/1',
+      lane: 'api',
+    });
+    expect(sink.captures[0].bytes.toString('utf8')).toBe('{"json":"BODY"}');
+  });
+
+  it("routes 'http' to the plain fetch transport and captures the raw body", async () => {
+    const { t, calls } = makeTransports();
+    const sink = new CollectingCaptureSink();
+    const fetch = createCapturingFetch(t, sink);
+
+    const result = await fetch('https://json.example.test/item/1', { transport: 'http' });
+
+    expect(result).toEqual({ html: 'HTTP-BODY' });
+    expect(calls[0]).toEqual(['http', 'https://json.example.test/item/1']);
+    expect(t.browser.scrapePage).not.toHaveBeenCalled();
+    expect(sink.captures).toHaveLength(1);
+    expect(sink.captures[0].lane).toBe('api');
+  });
+
+  it("routes an explicit 'browser' transport to scrapePage (no cookies) — capture is the browser lane's own job", async () => {
+    const { t, calls } = makeTransports();
+    const sink = new CollectingCaptureSink();
+    const fetch = createCapturingFetch(t, sink);
+
+    const result = await fetch('https://rendered.example.test/item/1', { transport: 'browser' });
+
+    expect(result).toEqual({ html: '<html>BROWSER</html>' });
+    expect(calls).toEqual([['scrapePage', 'https://rendered.example.test/item/1']]);
+    // capturingFetch does not double-capture the browser lane (navigateAndCapture owns that)
+    expect(sink.captures).toHaveLength(0);
+  });
+
+  it('defaults an UNDECLARED transport to the browser lane (regression guard for HTML-rendered rulesets)', async () => {
+    const { t, calls } = makeTransports();
+    const sink = new CollectingCaptureSink();
+    const fetch = createCapturingFetch(t, sink);
+
+    const result = await fetch('https://myfigurecollection.net/item/12345', undefined);
+
+    expect(result).toEqual({ html: '<html>BROWSER</html>' });
+    expect(calls).toEqual([['scrapePage', 'https://myfigurecollection.net/item/12345']]);
+    expect(sink.captures).toHaveLength(0);
+  });
+
+  it('uses scrapePageStealth when cookies are supplied, for the browser lane only', async () => {
+    const { t, calls } = makeTransports();
+    const sink = new CollectingCaptureSink();
+    const fetch = createCapturingFetch(t, sink);
+    const cookies = { PHPSESSID: 'abc' };
+
+    const result = await fetch('https://myfigurecollection.net/item/12345', undefined, { cookies });
+
+    expect(result).toEqual({ html: '<html>STEALTH</html>' });
+    expect(calls).toEqual([['scrapePageStealth', 'https://myfigurecollection.net/item/12345', { cookies }]]);
+  });
+
+  it('a capture-sink failure never breaks the fetch (impersonate lane)', async () => {
+    const { t } = makeTransports();
+    const sink = { capture: jest.fn().mockRejectedValue(new Error('object store down')) };
+    const fetch = createCapturingFetch(t, sink);
+
+    await expect(
+      fetch('https://api.sentai.example.test/item/1', { transport: 'impersonate' })
+    ).resolves.toEqual({ html: '{"json":"BODY"}' });
+  });
+});

--- a/src/__tests__/unit/scrapeQueueTransport.test.ts
+++ b/src/__tests__/unit/scrapeQueueTransport.test.ts
@@ -1,0 +1,271 @@
+/**
+ * ScrapeQueue ingest transport tests — the ingest raw-fetch honors the ruleset's declared
+ * `searchFetch` transport (impersonate / http / browser) instead of always browser-fetching.
+ *
+ * Bug this covers: an `impersonate`-transport JSON-API store (e.g. sentai) was always fetched via
+ * the headless browser, which renders the `.js` JSON response as an HTML document. Handing that
+ * rendered HTML to a ruleset's JSON.parse-based extract() silently returned empty data — nothing
+ * reached the spine, no error thrown. The fix routes the raw fetch through the transport the store
+ * declares (mirroring what the /lookup path already does via profiles.searchTransportFor), and
+ * preserves the raw-capture sink on every lane (previously only the browser lane captured).
+ */
+
+// Persistent mock objects that survive clearAllMocks
+const mockNotifyItemSuccess = jest.fn().mockResolvedValue(true);
+const mockNotifyItemFailed = jest.fn().mockResolvedValue(true);
+const mockNotifyItemSkipped = jest.fn().mockResolvedValue(true);
+
+jest.mock('../../services/genericScraper', () => ({
+  BrowserPool: {
+    getStealthBrowser: jest.fn(),
+    getBrowser: jest.fn(),
+    returnBrowser: jest.fn(),
+    getPoolSize: jest.fn().mockReturnValue(2),
+    getPoolCapacity: jest.fn().mockReturnValue(3),
+    reset: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/webhookClient', () => ({
+  notifyItemSuccess: (...args: any[]) => mockNotifyItemSuccess(...args),
+  notifyItemFailed: (...args: any[]) => mockNotifyItemFailed(...args),
+  notifyItemSkipped: (...args: any[]) => mockNotifyItemSkipped(...args),
+}));
+
+import type { ExtractionRuleset, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import { ScrapeQueue, resetScrapeQueue } from '../../services/scrapeQueue';
+import { createExtractionRegistry, ExtractionRegistryImpl } from '../../services/extractionRegistry';
+import { CollectingCaptureSink } from '../../services/captureSink';
+
+/**
+ * Registry with a store whose full StoreCapabilities (incl. `searchFetch`) is registered — the
+ * same shape a real plugin uses to declare its transport. `registerSite` is typed against the
+ * narrower `SiteConfig`, so the capability object is built and typed as `StoreCapabilities` first
+ * (assignability, not an inline literal) to carry `searchFetch` through untouched.
+ */
+function makeRegistry(ruleset: ExtractionRuleset, domain: string, searchFetch?: StoreCapabilities['searchFetch']): ExtractionRegistryImpl {
+  const registry = createExtractionRegistry();
+  const caps: StoreCapabilities = {
+    siteId: ruleset.siteId,
+    name: 'Mock Store',
+    domains: [domain],
+    rateLimit: {
+      domain,
+      baseDelayMs: 1000,
+      minDelayMs: 500,
+      maxDelayMs: 5000,
+      backoffMultiplier: 1.5,
+      recoveryDivisor: 1.5,
+      successThreshold: 3,
+    },
+    requiresBrowser: false,
+    allowedCookies: [],
+    searchFetch,
+  };
+  registry.registerSite(caps);
+  registry.registerRuleset(ruleset);
+  return registry;
+}
+
+/** Fixture ruleset whose extract() JSON.parses the body — mirrors a real JSON-API ruleset. */
+function makeJsonRuleset(): ExtractionRuleset & { extract: jest.Mock } {
+  const extract = jest.fn((body: string, url: string) => {
+    const parsed = JSON.parse(body); // throws on non-JSON, e.g. a browser-rendered HTML wrapper
+    return {
+      source: {
+        site: 'mock-sentai',
+        itemId: '1',
+        url,
+        extractedAt: '2026-08-14T00:00:00.000Z',
+        rulesetVersion: '1.0.0',
+      },
+      fields: { name: parsed.name },
+      warnings: [],
+    };
+  });
+  return {
+    siteId: 'mock-sentai',
+    version: '1.0.0',
+    extract,
+    validate: () => ({ valid: true, errors: [], warnings: [] }),
+  };
+}
+
+function makeHtmlRuleset(): ExtractionRuleset & { extract: jest.Mock } {
+  const extract = jest.fn((html: string, url: string) => ({
+    source: {
+      site: 'mock-mfc',
+      itemId: '12345',
+      url,
+      extractedAt: '2026-08-14T00:00:00.000Z',
+      rulesetVersion: '1.0.0',
+    },
+    fields: { name: 'Kitagawa Marin' },
+    warnings: [],
+  }));
+  return {
+    siteId: 'mock-mfc',
+    version: '1.0.0',
+    extract,
+    validate: () => ({ valid: true, errors: [], warnings: [] }),
+  };
+}
+
+function makeScrapingStub(html = '<html><body>rendered</body></html>') {
+  return {
+    scrapePage: jest.fn().mockResolvedValue({ html, url: 'https://x.test/item/1', title: 'Item', statusCode: 200 }),
+    scrapePageStealth: jest.fn().mockResolvedValue({ html, url: 'https://x.test/item/1', title: 'Item', statusCode: 200 }),
+  };
+}
+
+describe('ScrapeQueue - ingest raw-fetch honors ruleset transport', () => {
+  let queue: ScrapeQueue;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers({ advanceTimers: true });
+    resetScrapeQueue();
+    mockNotifyItemSuccess.mockResolvedValue(true);
+    mockNotifyItemFailed.mockResolvedValue(true);
+    mockNotifyItemSkipped.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    if (queue) {
+      queue.stop();
+      queue.clear();
+    }
+    resetScrapeQueue();
+    jest.useRealTimers();
+  });
+
+  async function advanceAndFlush(ms: number, iterations: number = 3) {
+    for (let i = 0; i < iterations; i++) {
+      jest.advanceTimersByTime(ms / iterations);
+      await jest.advanceTimersByTimeAsync(50);
+    }
+  }
+
+  it('demonstrates the OLD bug: browser-rendering a JSON-API response and handing it to a JSON.parse-based ruleset throws', async () => {
+    // This is the failure mode the fix eliminates: page-rendering a JSON API through Chrome wraps
+    // the body in an HTML document (Chrome's JSON-viewer), so the SAME ruleset that correctly
+    // parses a raw impit/http body throws on the browser-rendered wrapper — extraction fails
+    // silently (the queue's try/catch around extract() turns it into a clean item failure, never
+    // reaching send(), so nothing lands on the spine).
+    const ruleset = makeJsonRuleset();
+    const chromeRenderedWrapper = '<html><head></head><body><pre>{"name":"Cannot Parse Me"}</pre></body></html>';
+
+    expect(() => ruleset.extract(chromeRenderedWrapper, 'https://api.sentai.example.test/item/1')).toThrow();
+    // ...whereas the exact same ruleset succeeds on the RAW body the fix now fetches (proven in
+    // the next test, end-to-end through the queue).
+    expect(() => ruleset.extract('{"name":"OK"}', 'https://api.sentai.example.test/item/1')).not.toThrow();
+  });
+
+  it("routes an impersonate-transport store's ingest fetch through impit, not the browser, and hands the raw JSON to extract()", async () => {
+    const ruleset = makeJsonRuleset();
+    const scraping = makeScrapingStub(); // would render JSON as HTML — must NOT be called
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+    const impersonate = jest.fn().mockResolvedValue('{"name":"Sentai Figure"}');
+    const sink = new CollectingCaptureSink();
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'api.sentai.example.test', { transport: 'impersonate', browser: 'chrome142' }));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+    queue.setIngestTransports({ impersonate });
+    queue.setCaptureSink(sink);
+
+    const url = 'https://api.sentai.example.test/item/1';
+    const result = queue.enqueue(url, { url });
+    await advanceAndFlush(500);
+    const data = await result.promise;
+
+    // impit was used, with the store's declared profile
+    expect(impersonate).toHaveBeenCalledWith(url, { browser: 'chrome142', headers: undefined, userAgent: undefined });
+    // the browser was never touched
+    expect(scraping.scrapePage).not.toHaveBeenCalled();
+    expect(scraping.scrapePageStealth).not.toHaveBeenCalled();
+    // the RAW json body (not a browser-rendered wrapper) reached extract()
+    expect(ruleset.extract).toHaveBeenCalledWith('{"name":"Sentai Figure"}', url);
+    expect(data).toEqual({ name: 'Sentai Figure' });
+    // spine emit happened — this is the "zero claims" bug, fixed
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0].fields).toEqual({ name: 'Sentai Figure' });
+    // the fetched bytes were captured (previously only the browser lane captured)
+    expect(sink.captures).toHaveLength(1);
+    expect(sink.captures[0]).toMatchObject({ url, lane: 'api' });
+    expect(sink.captures[0].bytes.toString('utf8')).toBe('{"name":"Sentai Figure"}');
+  });
+
+  it("routes an http-transport store's ingest fetch through plain HTTP and captures the body", async () => {
+    const ruleset = makeJsonRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+    const http = jest.fn().mockResolvedValue('{"name":"Tier1 Figure"}');
+    const sink = new CollectingCaptureSink();
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'json.example.test', { transport: 'http' }));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+    queue.setIngestTransports({ http });
+    queue.setCaptureSink(sink);
+
+    const url = 'https://json.example.test/item/1';
+    const result = queue.enqueue(url, { url });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    expect(http).toHaveBeenCalledWith(url);
+    expect(scraping.scrapePage).not.toHaveBeenCalled();
+    expect(ruleset.extract).toHaveBeenCalledWith('{"name":"Tier1 Figure"}', url);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(sink.captures).toHaveLength(1);
+    expect(sink.captures[0].lane).toBe('api');
+  });
+
+  it('a browser-transport (or no-transport) store still uses the browser lane (regression guard)', async () => {
+    const ruleset = makeHtmlRuleset();
+    const scraping = makeScrapingStub('<html><body><h1>Kitagawa Marin</h1></body></html>');
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+    const impersonate = jest.fn();
+    const http = jest.fn();
+
+    queue = new ScrapeQueue(false);
+    // no searchFetch declared at all — must default to the browser lane, not http
+    queue.setPluginRegistry(makeRegistry(ruleset, 'myfigurecollection.net', undefined));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+    queue.setIngestTransports({ impersonate, http });
+
+    const result = queue.enqueue('12345', { priority: 'WARM' });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    expect(scraping.scrapePage).toHaveBeenCalledWith('https://myfigurecollection.net/item/12345');
+    expect(impersonate).not.toHaveBeenCalled();
+    expect(http).not.toHaveBeenCalled();
+    expect(ruleset.extract).toHaveBeenCalledWith('<html><body><h1>Kitagawa Marin</h1></body></html>', 'https://myfigurecollection.net/item/12345');
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('an explicit browser-transport store also uses the browser lane and keeps cookie-driven stealth fetch', async () => {
+    const ruleset = makeHtmlRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'myfigurecollection.net', { transport: 'browser' }));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const cookies = { PHPSESSID: 'abc' };
+    const result = queue.enqueue('12345', { priority: 'WARM', sessionId: 'session1', cookies });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    expect(scraping.scrapePageStealth).toHaveBeenCalledWith('https://myfigurecollection.net/item/12345', { cookies });
+    expect(scraping.scrapePage).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/engineServices/capturingFetch.ts
+++ b/src/services/engineServices/capturingFetch.ts
@@ -1,0 +1,94 @@
+/**
+ * capturingFetch — the ingest path's transport-aware raw fetch. A store's declared
+ * `StoreCapabilities.searchFetch` says how to reach it (http / impersonate / browser); this
+ * dispatches a single item URL through that transport instead of always paying for a headless
+ * browser. Mirrors fetchSearch's dispatcher (same transport switch, same per-store
+ * headers/profile), but differs in two ways the ingest path needs:
+ *   - it captures the fetched bytes to the raw-capture sink on EVERY lane. Only the browser lane
+ *     captures on its own (navigateAndCapture writes the wire+dom lanes internally) — the
+ *     impit/http lanes are captured here, under the 'api' lane, so raw.capture + the raw store
+ *     stay populated no matter which transport served the fetch.
+ *   - it returns `{ html }` (the shape ruleset.extract() consumes), not a bare string.
+ *
+ * An UNDECLARED transport (no `SearchFetch` at all) resolves to the browser lane — this preserves
+ * existing behavior for HTML-rendered rulesets that predate per-store transport declarations, and
+ * is a deliberate divergence from ProfileRegistry.searchTransportFor()'s default (which falls back
+ * to `requiresBrowser`): the ingest path wants "declared transport, else browser", not "declared
+ * transport, else infer from requiresBrowser".
+ */
+import type { SearchFetch, ScrapePageOptions, ScrapePageResult } from '@figurecollecting/scraper-plugin-contract';
+import type { CaptureSink } from '../captureSink.js';
+import { buildRawCapture } from '../captureSink.js';
+import { sanitizeForLog } from '../../utils/security.js';
+
+export interface CapturingFetchResult {
+  html: string;
+}
+
+/** The browser lane's raw-fetch surface — it already captures internally via navigateAndCapture. */
+export interface BrowserLaneFetcher {
+  scrapePage(url: string, options?: ScrapePageOptions): Promise<ScrapePageResult>;
+  scrapePageStealth(url: string, options?: ScrapePageOptions): Promise<ScrapePageResult>;
+}
+
+export interface CapturingFetchTransports {
+  /** Plain HTTP GET (Tier-1 cookieless JSON/HTML). */
+  http: (url: string) => Promise<string>;
+  /** impit TLS-impersonating GET (Cloudflare-fronted JSON APIs). */
+  impersonate: (url: string, opts: { browser?: string; headers?: Record<string, string>; userAgent?: string }) => Promise<string>;
+  /** Pooled browser navigation — the fallback for `browser`/undeclared transports. */
+  browser: BrowserLaneFetcher;
+}
+
+export type CapturingFetch = (
+  url: string,
+  searchFetch: SearchFetch | undefined,
+  options?: { cookies?: Record<string, string> },
+) => Promise<CapturingFetchResult>;
+
+/** Hand a non-browser-lane body to the sink under the 'api' lane. Capturing must never break a fetch. */
+async function captureApiBody(sink: CaptureSink, url: string, body: string): Promise<void> {
+  try {
+    await sink.capture(buildRawCapture({
+      url,
+      lane: 'api',
+      bytes: Buffer.from(body, 'utf8'),
+      fetchedAt: new Date().toISOString(),
+    }));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`[CAPTURE] sink failed for ${sanitizeForLog(url)}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * Build the dispatcher. `sink` backs the impit/http lanes' capture (the browser lane captures
+ * itself, via whatever sink `transports.browser` was built with).
+ */
+export function createCapturingFetch(transports: CapturingFetchTransports, sink: CaptureSink): CapturingFetch {
+  return async function capturingFetch(url, searchFetch, options = {}) {
+    switch (searchFetch?.transport) {
+      case 'impersonate': {
+        const html = await transports.impersonate(url, {
+          browser: searchFetch.browser,
+          headers: searchFetch.headers,
+          userAgent: searchFetch.userAgent,
+        });
+        await captureApiBody(sink, url, html);
+        return { html };
+      }
+      case 'http': {
+        const html = await transports.http(url);
+        await captureApiBody(sink, url, html);
+        return { html };
+      }
+      case 'browser':
+      default: {
+        const page = options.cookies
+          ? await transports.browser.scrapePageStealth(url, { cookies: options.cookies })
+          : await transports.browser.scrapePage(url);
+        return { html: page.html };
+      }
+    }
+  };
+}

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -25,12 +25,19 @@ import { getSessionManager, resetSessionManager, SessionManager, SessionPausedEv
 import { notifyItemFailed } from './webhookClient.js';
 import { enrichmentLogger } from '../utils/logger.js';
 import { createScrapingService } from './engineServices/scrapingService.js';
+import { createCapturingFetch, type CapturingFetch, type CapturingFetchTransports } from './engineServices/capturingFetch.js';
 import { getRawCaptureSink } from './s3ObjectStore.js';
 import { createIngestEmitterFromEnv } from './ingestEmitter.js';
+import { impitFetchBody } from './impitFetch.js';
+import { httpFetchBody } from './engineLookup.js';
+import { buildProfileRegistry, ProfileRegistry } from '../driver/profileRegistry.js';
+import type { CaptureSink } from './captureSink.js';
 import type {
   ExtractionRuleset,
   ExtractedData as PluginExtractedData,
   ScrapingService,
+  StoreCapabilities,
+  SearchFetch,
 } from '@figurecollecting/scraper-plugin-contract';
 
 // ============================================================================
@@ -127,11 +134,14 @@ export interface EnqueueResult {
 }
 
 /**
- * Narrow view of the plugin extraction registry the queue needs to decide
- * whether an item's URL has a plugin-provided ruleset (ingest cutover seam).
+ * Narrow view of the plugin extraction registry the queue needs: resolving a ruleset for an
+ * item's URL (ingest cutover seam), and every registered store's capabilities — so the queue can
+ * resolve a store's declared raw-fetch transport (searchFetch) the same way the /lookup path does
+ * via ProfileRegistry.
  */
 export interface RulesetResolver {
   getRulesetForUrl(url: string): ExtractionRuleset | undefined;
+  allStores(): StoreCapabilities[];
 }
 
 /**
@@ -287,6 +297,18 @@ export class ScrapeQueue {
   private ingestEmitter: IngestSender | null = null;
   private rawPageFetcher: RawPageFetcher | null = null;
 
+  // Store-capability index (searchFetch/rateLimit/etc.), rebuilt alongside pluginRegistry — the
+  // ingest path's transport lookup (getSearchFetchFor) reads a store's declared searchFetch from
+  // here, same as the /lookup path's ProfileRegistry.
+  private profiles: ProfileRegistry | null = null;
+  // Non-browser raw-fetch transports for the ingest path (tests / DI); default lazily to the
+  // engine's real impit/http fetchers — the same ones /lookup uses.
+  private impersonateFetch: CapturingFetchTransports['impersonate'] | null = null;
+  private httpFetch: CapturingFetchTransports['http'] | null = null;
+  // Raw-capture sink for the ingest path's impit/http lanes (tests / DI); defaults lazily to the
+  // shared engine sink — the same one the browser lane's navigateAndCapture writes to.
+  private captureSink: CaptureSink | null = null;
+
   constructor(testMode?: boolean) {
     // Auto-detect test environment if not explicitly set
     this.testMode = testMode ?? (
@@ -315,6 +337,9 @@ export class ScrapeQueue {
    */
   setPluginRegistry(registry: RulesetResolver | null): void {
     this.pluginRegistry = registry;
+    // Rebuild the capability index whenever the registry changes so getSearchFetchFor never
+    // reads a stale store list (mirrors how createEngineLookup/createEngineResolve build theirs).
+    this.profiles = registry ? buildProfileRegistry(registry.allStores()) : null;
   }
 
   /**
@@ -326,11 +351,31 @@ export class ScrapeQueue {
   }
 
   /**
-   * Override the raw page-fetch service used by the ingest path (tests / DI).
+   * Override the raw page-fetch service used by the ingest path's browser lane (tests / DI).
    * Defaults lazily to the same engine scraping service plugins get.
    */
   setScrapingService(service: RawPageFetcher | null): void {
     this.rawPageFetcher = service;
+  }
+
+  /**
+   * Override the ingest path's non-browser raw-fetch transports (tests / DI). Only the keys
+   * supplied are replaced; omitted keys keep their current fetcher (real or previously injected).
+   */
+  setIngestTransports(transports: {
+    impersonate?: CapturingFetchTransports['impersonate'];
+    http?: CapturingFetchTransports['http'];
+  }): void {
+    if (transports.impersonate) this.impersonateFetch = transports.impersonate;
+    if (transports.http) this.httpFetch = transports.http;
+  }
+
+  /**
+   * Override the raw-capture sink used by the ingest path's impit/http lanes (tests / DI).
+   * Defaults lazily to the shared engine sink (getRawCaptureSink()).
+   */
+  setCaptureSink(sink: CaptureSink | null): void {
+    this.captureSink = sink;
   }
 
   /**
@@ -934,18 +979,46 @@ export class ScrapeQueue {
   }
 
   /**
-   * The ingest path: fetch raw HTML, hand it to the plugin's ruleset for
-   * extraction, and emit the result to the aggregation spine. No webhook
-   * leg here. Throws on fetch, extraction, or emit failure so the item
-   * flows through the queue's existing failure handling (never a silent
-   * drop). Returns the extracted field bag so waiting callers' promises
+   * The item URL's store's declared search transport (undefined = undeclared → the ingest fetch
+   * defaults to the browser lane). A lookup failure (e.g. unparseable URL, or no registry yet)
+   * is treated the same as "undeclared" rather than throwing — the raw fetch still gets a lane.
+   */
+  private getSearchFetchFor(url: string): SearchFetch | undefined {
+    if (!this.profiles) return undefined;
+    try {
+      return this.profiles.forHost(new URL(url).hostname)?.searchFetch;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Build the ingest path's transport-aware capturing fetch. Rebuilt per call (cheap — it's a
+   * thin dispatcher) so DI overrides from setIngestTransports/setCaptureSink/setScrapingService
+   * are always picked up, including ones applied after this queue instance already fetched once.
+   */
+  private getCapturingFetch(): CapturingFetch {
+    return createCapturingFetch(
+      {
+        impersonate: this.impersonateFetch ?? impitFetchBody,
+        http: this.httpFetch ?? httpFetchBody,
+        browser: this.getRawPageFetcher(),
+      },
+      this.captureSink ?? getRawCaptureSink(),
+    );
+  }
+
+  /**
+   * The ingest path: fetch the item's raw body via the store's declared transport (impersonate /
+   * http / browser — undeclared defaults to browser), hand it to the plugin's ruleset for
+   * extraction, and emit the result to the aggregation spine. No webhook leg here. Throws on
+   * fetch, extraction, or emit failure so the item flows through the queue's existing failure
+   * handling (never a silent drop). Returns the extracted field bag so waiting callers' promises
    * still resolve.
    */
   private async processViaIngest(item: QueueItem, ruleset: ExtractionRuleset): Promise<ScrapedData> {
-    const fetcher = this.getRawPageFetcher();
-    const page = item.cookies
-      ? await fetcher.scrapePageStealth(item.url, { cookies: item.cookies })
-      : await fetcher.scrapePage(item.url);
+    const searchFetch = this.getSearchFetchFor(item.url);
+    const page = await this.getCapturingFetch()(item.url, searchFetch, { cookies: item.cookies });
 
     let extracted: PluginExtractedData;
     try {


### PR DESCRIPTION
The ingest path (processViaIngest) always browser-fetched the item URL, ignoring each ruleset's declared searchFetch.transport. For JSON-API rulesets (transport impersonate, e.g. sentai) the headless browser renders the .js JSON as HTML, so the JSON.parse-based extract() silently returns empty — nothing reaches the spine (confirmed live: a Sentai ingest produced 0 raw.capture rows / 0 claims).

Fix: new capturingFetch dispatches on the store's declared transport (impersonate->impit, http->plain GET, browser/undeclared->pooled browser) and captures fetched bytes to the raw-capture sink on every lane (non-browser lanes under a new 'api' lane; browser lane self-captures via navigateAndCapture). Undeclared transport defaults to browser (NOT requiresBrowser-inferred), preserving un-migrated HTML rulesets. Fixes ingest for every JSON-API ruleset uniformly (sentai/goodsmileus/projectke), retiring the per-ruleset extractAsync workaround.

Tests: 2 new suites (dispatch + queue-level routing incl. a regression guard); red->green proven; full suite 623 passed / 0 failed; tsc clean.