### PR TITLE
Remove pebble binary from production image to fix grype gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,6 +173,13 @@ RUN rm -rf /root/.cache/puppeteer \
 # launches via `node dist/...` (see CMD), so npm is not needed in the final image.
 RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
+# Remove Canonical's Pebble service manager: baked into the ubuntu:26.04 base layer
+# (not dpkg-owned, no apt rdepends) but never invoked here — the container runs
+# `node dist/index.js` directly (see CMD), never pebble. Its bundled Go stdlib trips
+# grype High/Critical advisories (GO-2026-5026/6089/6090/5972) that block the PR
+# security gate for every change. (2026-08-19)
+RUN rm -rf /usr/bin/pebble /var/lib/pebble
+
 # Copy built application from builder
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/packages/plugin-contract/dist ./packages/plugin-contract/dist


### PR DESCRIPTION
## Root cause

The PR security gate (`pr-security-scan` job, grype High/Critical check) has failed on every PR since 2026-07-31 (develop's last green scan). Root cause: 4 High Go-stdlib advisories (GO-2026-5026, GO-2026-6089, GO-2026-6090, GO-2026-5972, package `stdlib@go1.26.5`), all located at `/usr/bin/pebble`.

`pebble` is Canonical's Go-based service manager, baked directly into the `ubuntu:26.04` base layer (confirmed not dpkg-owned via `dpkg -S /usr/bin/pebble` → no match, and no apt rdepends). The container never runs it: entrypoint is `node --import ./dist/tracing.js dist/index.js` as non-root `pptruser` (see Dockerfile CMD).

## Fix

Removed `/usr/bin/pebble` and `/var/lib/pebble` in the `production` stage only (mirrors the existing npm/npx cleanup pattern a few lines above). `test`/`development` stages are untouched since they aren't scanned or shipped.

## Verification (local, before push)

Built the production target exactly as `pr-security-scan` does:
```
docker build --target production --secret id=node_auth_token,src=<token-file> --no-cache -t local-scan:pebble .
```
Build succeeded; `RUN rm -rf /usr/bin/pebble /var/lib/pebble` completed clean.

Ran grype exactly as the CI job does:
```
grype local-scan:pebble -c .grype.yaml -o table
```
Result: **0 High/Critical** (205 findings total, all Medium/Low/Negligible). No `pebble` references remain in the scan output.

Confirmed the image still runs:
```
docker run --rm local-scan:pebble node -e "console.log('ok')"
→ ok
```

## Diff

```diff
+# Remove Canonical's Pebble service manager: baked into the ubuntu:26.04 base layer
+# (not dpkg-owned, no apt rdepends) but never invoked here — the container runs
+# `node dist/index.js` directly (see CMD), never pebble. Its bundled Go stdlib trips
+# grype High/Critical advisories (GO-2026-5026/6089/6090/5972) that block the PR
+# security gate for every change. (2026-08-19)
+RUN rm -rf /usr/bin/pebble /var/lib/pebble
```

Single file changed (`Dockerfile`), 7 insertions, 0 deletions.
