### PR TITLE
De-MFC ingest-path logging: site-agnostic wording

### DIFF
--- a/src/__tests__/unit/scrapeQueueIngest.test.ts
+++ b/src/__tests__/unit/scrapeQueueIngest.test.ts
@@ -401,6 +401,40 @@ describe('ScrapeQueue - ingest cutover', () => {
     expect(queue.getStats().failed).toBe(1);
   });
 
+  it('logs ingest failures without MFC-era wording, keyed by the item URL as sourceUrl', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const ruleset = makeRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockRejectedValue(new Error('spine unavailable after retries'));
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'sentaifilmworks.example.test'));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const url = 'https://sentaifilmworks.example.test/products/some-figure.js';
+    const result = queue.enqueue(url, { url, priority: 'WARM', maxRetries: 0 });
+    const promiseRef = result.promise.catch((e: Error) => e);
+
+    await advanceAndFlush(500);
+    await advanceAndFlush(5000);
+    await promiseRef;
+
+    const loggedLines = logSpy.mock.calls.map((call) => String(call[0]));
+    const queueFailureLine = loggedLines.find((line) => line.includes('[SCRAPE QUEUE] Failed'));
+    const ingestFailureLine = loggedLines.find((line) => line.includes('[INGEST]') && line.includes('FAILURE'));
+
+    expect(queueFailureLine).toBeDefined();
+    expect(queueFailureLine).not.toContain('MFC');
+    expect(queueFailureLine).toContain(url);
+
+    expect(ingestFailureLine).toBeDefined();
+    expect(ingestFailureLine).not.toContain('ENRICHMENT');
+    expect(ingestFailureLine).toContain(`sourceUrl=${url}`);
+
+    logSpy.mockRestore();
+  });
+
   it('fails the item and logs the error when extraction throws', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const ruleset = makeRuleset(

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -543,7 +543,7 @@ export class ScrapeQueue {
       promise.catch(() => {});
 
       // mfcId can be a caller-supplied URL (trigger route) — sanitize for log
-      console.log(`[SCRAPE QUEUE] Deduplicated request for MFC ${sanitizeForLog(mfcId)} (${existingItem.waitingUserIds.length} users waiting)`); // lgtm[js/log-injection]
+      console.log(`[SCRAPE QUEUE] Deduplicated request for ${sanitizeForLog(mfcId)} (${existingItem.waitingUserIds.length} users waiting)`); // lgtm[js/log-injection]
 
       return {
         id: existingItem.id,
@@ -594,7 +594,7 @@ export class ScrapeQueue {
     this.statusQueued[itemStatus]++;
 
     // mfcId can be a caller-supplied URL (trigger route) — sanitize for log
-    console.log(`[SCRAPE QUEUE] Enqueued MFC ${sanitizeForLog(mfcId)} at priority ${effectivePriority} (queue size: ${this.getStats().total})`); // lgtm[js/log-injection]
+    console.log(`[SCRAPE QUEUE] Enqueued ${sanitizeForLog(mfcId)} at priority ${effectivePriority} (queue size: ${this.getStats().total})`); // lgtm[js/log-injection]
 
     // Start processing if not already running (skip in test mode)
     if (!this.testMode) {
@@ -685,7 +685,7 @@ export class ScrapeQueue {
     const cancelError = new Error('Request cancelled');
     item.resolvers.forEach(({ reject }) => reject(cancelError));
 
-    console.log(`[SCRAPE QUEUE] Cancelled request for MFC ${mfcId}`);
+    console.log(`[SCRAPE QUEUE] Cancelled request for ${mfcId}`);
     return true;
   }
 
@@ -811,7 +811,7 @@ export class ScrapeQueue {
     item.priority = newPriority;
     this.addToQueue(item);
 
-    console.log(`[SCRAPE QUEUE] Upgraded MFC ${item.mfcId} to ${newPriority}`);
+    console.log(`[SCRAPE QUEUE] Upgraded ${item.mfcId} to ${newPriority}`);
   }
 
   private comparePriority(a: QueuePriority, b: QueuePriority): number {
@@ -925,7 +925,7 @@ export class ScrapeQueue {
     this.lastRequestTime = now;
 
     const poolAvailable = BrowserPool.getPoolSize();
-    console.log(`[SCRAPE QUEUE] Processing MFC ${item.mfcId} (${item.priority}, attempt ${item.retryCount + 1}/${item.maxRetries + 1}, delay=${this.currentDelay}ms, pool=${poolAvailable}/${BrowserPool.getPoolCapacity()})`);
+    console.log(`[SCRAPE QUEUE] Processing ${item.mfcId} (${item.priority}, attempt ${item.retryCount + 1}/${item.maxRetries + 1}, delay=${this.currentDelay}ms, pool=${poolAvailable}/${BrowserPool.getPoolCapacity()})`);
 
     try {
       // Extraction is plugin-only: an ingest emitter must be configured AND
@@ -1157,7 +1157,7 @@ export class ScrapeQueue {
     // Resolve all waiting promises
     item.resolvers.forEach(({ resolve }) => resolve(result));
 
-    console.log(`[SCRAPE QUEUE] Completed MFC ${item.mfcId} (${item.waitingUserIds.length} users notified, delay=${this.currentDelay}ms)`);
+    console.log(`[SCRAPE QUEUE] Completed ${item.mfcId} (${item.waitingUserIds.length} users notified, delay=${this.currentDelay}ms)`);
   }
 
   private handleFailure(item: QueueItem, error: Error): void {
@@ -1167,7 +1167,7 @@ export class ScrapeQueue {
     item.retryCount++;
 
     const durationMs = Date.now() - item.queuedAt;
-    console.log(`[SCRAPE QUEUE] Failed MFC ${item.mfcId}: ${errorType} - ${sanitizeForLog(error.message)}`);
+    console.log(`[SCRAPE QUEUE] Failed ${item.mfcId}: ${errorType} - ${sanitizeForLog(error.message)}`);
 
     // Log enrichment failure for analysis
     enrichmentLogger.failure(item.mfcId, errorType, error.message, {
@@ -1181,7 +1181,7 @@ export class ScrapeQueue {
     if (errorType === 'rate_limited') {
       this.handleRateLimit();
 
-      // Log rate limit event specifically for MFC busy analysis
+      // Log rate limit event for rate-limit analysis
       const isCloudflare = error.message.toLowerCase().includes('cloudflare');
       enrichmentLogger.rateLimited(item.mfcId, item.sessionId, isCloudflare);
 
@@ -1219,7 +1219,7 @@ export class ScrapeQueue {
 
       if (failureResult.shouldRetry && failureResult.cooldownMs > 0) {
         // Apply cooldown delay before retry
-        console.log(`[SCRAPE QUEUE] Cookie failure - retrying MFC ${item.mfcId} after ${failureResult.cooldownMs / 1000}s cooldown`);
+        console.log(`[SCRAPE QUEUE] Cookie failure - retrying ${item.mfcId} after ${failureResult.cooldownMs / 1000}s cooldown`);
         this.addToQueue(item);
         return;
       }
@@ -1230,7 +1230,7 @@ export class ScrapeQueue {
       // Re-queue for retry
       this.addToQueue(item);
       enrichmentLogger.retry(item.mfcId, item.retryCount, item.maxRetries, item.sessionId);
-      console.log(`[SCRAPE QUEUE] Retrying MFC ${item.mfcId} (attempt ${item.retryCount + 1})`);
+      console.log(`[SCRAPE QUEUE] Retrying ${item.mfcId} (attempt ${item.retryCount + 1})`);
     } else {
       // Give up
       this.failedCount++;
@@ -1243,7 +1243,7 @@ export class ScrapeQueue {
       // Notify backend of permanent failure via webhook (non-blocking)
       if (item.sessionId) {
         notifyItemFailed(item.sessionId, item.mfcId, `${errorType}: ${error.message}`).catch(() => {
-          console.warn(`[SCRAPE QUEUE] Webhook notification failed for MFC ${item.mfcId}`);
+          console.warn(`[SCRAPE QUEUE] Webhook notification failed for ${item.mfcId}`);
         });
       }
 
@@ -1251,7 +1251,7 @@ export class ScrapeQueue {
       const finalError = new Error(`Scrape failed: ${errorType} - ${error.message}`);
       item.resolvers.forEach(({ reject }) => reject(finalError));
 
-      console.log(`[SCRAPE QUEUE] Gave up on MFC ${item.mfcId} after ${item.retryCount} attempts`);
+      console.log(`[SCRAPE QUEUE] Gave up on ${item.mfcId} after ${item.retryCount} attempts`);
     }
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -179,7 +179,7 @@ export const scraperDebug = {
  */
 export interface EnrichmentEvent {
   event: 'start' | 'success' | 'failure' | 'retry' | 'skip' | 'rate_limited';
-  mfcId: string;
+  sourceUrl: string;
   sessionId?: string;
   status?: 'owned' | 'ordered' | 'wished';
   errorType?: string;
@@ -215,10 +215,10 @@ export const enrichmentLogger = {
     const timestamp = new Date().toISOString();
     const entry = {
       timestamp,
-      component: 'ENRICHMENT',
+      component: 'INGEST',
       ...event,
     };
-    const logLine = `[${timestamp}] [ENRICHMENT] ${event.event.toUpperCase()} mfcId=${event.mfcId} ${JSON.stringify(entry)}`;
+    const logLine = `[${timestamp}] [INGEST] ${event.event.toUpperCase()} sourceUrl=${event.sourceUrl} ${JSON.stringify(entry)}`;
 
     // Console output
     console.log(logLine);
@@ -230,7 +230,7 @@ export const enrichmentLogger = {
   /**
    * Log successful enrichment with field completeness for analysis
    */
-  success(mfcId: string, sessionId?: string, durationMs?: number, fields?: {
+  success(sourceUrl: string, sessionId?: string, durationMs?: number, fields?: {
     imageUrl?: boolean;
     name?: boolean;
     manufacturer?: boolean;
@@ -238,13 +238,13 @@ export const enrichmentLogger = {
     releaseDate?: boolean;
     price?: boolean;
   }): void {
-    this.log({ event: 'success', mfcId, sessionId, durationMs, fields });
+    this.log({ event: 'success', sourceUrl, sessionId, durationMs, fields });
   },
 
   /**
    * Log failed enrichment with error details
    */
-  failure(mfcId: string, errorType: string, reason: string, opts?: {
+  failure(sourceUrl: string, errorType: string, reason: string, opts?: {
     sessionId?: string;
     httpStatus?: number;
     retryCount?: number;
@@ -253,7 +253,7 @@ export const enrichmentLogger = {
   }): void {
     this.log({
       event: 'failure',
-      mfcId,
+      sourceUrl,
       errorType,
       reason,
       ...opts,
@@ -261,28 +261,28 @@ export const enrichmentLogger = {
   },
 
   /**
-   * Log rate limit event (MFC busy)
+   * Log rate limit event (site busy / rate limited)
    */
-  rateLimited(mfcId: string, sessionId?: string, isCloudflare?: boolean): void {
+  rateLimited(sourceUrl: string, sessionId?: string, isCloudflare?: boolean): void {
     this.log({
       event: 'rate_limited',
-      mfcId,
+      sourceUrl,
       sessionId,
-      reason: isCloudflare ? 'Cloudflare block' : 'MFC rate limit (429/503)',
+      reason: isCloudflare ? 'Cloudflare block' : 'Rate limited (429/503)',
     });
   },
 
   /**
    * Log retry attempt
    */
-  retry(mfcId: string, retryCount: number, maxRetries: number, sessionId?: string): void {
-    this.log({ event: 'retry', mfcId, retryCount, maxRetries, sessionId });
+  retry(sourceUrl: string, retryCount: number, maxRetries: number, sessionId?: string): void {
+    this.log({ event: 'retry', sourceUrl, retryCount, maxRetries, sessionId });
   },
 
   /**
    * Log skipped item (already exists, duplicate, etc.)
    */
-  skip(mfcId: string, reason: string, sessionId?: string): void {
-    this.log({ event: 'skip', mfcId, reason, sessionId });
+  skip(sourceUrl: string, reason: string, sessionId?: string): void {
+    this.log({ event: 'skip', sourceUrl, reason, sessionId });
   },
 };


### PR DESCRIPTION
The ingest/scrape-queue logging still hardcoded MFC-era vocabulary even though the engine is now site-agnostic. A Sentai ingest failure logged as `[SCRAPE QUEUE] Failed MFC …` and `[ENRICHMENT] FAILURE mfcId=<url>`, reading as if it had taken a legacy MFC/browser path when it did not — actively misleading during the recent Sentai ingest bring-up.

**Changes (logging vocabulary only — no control-flow / contract changes):**
- `logger.ts`: `EnrichmentEvent.mfcId` → `sourceUrl`; component label `ENRICHMENT` → `INGEST`; rate-limit wording de-MFC'd.
- `scrapeQueue.ts`: 12 log sites drop the false "MFC" qualifier (`Failed MFC …` → `Failed …`, etc.).
- Adds a regression test asserting ingest-failure logs carry no `MFC`/`ENRICHMENT` wording and key the URL as `sourceUrl`.

**Deliberately left (out of scope for a logging fix):** the `QueueItem.mfcId` public-API field (documented dual-purpose contract key), `waitingUserIds` / "users notified" (a data-model name, separate concern), and genuinely MFC-specific code (`sessionManager`, `webhookClient`, `scraperDebug.mfc`).

**Verified:** red→green reproduced (the new test fails on `develop` with the real `Failed MFC …` line, passes after the fix); full suite **624 passed / 56 suites**, build clean.