### PR TITLE
Add extractMany and fetchBody to the plugin contract (0.4.0, additive) for multi-record extracts

### DIFF
--- a/packages/plugin-contract/CHANGELOG.md
+++ b/packages/plugin-contract/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `@figurecollecting/scraper-plugin-contract` will be documented in this
+file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); this
+package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2026-08-19
+
+Additive, backward-compatible: every existing 2-argument ruleset and every existing
+`ExtractContext` consumer still compiles unchanged. Built for orzgk Slice B (multi-record
+extract, see the Slice B build-ready spec, §1/§3.1/§6 B1/§10 D9).
+
+### Added
+- `ExtractionRuleset.extractMany?(html, url, ctx?)` — OPTIONAL, extracts MULTIPLE records from
+  one fetched page (`result[0]` = the page's own `extract()`-equivalent record, remaining
+  records share `source.site` but carry distinct `source.itemId`s, target-first ordering for
+  `fields.offerOf`/`fields.editionOf`). Engines that don't call it keep calling `extract()`.
+- `ExtractContext.scraping.fetchBody?(url, opts?)` — OPTIONAL, a lightweight non-browser
+  same-store follow-up GET through the engine's declared transport, raw-captured and
+  courtesy-gapped by the engine against the primary fetch.
+
+### Changed
+- `ExtractContext.scraping.batchFetch` and `.officialApi` are now OPTIONAL (`?`). They were
+  already documented as "a minimal engine may not yet provide" these; the type now matches
+  that reality instead of forcing every `ExtractContext` builder to stub them.

--- a/packages/plugin-contract/package.json
+++ b/packages/plugin-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figurecollecting/scraper-plugin-contract",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Plugin contract for the scraper engine: the interfaces and isScraperPlugin guard shared by the engine and ruleset plugin packages",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test:types": "tsc --noEmit -p test-types",
     "prepack": "npm run build"
   },
   "repository": {

--- a/packages/plugin-contract/src/index.ts
+++ b/packages/plugin-contract/src/index.ts
@@ -290,15 +290,26 @@ export interface StoreCapabilities extends SiteConfig {
  * Generic engine surface only: site config, page/batch/API fetch access, and
  * a logger — so rulesets that need multiple queries per item (search + detail,
  * batch endpoints, official APIs) can issue them through engine-managed
- * plumbing instead of owning their own HTTP stack. A minimal engine may not
- * yet provide `batchFetch`/`officialApi`; rulesets must treat `ctx` as
- * optional and degrade gracefully when it is absent.
+ * plumbing instead of owning their own HTTP stack. `batchFetch`/`officialApi`/
+ * `fetchBody` are all OPTIONAL — a minimal engine may not yet provide them;
+ * rulesets must treat `ctx` (and each of these members) as possibly absent
+ * and degrade gracefully.
  */
 export interface ExtractContext {
   config: SiteConfig;
   scraping: ScrapingService & {
-    batchFetch(codes: string[], opts?: Record<string, unknown>): Promise<Record<string, unknown>>;
-    officialApi(name: string, params: Record<string, unknown>, auth?: Record<string, unknown>): Promise<unknown>;
+    batchFetch?(codes: string[], opts?: Record<string, unknown>): Promise<Record<string, unknown>>;
+    officialApi?(name: string, params: Record<string, unknown>, auth?: Record<string, unknown>): Promise<unknown>;
+    /**
+     * Added for orzgk Slice B (spec.md D1/D9, §3.1): a lightweight, NON-browser same-store
+     * follow-up GET, issued through the engine's declared transport for this store (raw-captured
+     * to the raw sink like any other fetch) and courtesy-gapped by the engine against the
+     * primary fetch — the ruleset just awaits it, the engine enforces the gap. Used by
+     * `extractMany()` implementations that need a second call off the same host (e.g. a
+     * variation-batch endpoint) without owning their own HTTP stack. Optional: an engine that
+     * doesn't yet provide it leaves this undefined; rulesets must check before calling.
+     */
+    fetchBody?(url: string, opts?: { cookies?: Record<string, string> }): Promise<{ html: string; statusCode?: number }>;
   };
   logger: PluginLogger;
 }
@@ -314,6 +325,19 @@ export interface ExtractionRuleset {
    */
   extract(html: string, url: string, ctx?: ExtractContext): ExtractedData | Promise<ExtractedData>;
   validate(data: ExtractedData): ValidationResult;
+  /**
+   * OPTIONAL: extract MULTIPLE records from one fetched page — added for orzgk Slice B
+   * (spec.md D1/D9, §1.2, §3.1, §6 B1) so a variable-product listing can emit its own record
+   * plus one record per edition/offer found on the same page (or a courtesy-gapped follow-up
+   * fetch via `ctx.scraping.fetchBody`). Contract: (a) `result[0]` is the page's own record —
+   * exactly what `extract()` would return for this page; (b) every record shares `source.site`
+   * but carries a DISTINCT `source.itemId`; (c) each record must independently pass
+   * `validate()`; (d) ordering is TARGET-FIRST — a record naming another record via
+   * `fields.offerOf`/`fields.editionOf` must appear AFTER the record it targets, since the
+   * engine emits records sequentially in array order. Engines that don't call `extractMany`
+   * keep calling `extract()` — existing 2-argument rulesets are unaffected.
+   */
+  extractMany?(html: string, url: string, ctx?: ExtractContext): ExtractedData[] | Promise<ExtractedData[]>;
   /**
    * OPTIONAL: parse a SEARCH-results response body (fetched from the store's `retrieval.bySearch`
    * endpoint) into candidate items for cross-store lookup — the buy-decision fan-out. Distinct

--- a/packages/plugin-contract/test-types/ctx-with-fetch-body.ts
+++ b/packages/plugin-contract/test-types/ctx-with-fetch-body.ts
@@ -1,0 +1,23 @@
+/**
+ * Type-test fixture: ExtractContext.scraping.fetchBody() — the engine-provided, non-browser
+ * captured follow-up GET (orzgk Slice B call #2, spec.md §1.3/§3.1 D1/D9). RED before the
+ * 0.4.0 bump (fetchBody does not exist on `scraping` ⇒ "property does not exist" error);
+ * GREEN after, including the `{ html, statusCode? }` result shape and optional `cookies` opt.
+ */
+import type { ExtractContext } from '../src/index';
+
+async function useFetchBody(ctx: ExtractContext): Promise<void> {
+  if (!ctx.scraping.fetchBody) return;
+
+  const result = await ctx.scraping.fetchBody('https://www.orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=68026029');
+  const html: string = result.html;
+  const statusCode: number | undefined = result.statusCode;
+  void html;
+  void statusCode;
+
+  await ctx.scraping.fetchBody('https://www.orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=68026029', {
+    cookies: { session: 'abc' },
+  });
+}
+
+void useFetchBody;

--- a/packages/plugin-contract/test-types/ctx-without-optional-services.ts
+++ b/packages/plugin-contract/test-types/ctx-without-optional-services.ts
@@ -1,0 +1,59 @@
+/**
+ * Type-test fixture: an ExtractContext built WITHOUT batchFetch/officialApi on `scraping`
+ * (orzgk Slice B needs a ctx a minimal engine can construct, spec.md §3.1). RED before the
+ * 0.4.0 bump (batchFetch/officialApi are required ⇒ "missing properties" error); GREEN
+ * after they become optional.
+ */
+import type {
+  ExtractContext,
+  ScrapingService,
+  ScrapePageResult,
+  SiteConfig,
+  PluginLogger,
+} from '../src/index';
+
+const scraping: ScrapingService = {
+  async scrapePage(url: string): Promise<ScrapePageResult> {
+    return { html: '', url, title: '' };
+  },
+  async scrapePageStealth(url: string): Promise<ScrapePageResult> {
+    return { html: '', url, title: '' };
+  },
+  async browserFetch(_url: string): Promise<string> {
+    return '';
+  },
+  async withBrowser<T>(fn: (browser: unknown) => Promise<T>): Promise<T> {
+    return fn(undefined);
+  },
+  async withPage<T>(fn: (page: unknown) => Promise<T>): Promise<T> {
+    return fn(undefined);
+  },
+};
+
+const config: SiteConfig = {
+  siteId: 'orzgk',
+  name: 'orzgk',
+  domains: ['orzgk.com'],
+  rateLimit: {
+    domain: 'orzgk.com',
+    baseDelayMs: 3000,
+    minDelayMs: 1500,
+    maxDelayMs: 30000,
+    backoffMultiplier: 2,
+    recoveryDivisor: 2,
+    successThreshold: 3,
+  },
+  requiresBrowser: false,
+  allowedCookies: [],
+};
+
+const logger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const ctx: ExtractContext = { config, scraping, logger };
+
+void ctx;

--- a/packages/plugin-contract/test-types/existing-two-arg-ruleset.ts
+++ b/packages/plugin-contract/test-types/existing-two-arg-ruleset.ts
@@ -1,0 +1,25 @@
+/**
+ * Type-test fixture: a plain, pre-existing 2-argument ruleset (extract + validate only,
+ * no extractMany) must keep compiling unchanged against ExtractionRuleset — this is the
+ * backward-compatibility guarantee for the 0.4.0 additive bump (orzgk Slice B, spec.md D9).
+ * This file must NEVER go red; it is the regression guard for every other fixture in this
+ * directory that intentionally starts red.
+ */
+import type { ExtractionRuleset, ExtractedData, ValidationResult } from '../src/index';
+
+const ruleset: ExtractionRuleset = {
+  siteId: 'example',
+  version: '1.0',
+  extract(html: string, url: string): ExtractedData {
+    return {
+      source: { site: 'example', itemId: '1', extractedAt: new Date().toISOString() },
+      fields: { html, url },
+      warnings: [],
+    };
+  },
+  validate(_data: ExtractedData): ValidationResult {
+    return { valid: true, errors: [], warnings: [] };
+  },
+};
+
+void ruleset;

--- a/packages/plugin-contract/test-types/extract-many-ruleset.ts
+++ b/packages/plugin-contract/test-types/extract-many-ruleset.ts
@@ -1,0 +1,39 @@
+/**
+ * Type-test fixture: a ruleset implementing the OPTIONAL extractMany() member (added for
+ * orzgk Slice B multi-record extract, spec.md §3.1/§6 B1). RED before the 0.4.0 bump
+ * (extractMany does not exist on ExtractionRuleset ⇒ excess-property error on the object
+ * literal); GREEN after.
+ */
+import type { ExtractionRuleset, ExtractedData, ValidationResult, ExtractContext } from '../src/index';
+
+const ruleset: ExtractionRuleset = {
+  siteId: 'orzgk',
+  version: '1.1',
+  extract(html: string, url: string): ExtractedData {
+    return {
+      source: { site: 'orzgk', itemId: 'parent', extractedAt: new Date().toISOString() },
+      fields: { html, url },
+      warnings: [],
+    };
+  },
+  validate(_data: ExtractedData): ValidationResult {
+    return { valid: true, errors: [], warnings: [] };
+  },
+  async extractMany(html: string, url: string, ctx?: ExtractContext): Promise<ExtractedData[]> {
+    void ctx;
+    return [
+      {
+        source: { site: 'orzgk', itemId: 'parent', extractedAt: new Date().toISOString() },
+        fields: { html, url },
+        warnings: [],
+      },
+      {
+        source: { site: 'orzgk', itemId: 'child-1', extractedAt: new Date().toISOString() },
+        fields: { editionOf: 'parent' },
+        warnings: [],
+      },
+    ];
+  },
+};
+
+void ruleset;

--- a/packages/plugin-contract/test-types/tsconfig.json
+++ b/packages/plugin-contract/test-types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## What — plugin-contract 0.3.4 → 0.4.0 (additive) for orzgk Slice B multi-record extract
Spec of record: `~/tmp/orzgk-slice-b/spec.md` (D1/D2/D9 + §10 amendments A1–A3).

- `ExtractionRuleset.extractMany?(html, url, ctx?) → ExtractedData[] | Promise<...>` — a ruleset may return **multiple records** from one page. Contract: `[0]` is the page's own (parent) record; children carry `editionOf=<parent itemId>` (edition children, lane E) or `offerOf` (tier children, lane S); every record has a distinct `source.itemId`; a child's target precedes it in the array; the engine emits **sequentially in array order, awaiting each** (parent commits before any child RPC — no batch RPC, no ingest-contract change).
- `ExtractContext.scraping.fetchBody?(url, {cookies?}) → {html, statusCode?}` — a lightweight non-browser captured GET the engine will implement over its capturing fetch using the store's declared `searchFetch` transport (raw bytes still reach the capture sink), courtesy-gapped by the store's `rateLimit.baseDelayMs` after the primary fetch (engine-enforced).
- `batchFetch` / `officialApi` made explicitly **optional** (they were type-only stubs; a ctx without them now type-checks).
- Version 0.4.0.

## Verification (orchestrator-reproduced)
- **Additivity proven**: the entire engine (all existing 2-arg rulesets/tests) typechecks unchanged against 0.4.0.
- Type-level tests (`test-types/`): existing 2-arg ruleset compiles; `extractMany` ruleset compiles; ctx with/without the optional services compiles. **Red→green by me**: 5 TS errors against the old contract, clean at HEAD.
- Package builds clean.

## Not in this PR
Engine runtime (`extractRecords`/`extractContext`/`emitAll` — B3) and the orzgk ruleset (B2). No ingest-contract change (D2: sequential unary `Ingest` suffices).
