### PR TITLE
Add extractRecords/extractContext and sequential multi-record emit for extractMany rulesets (Slice B, B3)

### DIFF
--- a/src/__tests__/integration/ingestRoutes.test.ts
+++ b/src/__tests__/integration/ingestRoutes.test.ts
@@ -284,7 +284,8 @@ describe('POST /ingest/scrape', () => {
 
       // engine fetched the raw page; extraction was the plugin's job
       expect(scraping.scrapePage).toHaveBeenCalledWith(FIXTURE_URL);
-      expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, FIXTURE_URL);
+      // B3: extractRecords forwards the built ExtractContext as extract's 3rd arg.
+      expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, FIXTURE_URL, expect.anything());
       // the extraction went to the spine, verbatim
       const sent = send.mock.calls[0][0];
       expect(sent.source.site).toBe('mock-site');

--- a/src/__tests__/unit/scrapeQueueExtractMany.test.ts
+++ b/src/__tests__/unit/scrapeQueueExtractMany.test.ts
@@ -1,0 +1,271 @@
+/**
+ * ScrapeQueue B3 wiring — orzgk Slice B, spec.md D2/D7/D11: `processViaIngest` dispatches through
+ * `extractRecords` (extractMany > extractAsync > extract, always an array) and emits every
+ * record as a SEQUENTIAL UNARY `ingestEmitter.send()` call, parent/target-first, `await`ing each
+ * — stopping at the FIRST failure so no later (dependent) record is ever sent ahead of a target
+ * that never landed. `handleSuccess`/the caller's resolved promise still see `[0].fields` (the
+ * page's own record), same as today's single-record path. Also covers `ExtractContext.scraping
+ * .fetchBody` reaching the ingest path's real transport dispatch (D1/D8/D9) end-to-end.
+ */
+
+const mockNotifyItemSuccess = jest.fn().mockResolvedValue(true);
+const mockNotifyItemFailed = jest.fn().mockResolvedValue(true);
+const mockNotifyItemSkipped = jest.fn().mockResolvedValue(true);
+
+jest.mock('../../services/genericScraper', () => ({
+  BrowserPool: {
+    getStealthBrowser: jest.fn(),
+    getBrowser: jest.fn(),
+    returnBrowser: jest.fn(),
+    getPoolSize: jest.fn().mockReturnValue(2),
+    getPoolCapacity: jest.fn().mockReturnValue(3),
+    reset: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/webhookClient', () => ({
+  notifyItemSuccess: (...args: any[]) => mockNotifyItemSuccess(...args),
+  notifyItemFailed: (...args: any[]) => mockNotifyItemFailed(...args),
+  notifyItemSkipped: (...args: any[]) => mockNotifyItemSkipped(...args),
+}));
+
+import type { ExtractContext, ExtractedData, ExtractionRuleset, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import { ScrapeQueue, resetScrapeQueue } from '../../services/scrapeQueue';
+import { createExtractionRegistry, ExtractionRegistryImpl } from '../../services/extractionRegistry';
+import { CollectingCaptureSink } from '../../services/captureSink';
+
+function makeRegistry(
+  ruleset: ExtractionRuleset,
+  domain: string,
+  searchFetch?: StoreCapabilities['searchFetch'],
+  baseDelayMs = 1000,
+): ExtractionRegistryImpl {
+  const registry = createExtractionRegistry();
+  const caps: StoreCapabilities = {
+    siteId: ruleset.siteId,
+    name: 'Mock Multi Store',
+    domains: [domain],
+    rateLimit: {
+      domain,
+      baseDelayMs,
+      minDelayMs: 500,
+      maxDelayMs: 5000,
+      backoffMultiplier: 1.5,
+      recoveryDivisor: 1.5,
+      successThreshold: 3,
+    },
+    requiresBrowser: false,
+    allowedCookies: [],
+    searchFetch,
+  };
+  registry.registerSite(caps);
+  registry.registerRuleset(ruleset);
+  return registry;
+}
+
+function rec(itemId: string, fields: Record<string, unknown>): ExtractedData {
+  return {
+    source: { site: 'mock-multi', itemId, url: 'https://orzgk.example.test/item/P', extractedAt: '2026-08-19T00:00:00.000Z' },
+    fields,
+    warnings: [],
+  };
+}
+
+/** Three-record fixture: parent P, editions C1/C2 (editionOf=P) — mirrors the orzgk Vegito shape. */
+function makeMultiRuleset(
+  extractManyImpl?: jest.Mock,
+): ExtractionRuleset & { extractMany: jest.Mock; extract: jest.Mock } {
+  const extractMany =
+    extractManyImpl ??
+    jest.fn(async (_html: string, url: string) => [
+      rec('P', { name: 'Parent Listing' }),
+      rec('C1', { name: 'Edition 1', editionOf: 'P' }),
+      rec('C2', { name: 'Edition 2', editionOf: 'P' }),
+    ].map((r) => ({ ...r, source: { ...r.source, url } })));
+  return {
+    siteId: 'mock-multi',
+    version: '1.1',
+    extract: jest.fn(() => {
+      throw new Error('extract() should not run when extractMany is present');
+    }),
+    extractMany,
+    validate: () => ({ valid: true, errors: [], warnings: [] }),
+  };
+}
+
+function makeScrapingStub(html = '{"variable":true}') {
+  return {
+    scrapePage: jest.fn().mockResolvedValue({ html, url: 'https://orzgk.example.test/item/P', title: 'Item', statusCode: 200 }),
+    scrapePageStealth: jest.fn().mockResolvedValue({ html, url: 'https://orzgk.example.test/item/P', title: 'Item', statusCode: 200 }),
+  };
+}
+
+describe('ScrapeQueue — extractRecords/emitAll wiring (B3)', () => {
+  let queue: ScrapeQueue;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers({ advanceTimers: true });
+    resetScrapeQueue();
+    mockNotifyItemSuccess.mockResolvedValue(true);
+    mockNotifyItemFailed.mockResolvedValue(true);
+    mockNotifyItemSkipped.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    if (queue) {
+      queue.stop();
+      queue.clear();
+    }
+    resetScrapeQueue();
+    jest.useRealTimers();
+  });
+
+  async function advanceAndFlush(ms: number, iterations: number = 3) {
+    for (let i = 0; i < iterations; i++) {
+      jest.advanceTimersByTime(ms / iterations);
+      await jest.advanceTimersByTimeAsync(50);
+    }
+  }
+
+  it('emits every extractMany record as a sequential unary send(), IN ARRAY ORDER, and resolves the caller with [0].fields', async () => {
+    const ruleset = makeMultiRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'orzgk.example.test'));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const url = 'https://orzgk.example.test/item/P';
+    const result = queue.enqueue(url, { url, priority: 'WARM', sessionId: 'session1' });
+    await advanceAndFlush(500);
+    const data = await result.promise;
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send.mock.calls[0][0].source.itemId).toBe('P');
+    expect(send.mock.calls[1][0].source.itemId).toBe('C1');
+    expect(send.mock.calls[2][0].source.itemId).toBe('C2');
+    // send() calls happened in strict sequence (each awaited before the next fires) — verify via
+    // invocation order matching array order (already implied by the assertions above, restated
+    // for clarity against accidental Promise.all-style concurrent dispatch).
+    const order = send.mock.invocationCallOrder;
+    expect(order[0]).toBeLessThan(order[1]);
+    expect(order[1]).toBeLessThan(order[2]);
+
+    // handleSuccess / the waiting caller's promise resolve with the PARENT's fields, not the last
+    // record's — same shape as today's single-record path.
+    expect(data).toEqual({ name: 'Parent Listing' });
+    expect(queue.getStats().completed).toBe(1);
+  });
+
+  it('stops at the FIRST send failure: later (dependent) records are never sent, and the item fails', async () => {
+    const ruleset = makeMultiRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest
+      .fn()
+      .mockResolvedValueOnce({ sourceId: 'p' }) // P succeeds
+      .mockRejectedValueOnce(new Error('spine unavailable')); // C1 fails — C2 must never be attempted
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'orzgk.example.test'));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const url = 'https://orzgk.example.test/item/P';
+    const result = queue.enqueue(url, { url, maxRetries: 0 });
+    const promiseRef = result.promise.catch((e: Error) => e);
+
+    await advanceAndFlush(500);
+    await advanceAndFlush(5000);
+
+    const error = await promiseRef;
+    expect(error).toBeInstanceOf(Error);
+    // exactly 2 sends: P (ok) + C1 (failed) — C2 (the 3rd record) was NEVER sent
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[0][0].source.itemId).toBe('P');
+    expect(send.mock.calls[1][0].source.itemId).toBe('C1');
+    expect(queue.getStats().failed).toBe(1);
+  });
+
+  it('logs a records-emitted count on success', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const ruleset = makeMultiRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'orzgk.example.test'));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const url = 'https://orzgk.example.test/item/P';
+    const result = queue.enqueue(url, { url });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    const lines = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(lines.some((line) => /records emitted=3/.test(line))).toBe(true);
+    logSpy.mockRestore();
+  });
+
+  it('logs how many records were emitted before a partial-emit failure (never silently swallowed)', async () => {
+    const logSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const ruleset = makeMultiRuleset();
+    const scraping = makeScrapingStub();
+    const send = jest
+      .fn()
+      .mockResolvedValueOnce({ sourceId: 'p' })
+      .mockRejectedValueOnce(new Error('spine unavailable'));
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'orzgk.example.test'));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+
+    const url = 'https://orzgk.example.test/item/P';
+    const result = queue.enqueue(url, { url, maxRetries: 0 });
+    const promiseRef = result.promise.catch((e: Error) => e);
+    await advanceAndFlush(500);
+    await advanceAndFlush(5000);
+    await promiseRef;
+
+    const lines = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(lines.some((line) => /1\/3 record/.test(line))).toBe(true);
+    logSpy.mockRestore();
+  });
+
+  it('passes a real ExtractContext to extractMany whose scraping.fetchBody dispatches via the store\'s declared searchFetch transport (captured, api lane)', async () => {
+    const followUpUrl = 'https://orzgk.example.test/wc/store/v1/products?type=variation&parent=P';
+    const extractMany = jest.fn(async (_html: string, url: string, ctx?: ExtractContext) => {
+      const followUp = await ctx!.scraping.fetchBody!(followUpUrl);
+      return [
+        rec('P', { name: 'Parent Listing', followUpBody: followUp.html }),
+      ].map((r) => ({ ...r, source: { ...r.source, url } }));
+    });
+    const ruleset = makeMultiRuleset(extractMany);
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+    const http = jest.fn().mockResolvedValue('{"variations":[1,2]}');
+    const sink = new CollectingCaptureSink();
+
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeRegistry(ruleset, 'orzgk.example.test', { transport: 'http' }));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+    queue.setIngestTransports({ http });
+    queue.setCaptureSink(sink);
+
+    const url = 'https://orzgk.example.test/item/P';
+    const result = queue.enqueue(url, { url });
+    await advanceAndFlush(500);
+    await result.promise;
+
+    expect(http).toHaveBeenCalledWith(followUpUrl);
+    expect(send.mock.calls[0][0].fields.followUpBody).toBe('{"variations":[1,2]}');
+    // both the primary AND the follow-up fetch were captured under the api lane
+    const apiCaptures = sink.captures.filter((c) => c.lane === 'api');
+    expect(apiCaptures.map((c) => c.url)).toEqual(expect.arrayContaining([url, followUpUrl]));
+  });
+});

--- a/src/__tests__/unit/scrapeQueueIngest.test.ts
+++ b/src/__tests__/unit/scrapeQueueIngest.test.ts
@@ -176,7 +176,9 @@ describe('ScrapeQueue - ingest cutover', () => {
 
     // engine fetched the raw page; extraction was the plugin's job
     expect(scraping.scrapePage).toHaveBeenCalledWith('https://myfigurecollection.net/item/12345');
-    expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, 'https://myfigurecollection.net/item/12345');
+    // B3: extractRecords always forwards the built ExtractContext as extract's 3rd arg (ctx.scraping.fetchBody
+    // is the extractMany-only seam; a 2-arg ruleset like this one simply ignores it).
+    expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, 'https://myfigurecollection.net/item/12345', expect.anything());
     // the extraction went to the spine, verbatim
     expect(send).toHaveBeenCalledTimes(1);
     const sent = send.mock.calls[0][0];
@@ -205,7 +207,8 @@ describe('ScrapeQueue - ingest cutover', () => {
     await advanceAndFlush(500);
     const data = await result.promise;
 
-    expect(ruleset.extractAsync).toHaveBeenCalledWith(FIXTURE_HTML, url);
+    // B3: extractRecords forwards ctx to extractAsync too (same rationale as the extract() case above).
+    expect(ruleset.extractAsync).toHaveBeenCalledWith(FIXTURE_HTML, url, expect.anything());
     expect(ruleset.extract).not.toHaveBeenCalled();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send.mock.calls[0][0].fields).toEqual({ name: 'Fate/stay night' });
@@ -246,7 +249,8 @@ describe('ScrapeQueue - ingest cutover', () => {
     await advanceAndFlush(500);
     const data = await result.promise;
 
-    expect(extractFn).toHaveBeenCalledWith(FIXTURE_HTML, 'https://myfigurecollection.net/item/12345');
+    // B3: extractRecords forwards ctx as the 3rd arg (see the "fetch -> extract -> emit" test above).
+    expect(extractFn).toHaveBeenCalledWith(FIXTURE_HTML, 'https://myfigurecollection.net/item/12345', expect.anything());
     // the RESOLVED extraction (not a Promise) went to the spine
     expect(send).toHaveBeenCalledTimes(1);
     expect(send.mock.calls[0][0].fields).toEqual({ name: 'Async Marin', jan: '4530956107891' });
@@ -273,7 +277,8 @@ describe('ScrapeQueue - ingest cutover', () => {
     await result.promise;
 
     expect(scraping.scrapePage).toHaveBeenCalledWith(url);
-    expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, url);
+    // B3: extractRecords forwards ctx as the 3rd arg (see the "fetch -> extract -> emit" test above).
+    expect(ruleset.extract).toHaveBeenCalledWith(FIXTURE_HTML, url, expect.anything());
     expect(send).toHaveBeenCalledTimes(1);
   });
 

--- a/src/__tests__/unit/scrapeQueueTransport.test.ts
+++ b/src/__tests__/unit/scrapeQueueTransport.test.ts
@@ -186,7 +186,8 @@ describe('ScrapeQueue - ingest raw-fetch honors ruleset transport', () => {
     expect(scraping.scrapePage).not.toHaveBeenCalled();
     expect(scraping.scrapePageStealth).not.toHaveBeenCalled();
     // the RAW json body (not a browser-rendered wrapper) reached extract()
-    expect(ruleset.extract).toHaveBeenCalledWith('{"name":"Sentai Figure"}', url);
+    // B3: extractRecords forwards the built ExtractContext as extract's 3rd arg.
+    expect(ruleset.extract).toHaveBeenCalledWith('{"name":"Sentai Figure"}', url, expect.anything());
     expect(data).toEqual({ name: 'Sentai Figure' });
     // spine emit happened — this is the "zero claims" bug, fixed
     expect(send).toHaveBeenCalledTimes(1);
@@ -218,7 +219,8 @@ describe('ScrapeQueue - ingest raw-fetch honors ruleset transport', () => {
 
     expect(http).toHaveBeenCalledWith(url);
     expect(scraping.scrapePage).not.toHaveBeenCalled();
-    expect(ruleset.extract).toHaveBeenCalledWith('{"name":"Tier1 Figure"}', url);
+    // B3: extractRecords forwards the built ExtractContext as extract's 3rd arg.
+    expect(ruleset.extract).toHaveBeenCalledWith('{"name":"Tier1 Figure"}', url, expect.anything());
     expect(send).toHaveBeenCalledTimes(1);
     expect(sink.captures).toHaveLength(1);
     expect(sink.captures[0].lane).toBe('api');
@@ -245,7 +247,8 @@ describe('ScrapeQueue - ingest raw-fetch honors ruleset transport', () => {
     expect(scraping.scrapePage).toHaveBeenCalledWith('https://myfigurecollection.net/item/12345');
     expect(impersonate).not.toHaveBeenCalled();
     expect(http).not.toHaveBeenCalled();
-    expect(ruleset.extract).toHaveBeenCalledWith('<html><body><h1>Kitagawa Marin</h1></body></html>', 'https://myfigurecollection.net/item/12345');
+    // B3: extractRecords forwards the built ExtractContext as extract's 3rd arg.
+    expect(ruleset.extract).toHaveBeenCalledWith('<html><body><h1>Kitagawa Marin</h1></body></html>', 'https://myfigurecollection.net/item/12345', expect.anything());
     expect(send).toHaveBeenCalledTimes(1);
   });
 

--- a/src/driver/__tests__/assembleCrawlDriver.test.ts
+++ b/src/driver/__tests__/assembleCrawlDriver.test.ts
@@ -106,4 +106,35 @@ describe('assembleCrawlDriver — end-to-end crawl runtime', () => {
     const { driver } = build();
     expect(driver.profiles.retrievalFor('www.amiami.com')?.byId?.urlTemplate).toContain('{id}');
   });
+
+  /**
+   * B3 driver parity (spec.md orzgk Slice B D7): `resolveContext` on CrawlDriverServices reaches
+   * the ruleset's `extractMany` through the full assembled chain (dormant until A3 — no
+   * non-test importer wires a real resolveContext yet, but the seam must reach end-to-end now).
+   */
+  it("passes resolveContext through to the worker, reaching a ruleset's extractMany with the resolved ExtractContext", async () => {
+    const ctx = { config: {}, scraping: {}, logger: {} } as never;
+    const extractMany = jest.fn((_html: string, url: string) => [extracted(gcodeOf(url))]);
+    const rs: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '1.1',
+      extract: jest.fn(() => {
+        throw new Error('extract() should not run when extractMany is present');
+      }),
+      extractMany,
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const resolveContext = jest.fn().mockReturnValue(ctx);
+    const { sends, driver } = build({
+      extraction: { allStores: () => [AMIAMI], getRulesetForUrl: () => rs },
+      resolveContext,
+    });
+
+    const result = await driver.crawlSite('amiami', ['A1']);
+
+    expect(resolveContext).toHaveBeenCalledWith('amiami', { id: 'A1', host: 'www.amiami.com' }, expect.any(String));
+    expect(extractMany).toHaveBeenCalledWith('<html/>', expect.any(String), ctx);
+    expect(sends.map((e) => e.source.itemId)).toEqual(['A1']);
+    expect(result.coverage.done).toBe(1);
+  });
 });

--- a/src/driver/__tests__/crawlWorker.test.ts
+++ b/src/driver/__tests__/crawlWorker.test.ts
@@ -177,3 +177,93 @@ describe('makeCrawlWorker — per-item fetch → extract → emit', () => {
     expect(outcome).toBe('rate-limited');
   });
 });
+
+/**
+ * B3 driver parity (spec.md orzgk Slice B D7): extractRecords/emitAll wired into the worker —
+ * dormant behind `extractMany` (no non-test importer calls it yet), unit-tested here so it soaks
+ * ready. `extractMany` folds through the SAME extractRecords helper the live queue uses
+ * (engineServices/extractRecords.ts), so a multi-record ruleset gets identical array-emit +
+ * ordering-guard behavior on both paths.
+ */
+describe('makeCrawlWorker — extractMany array emit (B3 driver parity)', () => {
+  const multiRuleset = (extractMany: jest.Mock): ExtractionRuleset =>
+    ruleset({
+      extract: jest.fn(() => {
+        throw new Error('extract() should not run when extractMany is present');
+      }),
+      extractMany,
+    });
+
+  it('extractMany present: emits every record in array order, markDone once, returns success', async () => {
+    const records: ExtractedData[] = [
+      extracted({ source: { site: 'amiami', itemId: 'P', extractedAt: 't0' } }),
+      extracted({ source: { site: 'amiami', itemId: 'C1', extractedAt: 't0' }, fields: { editionOf: 'P' } }),
+    ];
+    const extractMany = jest.fn().mockResolvedValue(records);
+    const rs = multiRuleset(extractMany);
+    const { deps, ledger, worker } = build({ lookupRuleset: jest.fn().mockReturnValue(rs) });
+
+    const outcome = await worker(TASK);
+
+    expect(extractMany).toHaveBeenCalledWith('<html>ok</html>', URL, undefined);
+    expect(deps.emit).toHaveBeenCalledTimes(2);
+    expect((deps.emit as jest.Mock).mock.calls[0][0]).toEqual(records[0]);
+    expect((deps.emit as jest.Mock).mock.calls[1][0]).toEqual(records[1]);
+    const order = (deps.emit as jest.Mock).mock.invocationCallOrder;
+    expect(order[0]).toBeLessThan(order[1]);
+    expect(ledger.done).toEqual(['abc123']);
+    expect(ledger.failed).toEqual([]);
+    expect(outcome).toBe('success');
+  });
+
+  it('emit throws on the SECOND record: the third is never sent, item stays pending (not markFailed), rate-limited', async () => {
+    const records: ExtractedData[] = [
+      extracted({ source: { site: 'amiami', itemId: 'P', extractedAt: 't0' } }),
+      extracted({ source: { site: 'amiami', itemId: 'C1', extractedAt: 't0' }, fields: { editionOf: 'P' } }),
+      extracted({ source: { site: 'amiami', itemId: 'C2', extractedAt: 't0' }, fields: { editionOf: 'P' } }),
+    ];
+    const extractMany = jest.fn().mockResolvedValue(records);
+    const rs = multiRuleset(extractMany);
+    const emit = jest
+      .fn()
+      .mockResolvedValueOnce({ sourceId: 'p' })
+      .mockRejectedValueOnce(new Error('spine UNAVAILABLE'));
+    const { deps, ledger, worker } = build({ lookupRuleset: jest.fn().mockReturnValue(rs), emit });
+
+    const outcome = await worker(TASK);
+
+    expect(deps.emit).toHaveBeenCalledTimes(2); // P (ok), C1 (fails) — C2 never attempted
+    expect(ledger.done).toEqual([]);
+    expect(ledger.failed).toEqual([]); // pending — delivery failed, not the item
+    expect(outcome).toBe('rate-limited');
+  });
+
+  it('threads resolveContext\'s ExtractContext into extractMany (not just extract)', async () => {
+    const ctx = { config: {}, scraping: {}, logger: {} } as never;
+    const extractMany = jest.fn().mockResolvedValue([extracted()]);
+    const rs = multiRuleset(extractMany);
+    const resolveContext = jest.fn().mockReturnValue(ctx);
+    const { worker } = build({ lookupRuleset: jest.fn().mockReturnValue(rs), resolveContext });
+
+    await worker(TASK);
+
+    expect(extractMany).toHaveBeenCalledWith('<html>ok</html>', URL, ctx);
+  });
+
+  it('an extractRecords ordering-guard violation (D11) is a content failure: markFailed + success, no emit', async () => {
+    // child (editionOf=P) BEFORE its target P — target-first ordering violated.
+    const extractMany = jest.fn().mockResolvedValue([
+      extracted({ source: { site: 'amiami', itemId: 'C1', extractedAt: 't0' }, fields: { editionOf: 'P' } }),
+      extracted({ source: { site: 'amiami', itemId: 'P', extractedAt: 't0' } }),
+    ]);
+    const rs = multiRuleset(extractMany);
+    const { deps, ledger, worker } = build({ lookupRuleset: jest.fn().mockReturnValue(rs) });
+
+    const outcome = await worker(TASK);
+
+    expect(deps.emit).not.toHaveBeenCalled();
+    expect(ledger.failed).toEqual(['abc123']);
+    expect(ledger.done).toEqual([]);
+    expect(outcome).toBe('success');
+  });
+});

--- a/src/driver/assembleCrawlDriver.ts
+++ b/src/driver/assembleCrawlDriver.ts
@@ -26,11 +26,13 @@ import { CrawlLoop, type CrawlLoopStats } from './crawlLoop.js';
 import { CoverageLedger, type CoverageCounts } from './coverageLedger.js';
 import type { PoolCapacity } from './poolRouter.js';
 import type {
+  ExtractContext,
   ExtractedData,
   ExtractionRuleset,
   ScrapePageResult,
   StoreCapabilities,
 } from '@figurecollecting/scraper-plugin-contract';
+import type { CrawlTask } from './dispatchScheduler.js';
 
 export interface CrawlDriverServices {
   /** Engine registry: the registered stores (→ ProfileRegistry) + URL→ruleset lookup. */
@@ -47,6 +49,14 @@ export interface CrawlDriverServices {
   sleep: (ms: number) => Promise<void>;
   /** Per-pool worker capacity (browser/fetch), sized vs the crawl-rate budget. */
   capacity: PoolCapacity;
+  /**
+   * OPTIONAL per-extraction ExtractContext resolver (B3, spec.md orzgk Slice B D7) — reaches
+   * `extractRecords`/`extractMany` through `assembleCrawlWorker` (`crawlWorker.ts`'s
+   * `resolveContext?: (task, url) => ExtractContext | undefined` seam) for multi-query rulesets.
+   * `siteId` is supplied by `crawlSite` (already in scope there) since `CrawlTask` itself only
+   * carries `host`. Dormant until A3 — no non-test importer of `src/driver/` yet.
+   */
+  resolveContext?: (siteId: string, task: CrawlTask, url: string) => ExtractContext | undefined;
 }
 
 export interface CrawlSiteResult {
@@ -84,6 +94,9 @@ export function assembleCrawlDriver(services: CrawlDriverServices): CrawlDriver 
         retrievalFor: (h) => profiles.retrievalFor(h),
         emit: services.emit,
         ledger,
+        ...(services.resolveContext
+          ? { resolveContext: (task, url) => services.resolveContext!(siteId, task, url) }
+          : {}),
       });
 
       const { scheduler } = assembleScheduler(profiles, services.capacity);

--- a/src/driver/crawlWorker.ts
+++ b/src/driver/crawlWorker.ts
@@ -2,7 +2,7 @@
  * crawlWorker — the crawl driver's I2 worker: the `(task) => Promise<Outcome>` function the
  * CrawlLoop launches per dispatch. It composes the injected engine ports into one item pipeline:
  *
- *   resolveUrl(task) → fetch(url) → lookupRuleset(url).extract(html, url, ctx) → emit(extracted)
+ *   resolveUrl(task) → fetch(url) → extractRecords(lookupRuleset(url), html, url, ctx) → emit(each)
  *
  * and records the item's fate on the CoverageLedger. Everything is injected (no ScrapingService /
  * ExtractionRegistry / IngestEmitter imports here) so the worker is a pure composition unit,
@@ -18,7 +18,7 @@
  *   fetch throws / 429 / 503 → (pending)  + 'rate-limited' host throttled/blocked → back off, retry
  *   extract throws           → markFailed + 'success'      page fetched OK; CONTENT failed (see note)
  *   emit throws              → (pending)  + 'rate-limited' delivery failed → backpressure, retry
- *   emit OK                  → markDone   + 'success'      covered
+ *   emit OK (every record)   → markDone   + 'success'      covered
  *
  * LAYERING NOTE — why "extract throws" is a content failure, not a block: Cloudflare / throttle
  * detection is the FETCH port's contract (it throws or returns a 429/503). So by the time control
@@ -26,10 +26,23 @@
  * failure (the plugin wraps extract with the coverage gate), which backing off the host would not
  * fix. Spine-down backpressure via 'rate-limited' on emit failure is deliberately crude — a
  * spine-health circuit breaker belongs at the loop/driver level (I3), not per item.
+ *
+ * B3 DRIVER PARITY (spec.md orzgk Slice B D7): extraction is dispatched through `extractRecords`
+ * (engineServices/extractRecords.ts — the SAME helper the live ingest queue uses), which folds
+ * `extractMany` (if the ruleset has it) into an always-array result and enforces the D11
+ * ordering/uniqueness guards; a violation throws, landing in the SAME "extract throws → markFailed
+ * + success" bucket as any other content failure. `emit` then runs sequentially over EVERY record
+ * in array order (D2: parent-first, each awaited) — the first emit failure stops the loop (later,
+ * dependent records are never sent) and lands in the SAME "emit throws → pending + rate-limited"
+ * bucket as today's single-record path. A single-record ruleset (no `extractMany`) is therefore
+ * byte-for-byte unaffected: `extractRecords` wraps its one record in a 1-element array, so the
+ * `emit` loop runs exactly once, exactly as it does today. Dormant until A3 (no non-test importer
+ * of `src/driver/` yet).
  */
 import type { CrawlTask, Outcome } from './dispatchScheduler.js';
 import type { CoverageLedger } from './coverageLedger.js';
 import type { ExtractContext, ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+import { extractRecords } from '../services/engineServices/extractRecords.js';
 
 /** What the fetch port yields. It MUST throw on CF-block / network error (→ treated as throttle). */
 export interface FetchResult {
@@ -85,16 +98,21 @@ export function makeCrawlWorker(deps: CrawlWorkerDeps): (task: CrawlTask) => Pro
       return 'rate-limited'; // host throttled → back off, leave the item pending
     }
 
-    let extracted: ExtractedData;
+    let records: ExtractedData[];
     try {
-      extracted = await ruleset.extract(page.html, url, deps.resolveContext?.(task, url));
+      records = await extractRecords(ruleset, page.html, url, deps.resolveContext?.(task, url));
     } catch {
       deps.ledger.markFailed(task.id); // page came back fine; content/coverage failed — not a throttle
       return 'success';
     }
 
     try {
-      await deps.emit(extracted);
+      // D2: sequential unary emit, array order (parent-first), each awaited — stop at the first
+      // failure so a dependent (editionOf/offerOf) record is never sent ahead of a target that
+      // never landed. A single-record ruleset's one-element array runs this loop exactly once.
+      for (const record of records) {
+        await deps.emit(record);
+      }
     } catch {
       return 'rate-limited'; // delivery failed (spine) → backpressure; item stays pending for retry
     }

--- a/src/services/engineServices/__tests__/extractContext.test.ts
+++ b/src/services/engineServices/__tests__/extractContext.test.ts
@@ -1,0 +1,289 @@
+/**
+ * extractContext — `buildExtractContext`'s `scraping.fetchBody`: dispatches through the SAME
+ * store transport as the primary fetch, waits the D8 courtesy gap (same host only), passes
+ * cookies through, and stubs out the ScrapingService members it does not implement.
+ */
+import { buildExtractContext, DEFAULT_FETCH_BODY_GAP_MS } from '../extractContext';
+import type { SiteConfig } from '@figurecollecting/scraper-plugin-contract';
+
+const CONFIG: SiteConfig = {
+  siteId: 'orzgk',
+  name: 'orzgk',
+  domains: ['orzgk.com'],
+  rateLimit: {
+    domain: 'orzgk.com',
+    baseDelayMs: 3000,
+    minDelayMs: 500,
+    maxDelayMs: 10000,
+    backoffMultiplier: 1.5,
+    recoveryDivisor: 1.5,
+    successThreshold: 3,
+  },
+  requiresBrowser: false,
+  allowedCookies: [],
+};
+
+const LOGGER = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+function makeScraping() {
+  return {
+    scrapePage: jest.fn().mockResolvedValue({ html: '<page/>', url: '', title: '', statusCode: 200 }),
+    scrapePageStealth: jest.fn().mockResolvedValue({ html: '<page/>', url: '', title: '', statusCode: 200 }),
+  };
+}
+
+describe('buildExtractContext — scraping.fetchBody', () => {
+  it('waits until primaryFetchedAt + baseDelayMs (same host) before dispatching, using a fake clock', async () => {
+    let clock = 1_000_000;
+    const now = jest.fn(() => clock);
+    const sleep = jest.fn(async (ms: number) => {
+      clock += ms;
+    });
+    const capturingFetch = jest.fn().mockResolvedValue({ html: '{"variations":[]}' });
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 1_000_000, // == now() at t0
+      baseDelayMs: 3000,
+      now,
+      sleep,
+    });
+
+    const followUpUrl = 'https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1';
+    await ctx.scraping.fetchBody!(followUpUrl);
+
+    expect(sleep).toHaveBeenCalledWith(3000);
+    // capturingFetch must not have been called before the sleep advanced the clock.
+    const sleepOrder = sleep.mock.invocationCallOrder[0];
+    const fetchOrder = capturingFetch.mock.invocationCallOrder[0];
+    expect(sleepOrder).toBeLessThan(fetchOrder);
+    expect(capturingFetch).toHaveBeenCalledWith(followUpUrl, { transport: 'http' }, {});
+  });
+
+  it('does NOT wait (no early call, but also no needless delay) once primaryFetchedAt + gap has already elapsed', async () => {
+    const now = jest.fn(() => 1_010_000); // 10s after primary fetch — well past a 3s gap
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const capturingFetch = jest.fn().mockResolvedValue({ html: '{}' });
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 1_000_000,
+      baseDelayMs: 3000,
+      now,
+      sleep,
+    });
+
+    await ctx.scraping.fetchBody!('https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1');
+
+    expect(sleep).not.toHaveBeenCalled();
+    expect(capturingFetch).toHaveBeenCalled();
+  });
+
+  it('does NOT apply the courtesy gap when the follow-up targets a DIFFERENT host than the primary fetch', async () => {
+    const now = jest.fn(() => 1_000_000);
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const capturingFetch = jest.fn().mockResolvedValue({ html: '{}' });
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 1_000_000,
+      baseDelayMs: 3000,
+      now,
+      sleep,
+    });
+
+    await ctx.scraping.fetchBody!('https://a-totally-different-store.example/api/x');
+
+    expect(sleep).not.toHaveBeenCalled();
+    expect(capturingFetch).toHaveBeenCalled();
+  });
+
+  it('dispatches via capturingFetch using the STORE\'s declared searchFetch transport', async () => {
+    const capturingFetch = jest.fn().mockResolvedValue({ html: 'body' });
+    const searchFetch = { transport: 'impersonate' as const, browser: 'chrome142' };
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch,
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 0,
+      baseDelayMs: 0,
+      now: () => 0,
+    });
+
+    await ctx.scraping.fetchBody!('https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1');
+
+    expect(capturingFetch).toHaveBeenCalledWith(
+      'https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1',
+      searchFetch,
+      {},
+    );
+  });
+
+  it('passes the context\'s cookies through to capturingFetch', async () => {
+    const capturingFetch = jest.fn().mockResolvedValue({ html: 'body' });
+    const cookies = { cf_clearance: 'abc123' };
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      cookies,
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 0,
+      baseDelayMs: 0,
+      now: () => 0,
+    });
+
+    await ctx.scraping.fetchBody!('https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1');
+
+    expect(capturingFetch).toHaveBeenCalledWith(expect.any(String), expect.anything(), { cookies });
+  });
+
+  it('lets a per-call opts.cookies override the context\'s own cookies', async () => {
+    const capturingFetch = jest.fn().mockResolvedValue({ html: 'body' });
+    const callCookies = { session: 'override' };
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      cookies: { session: 'default' },
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 0,
+      baseDelayMs: 0,
+      now: () => 0,
+    });
+
+    await ctx.scraping.fetchBody!('https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1', {
+      cookies: callCookies,
+    });
+
+    expect(capturingFetch).toHaveBeenCalledWith(expect.any(String), expect.anything(), { cookies: callCookies });
+  });
+
+  it('falls back to DEFAULT_FETCH_BODY_GAP_MS when baseDelayMs is not supplied', async () => {
+    let clock = 5000;
+    const now = jest.fn(() => clock);
+    const sleep = jest.fn(async (ms: number) => {
+      clock += ms;
+    });
+    const capturingFetch = jest.fn().mockResolvedValue({ html: '{}' });
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 5000,
+      now,
+      sleep,
+      // baseDelayMs intentionally omitted
+    });
+
+    await ctx.scraping.fetchBody!('https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1');
+
+    expect(sleep).toHaveBeenCalledWith(DEFAULT_FETCH_BODY_GAP_MS);
+  });
+
+  it('passes config and logger through onto the ExtractContext verbatim, and forwards scrapePage/scrapePageStealth', async () => {
+    const scraping = makeScraping();
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping,
+      capturingFetch: jest.fn(),
+      searchFetch: undefined,
+      primaryUrl: 'https://orzgk.com/x',
+      primaryFetchedAt: 0,
+      now: () => 0,
+    });
+
+    expect(ctx.config).toBe(CONFIG);
+    expect(ctx.logger).toBe(LOGGER);
+
+    await ctx.scraping.scrapePage('https://orzgk.com/x');
+    expect(scraping.scrapePage).toHaveBeenCalledWith('https://orzgk.com/x', undefined);
+
+    await ctx.scraping.scrapePageStealth('https://orzgk.com/x', { cookies: { a: 'b' } });
+    expect(scraping.scrapePageStealth).toHaveBeenCalledWith('https://orzgk.com/x', { cookies: { a: 'b' } });
+  });
+
+  it('treats an unparseable primaryUrl/target url as "no host" — no courtesy gap, never throws', async () => {
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const capturingFetch = jest.fn().mockResolvedValue({ html: 'body' });
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'not a url at all',
+      primaryFetchedAt: 0,
+      baseDelayMs: 3000,
+      now: () => 0,
+      sleep,
+    });
+
+    await expect(ctx.scraping.fetchBody!('also not a url')).resolves.toEqual({ html: 'body' });
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('throws a clear error if a ruleset calls browserFetch/withBrowser/withPage through this context', () => {
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch: jest.fn(),
+      searchFetch: undefined,
+      primaryUrl: 'https://orzgk.com/x',
+      primaryFetchedAt: 0,
+      now: () => 0,
+    });
+
+    expect(() => ctx.scraping.browserFetch('https://orzgk.com/x')).toThrow(/browserFetch/);
+    expect(() => ctx.scraping.withBrowser(async () => undefined)).toThrow(/withBrowser/);
+    expect(() => ctx.scraping.withPage(async () => undefined)).toThrow(/withPage/);
+  });
+
+  it('leaves batchFetch/officialApi undefined (optional, not built this increment)', () => {
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch: jest.fn(),
+      searchFetch: undefined,
+      primaryUrl: 'https://orzgk.com/x',
+      primaryFetchedAt: 0,
+      now: () => 0,
+    });
+
+    expect(ctx.scraping.batchFetch).toBeUndefined();
+    expect(ctx.scraping.officialApi).toBeUndefined();
+  });
+});

--- a/src/services/engineServices/__tests__/extractRecords.test.ts
+++ b/src/services/engineServices/__tests__/extractRecords.test.ts
@@ -1,0 +1,161 @@
+/**
+ * extractRecords — dispatch precedence (extractMany > extractAsync > extract), always-array
+ * wrapping, and the D11 multi-record guards (empty / duplicate itemId / target-before-source).
+ */
+import type { ExtractContext, ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+import { extractRecords } from '../extractRecords';
+
+const HTML = '<html>ok</html>';
+const URL = 'https://example.test/item/1';
+
+function baseRuleset(overrides: Partial<ExtractionRuleset> = {}): ExtractionRuleset {
+  return {
+    siteId: 'mock-site',
+    version: '1.0.0',
+    extract: jest.fn(),
+    validate: jest.fn(() => ({ valid: true, errors: [], warnings: [] })),
+    ...overrides,
+  };
+}
+
+function record(itemId: string, fields: Record<string, unknown> = {}): ExtractedData {
+  return {
+    source: { site: 'mock-site', itemId, url: URL, extractedAt: '2026-08-19T00:00:00.000Z' },
+    fields,
+    warnings: [],
+  };
+}
+
+describe('extractRecords — dispatch precedence', () => {
+  it('calls extractMany when present, ignoring extract/extractAsync, and returns its array verbatim', async () => {
+    const many = jest.fn().mockResolvedValue([record('P'), record('C', { editionOf: 'P' })]);
+    const extract = jest.fn();
+    const extractAsync = jest.fn();
+    const ruleset = baseRuleset({ extract, extractMany: many }) as ExtractionRuleset & {
+      extractAsync: jest.Mock;
+    };
+    ruleset.extractAsync = extractAsync;
+
+    const ctx = { config: {}, scraping: {}, logger: {} } as unknown as ExtractContext;
+    const result = await extractRecords(ruleset, HTML, URL, ctx);
+
+    expect(many).toHaveBeenCalledWith(HTML, URL, ctx);
+    expect(extract).not.toHaveBeenCalled();
+    expect(extractAsync).not.toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(result[0].source.itemId).toBe('P');
+    expect(result[1].source.itemId).toBe('C');
+  });
+
+  it('falls back to extractAsync (wrapped in a 1-element array) when extractMany is absent', async () => {
+    const extractAsync = jest.fn().mockResolvedValue(record('A'));
+    const extract = jest.fn();
+    const ruleset = baseRuleset({ extract }) as ExtractionRuleset & { extractAsync: jest.Mock };
+    ruleset.extractAsync = extractAsync;
+
+    const result = await extractRecords(ruleset, HTML, URL, undefined);
+
+    expect(extractAsync).toHaveBeenCalledWith(HTML, URL, undefined);
+    expect(extract).not.toHaveBeenCalled();
+    expect(result).toEqual([record('A')]);
+  });
+
+  it('falls back to extract (wrapped in a 1-element array) when neither extractMany nor extractAsync is present — byte-for-byte today\'s single-record path', async () => {
+    const extract = jest.fn().mockResolvedValue(record('SOLO'));
+    const ruleset = baseRuleset({ extract });
+    const ctx = { config: {}, scraping: {}, logger: {} } as unknown as ExtractContext;
+
+    const result = await extractRecords(ruleset, HTML, URL, ctx);
+
+    expect(extract).toHaveBeenCalledWith(HTML, URL, ctx);
+    expect(result).toEqual([record('SOLO')]);
+  });
+
+  it('awaits a synchronous extract() return value transparently (E1)', async () => {
+    const extract = jest.fn().mockReturnValue(record('SYNC'));
+    const ruleset = baseRuleset({ extract });
+
+    const result = await extractRecords(ruleset, HTML, URL, undefined);
+
+    expect(result).toEqual([record('SYNC')]);
+  });
+});
+
+describe('extractRecords — D11 guards', () => {
+  it('throws when extractMany returns an empty array (nothing emitted)', async () => {
+    const ruleset = baseRuleset({ extractMany: jest.fn().mockResolvedValue([]) });
+
+    await expect(extractRecords(ruleset, HTML, URL, undefined)).rejects.toThrow(/empty/i);
+  });
+
+  it('throws on a duplicate source.itemId across records', async () => {
+    const ruleset = baseRuleset({
+      extractMany: jest.fn().mockResolvedValue([record('X'), record('X')]),
+    });
+
+    await expect(extractRecords(ruleset, HTML, URL, undefined)).rejects.toThrow(/duplicate/i);
+  });
+
+  it('throws when a child (editionOf) precedes its target (child-before-target)', async () => {
+    const ruleset = baseRuleset({
+      extractMany: jest.fn().mockResolvedValue([record('C', { editionOf: 'P' }), record('P')]),
+    });
+
+    await expect(extractRecords(ruleset, HTML, URL, undefined)).rejects.toThrow(/target-first|before/i);
+  });
+
+  it('throws when a record (offerOf) names a target itemId that never appears at all', async () => {
+    const ruleset = baseRuleset({
+      extractMany: jest.fn().mockResolvedValue([record('P'), record('T', { offerOf: 'GHOST' })]),
+    });
+
+    await expect(extractRecords(ruleset, HTML, URL, undefined)).rejects.toThrow(/target-first|before/i);
+  });
+
+  it('throws when a record targets itself via editionOf', async () => {
+    const ruleset = baseRuleset({
+      extractMany: jest.fn().mockResolvedValue([record('P'), record('SELF', { editionOf: 'SELF' })]),
+    });
+
+    await expect(extractRecords(ruleset, HTML, URL, undefined)).rejects.toThrow(/itself/i);
+  });
+
+  it('accepts a valid target-first array with editionOf AND a separate offerOf chain', async () => {
+    const ruleset = baseRuleset({
+      extractMany: jest.fn().mockResolvedValue([
+        record('P'),
+        record('E1', { editionOf: 'P' }),
+        record('T1', { offerOf: 'E1' }),
+      ]),
+    });
+
+    const result = await extractRecords(ruleset, HTML, URL, undefined);
+    expect(result.map((r) => r.source.itemId)).toEqual(['P', 'E1', 'T1']);
+  });
+
+  it('never calls ruleset.validate() — mirrors today\'s path, which does not validate either', async () => {
+    const validate = jest.fn(() => ({ valid: true, errors: [], warnings: [] }));
+    const ruleset = baseRuleset({
+      validate,
+      extractMany: jest.fn().mockResolvedValue([record('P')]),
+    });
+
+    await extractRecords(ruleset, HTML, URL, undefined);
+    expect(validate).not.toHaveBeenCalled();
+  });
+
+  it('treats a record with no fields object as carrying no target (never throws reading it)', async () => {
+    const bare = { source: { site: 'mock-site', itemId: 'BARE', url: URL, extractedAt: 't' } } as unknown as ExtractedData;
+    const ruleset = baseRuleset({ extractMany: jest.fn().mockResolvedValue([bare]) });
+
+    const result = await extractRecords(ruleset, HTML, URL, undefined);
+    expect(result).toEqual([bare]);
+  });
+
+  it('throws when a record has no source.itemId', async () => {
+    const bad = { source: { site: 'mock-site', itemId: '', url: URL, extractedAt: 't' }, fields: {}, warnings: [] };
+    const ruleset = baseRuleset({ extractMany: jest.fn().mockResolvedValue([bad]) });
+
+    await expect(extractRecords(ruleset, HTML, URL, undefined)).rejects.toThrow(/itemId/i);
+  });
+});

--- a/src/services/engineServices/extractContext.ts
+++ b/src/services/engineServices/extractContext.ts
@@ -1,0 +1,125 @@
+/**
+ * extractContext — builds the `ExtractContext` handed to `extractRecords` (and, through it, to a
+ * ruleset's `extract`/`extractMany`). The one member this increment actually implements is
+ * `scraping.fetchBody` (spec.md orzgk Slice B D1/D8/D9, plugin-contract 0.4.0): a same-store
+ * follow-up GET for `extractMany()` implementations that need a second call off the same host
+ * (e.g. a variation-batch endpoint) without owning their own HTTP stack.
+ *
+ * `fetchBody` is implemented over the SAME transport-dispatching `capturingFetch` the primary
+ * ingest fetch already uses (`engineServices/capturingFetch.ts`), given the store's OWN declared
+ * `searchFetch` transport — so the follow-up's raw bytes still land in the capture sink under the
+ * 'api' lane, same as the primary fetch. Cookies pass through (opts.cookies overrides the
+ * context's own).
+ *
+ * COURTESY GAP (D8): before dispatching, `fetchBody` waits until `primaryFetchedAt +
+ * baseDelayMs` has elapsed — but ONLY when the follow-up targets the SAME host as the primary
+ * fetch (a follow-up to a different host owes that host no courtesy against an unrelated fetch).
+ * `now`/`sleep` are injectable so tests run on a fake clock with zero real waiting.
+ *
+ * `batchFetch`/`officialApi` are left undefined (optional per contract 0.4.0) — not built this
+ * increment. `scrapePage`/`scrapePageStealth` pass through to the real base scraping service the
+ * caller supplies; `browserFetch`/`withBrowser`/`withPage` are NOT reachable via `fetchBody`
+ * (which is deliberately a non-browser transport-only seam) and are stubbed to throw a clear
+ * error if a ruleset ever calls them through `ExtractContext.scraping` — a loud failure, not a
+ * silent no-op, if a future ruleset assumes more surface than this context provides.
+ */
+import type {
+  ExtractContext,
+  ScrapingService,
+  SearchFetch,
+  SiteConfig,
+  PluginLogger,
+} from '@figurecollecting/scraper-plugin-contract';
+import type { CapturingFetch } from './capturingFetch.js';
+
+/**
+ * Default courtesy gap (ms) when a store profile declares no `rateLimit.baseDelayMs` — should be
+ * rare (every registered store's `SiteConfig.rateLimit` is required), but `buildExtractContext`
+ * accepts callers that could not resolve one. 2000ms is a conservative floor (below orzgk's own
+ * declared 3000ms, above the engine's global-lane MIN_DELAY of 274ms) — a real store should always
+ * declare its own via `rateLimit.baseDelayMs` rather than relying on this default.
+ */
+export const DEFAULT_FETCH_BODY_GAP_MS = 2000;
+
+/** Base page-fetch methods `fetchBody` is layered over; the only ones this context truly needs. */
+type BaseScraping = Pick<ScrapingService, 'scrapePage' | 'scrapePageStealth'>;
+
+export interface BuildExtractContextOptions {
+  /** `ExtractContext.config` — the resolved store's SiteConfig (or StoreCapabilities, a superset). */
+  config: SiteConfig;
+  logger: PluginLogger;
+  /** Base page-fetch surface passed through onto `ExtractContext.scraping`. */
+  scraping: BaseScraping;
+  /** The engine's transport-dispatching capturing fetch (impersonate/http/browser + sink capture). */
+  capturingFetch: CapturingFetch;
+  /** The store's OWN declared search-fetch transport (undeclared → capturingFetch's browser default). */
+  searchFetch: SearchFetch | undefined;
+  /** Cookies to pass through to `fetchBody`, unless a call overrides them via `opts.cookies`. */
+  cookies?: Record<string, string>;
+  /** The URL the PRIMARY fetch (that produced `html`) was fetched from — for the same-host gate. */
+  primaryUrl: string;
+  /** epoch ms when the primary fetch completed (the courtesy gap's anchor). */
+  primaryFetchedAt: number;
+  /** Courtesy gap in ms; defaults to `DEFAULT_FETCH_BODY_GAP_MS` when the store declares none. */
+  baseDelayMs?: number;
+  /** Injectable clock (default `Date.now`). */
+  now?: () => number;
+  /** Injectable sleep (default a real `setTimeout` promise). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Lowercased, `www.`-stripped hostname; `undefined` on an unparseable URL (never throws). */
+function safeHostname(url: string): string | undefined {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, '');
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function notSupported(member: string): () => never {
+  return () => {
+    throw new Error(
+      `[EXTRACT CONTEXT] ScrapingService.${member} is not available via ExtractContext — this context provides only ` +
+        `scrapePage/scrapePageStealth (passthrough) and fetchBody (the extractMany same-store follow-up seam)`
+    );
+  };
+}
+
+/** Build the `ExtractContext` for one item's extraction (see module doc for `fetchBody`'s contract). */
+export function buildExtractContext(options: BuildExtractContextOptions): ExtractContext {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const gapMs = options.baseDelayMs ?? DEFAULT_FETCH_BODY_GAP_MS;
+  const primaryHost = safeHostname(options.primaryUrl);
+
+  return {
+    config: options.config,
+    logger: options.logger,
+    scraping: {
+      scrapePage: (url, pageOptions) => options.scraping.scrapePage(url, pageOptions),
+      scrapePageStealth: (url, pageOptions) => options.scraping.scrapePageStealth(url, pageOptions),
+      browserFetch: notSupported('browserFetch'),
+      withBrowser: notSupported('withBrowser'),
+      withPage: notSupported('withPage'),
+
+      async fetchBody(url, fetchOpts) {
+        const targetHost = safeHostname(url);
+        // Same-host-only courtesy: an unrelated host owes nothing against THIS primary fetch.
+        if (targetHost !== undefined && targetHost === primaryHost) {
+          const waitUntil = options.primaryFetchedAt + gapMs;
+          const remaining = waitUntil - now();
+          if (remaining > 0) {
+            await sleep(remaining);
+          }
+        }
+        const cookies = fetchOpts?.cookies ?? options.cookies;
+        return options.capturingFetch(url, options.searchFetch, cookies ? { cookies } : {});
+      },
+    },
+  };
+}

--- a/src/services/engineServices/extractRecords.ts
+++ b/src/services/engineServices/extractRecords.ts
@@ -1,0 +1,112 @@
+/**
+ * extractRecords — folds a ruleset's extraction dispatch (extractMany > extractAsync > extract,
+ * see plugin-contract's E1/extractMany doc) into ONE always-array result, so every caller (the
+ * live ingest queue, the crawl driver) can treat "one record" and "N records" identically:
+ *
+ *   - `extractMany` present  → `await ruleset.extractMany(html, url, ctx)` verbatim.
+ *   - `extractMany` absent   → `[await (extractAsync ?? extract)(html, url, ctx)]` — the exact
+ *     duck-typed fallback the engine already runs today (scrapeQueue.ts's pre-B3
+ *     `extractAsync`-then-`extract` dispatch), just wrapped in a one-element array. A
+ *     single-record ruleset's OWN extraction call is therefore byte-for-byte what it is today;
+ *     only the caller-facing shape (array vs bare object) changes.
+ *
+ * Guards (spec.md orzgk Slice B, D11) run on every dispatch, single-record included, so a
+ * multi-record ruleset's ordering bug surfaces loudly as a thrown content failure — NOTHING is
+ * emitted, nothing is silently reordered or dropped:
+ *   - empty result (a ruleset returning `[]` from `extractMany`) → throw.
+ *   - two records sharing `source.itemId` → throw.
+ *   - a record's `fields.editionOf` / `fields.offerOf` naming another record's `itemId` that is
+ *     NOT a STRICTLY EARLIER record in the array (self-reference or forward/missing reference)
+ *     → throw. This is what lets the wire step (D2: N sequential unary `Ingest` calls, parent
+ *     first) trust array order == dependency order without re-deriving it.
+ *
+ * Deliberately NOT run here: `ruleset.validate()`. Neither the live queue's `processViaIngest`
+ * nor the crawl driver's `crawlWorker` call `validate()` today (grep confirms zero call sites) —
+ * this helper mirrors that, so wiring it in changes nothing about when/whether validation runs.
+ */
+import type { ExtractContext, ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+
+/**
+ * The duck-typed async-extraction path some rulesets exposed before E1 made `extract()` itself
+ * async-capable (VNDB, AmiAmi-era plugins). Kept for exactly those; the contract has no such
+ * member, hence the local shape.
+ */
+type RulesetWithExtractAsync = ExtractionRuleset & {
+  extractAsync?: (html: string, url: string, ctx?: ExtractContext) => Promise<ExtractedData>;
+};
+
+/** Which multi-record target field a record carries (mutually exclusive in practice). */
+type TargetRef = { field: 'editionOf' | 'offerOf'; itemId: string };
+
+function readTargetRef(record: ExtractedData): TargetRef | undefined {
+  const fields = (record?.fields ?? {}) as Record<string, unknown>;
+  if (typeof fields.editionOf === 'string') return { field: 'editionOf', itemId: fields.editionOf };
+  if (typeof fields.offerOf === 'string') return { field: 'offerOf', itemId: fields.offerOf };
+  return undefined;
+}
+
+function validateRecordSet(ruleset: ExtractionRuleset, records: ExtractedData[]): void {
+  const label = `${ruleset.siteId}@${ruleset.version}`;
+
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error(`[EXTRACT RECORDS] ${label}: extraction produced no records (empty result)`);
+  }
+
+  const seenIds = new Set<string>();
+  records.forEach((record, index) => {
+    const itemId = record?.source?.itemId;
+    if (!itemId) {
+      throw new Error(`[EXTRACT RECORDS] ${label}: record[${index}] has no source.itemId`);
+    }
+    if (seenIds.has(itemId)) {
+      throw new Error(
+        `[EXTRACT RECORDS] ${label}: duplicate source.itemId '${itemId}' at record[${index}] — every record must be a distinct entity`
+      );
+    }
+
+    const target = readTargetRef(record);
+    if (target) {
+      if (target.itemId === itemId) {
+        throw new Error(
+          `[EXTRACT RECORDS] ${label}: record[${index}] (itemId '${itemId}') targets itself via fields.${target.field}`
+        );
+      }
+      if (!seenIds.has(target.itemId)) {
+        throw new Error(
+          `[EXTRACT RECORDS] ${label}: record[${index}] (itemId '${itemId}') targets '${target.itemId}' via fields.${target.field}, ` +
+            `but no earlier record in the array carries that itemId — target-first ordering violated`
+        );
+      }
+    }
+
+    // Added AFTER the target check so target-first ordering means STRICTLY earlier, never self.
+    seenIds.add(itemId);
+  });
+}
+
+/**
+ * Dispatch a ruleset's extraction and return it as an array, guarded per D11. Always resolves to
+ * a non-empty array or throws — never returns `undefined`/partial.
+ */
+export async function extractRecords(
+  ruleset: ExtractionRuleset,
+  html: string,
+  url: string,
+  ctx?: ExtractContext,
+): Promise<ExtractedData[]> {
+  let records: ExtractedData[];
+
+  if (typeof ruleset.extractMany === 'function') {
+    records = await ruleset.extractMany(html, url, ctx);
+  } else {
+    const withAsync = ruleset as RulesetWithExtractAsync;
+    const record =
+      typeof withAsync.extractAsync === 'function'
+        ? await withAsync.extractAsync(html, url, ctx)
+        : await ruleset.extract(html, url, ctx);
+    records = [record];
+  }
+
+  validateRecordSet(ruleset, records);
+  return records;
+}

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -31,11 +31,16 @@ import { createIngestEmitterFromEnv } from './ingestEmitter.js';
 import { impitFetchBody } from './impitFetch.js';
 import { httpFetchBody } from './engineLookup.js';
 import { buildProfileRegistry, ProfileRegistry } from '../driver/profileRegistry.js';
+import { extractRecords } from './engineServices/extractRecords.js';
+import { buildExtractContext } from './engineServices/extractContext.js';
+import { createPluginLogger } from './engineServices/pluginLogger.js';
 import type { CaptureSink } from './captureSink.js';
 import type {
   ExtractionRuleset,
+  ExtractContext,
   ExtractedData as PluginExtractedData,
   ScrapingService,
+  SiteConfig,
   StoreCapabilities,
   SearchFetch,
 } from '@figurecollecting/scraper-plugin-contract';
@@ -1019,16 +1024,21 @@ export class ScrapeQueue {
   private async processViaIngest(item: QueueItem, ruleset: ExtractionRuleset): Promise<ScrapedData> {
     const searchFetch = this.getSearchFetchFor(item.url);
     const page = await this.getCapturingFetch()(item.url, searchFetch, { cookies: item.cookies });
+    // Anchor for the courtesy gap (D8): the instant the PRIMARY fetch completed, so a same-store
+    // `ctx.scraping.fetchBody` follow-up (extractMany's second call) waits the store's declared
+    // gap against THIS fetch, not against whenever the follow-up happens to be invoked.
+    const primaryFetchedAt = Date.now();
+    const ctx = this.buildIngestExtractContext(item, ruleset, searchFetch, primaryFetchedAt);
 
-    let extracted: PluginExtractedData;
+    let records: PluginExtractedData[];
     try {
-      // extract() is async-capable (E1): the contract allows it to return
-      // ExtractedData or a Promise, so the result is ALWAYS awaited — sync
-      // rulesets pass through unchanged. The duck-typed extractAsync path
-      // predates E1 and is kept for rulesets that still expose it.
-      extracted = typeof (ruleset as { extractAsync?: unknown }).extractAsync === 'function'
-        ? await (ruleset as unknown as { extractAsync(h: string, u: string): Promise<PluginExtractedData> }).extractAsync(page.html, item.url)
-        : await ruleset.extract(page.html, item.url);
+      // extractRecords folds extractMany > extractAsync > extract into one always-array result
+      // (engineServices/extractRecords.ts) — a single-record ruleset's own extraction call is
+      // byte-for-byte what it was before this dispatch existed; only the caller-facing shape
+      // (array vs bare object) is new. D11 guards (empty / dup itemId / target-before-source) run
+      // inside it: a violation throws here, so nothing is emitted, same as any other extraction
+      // failure.
+      records = await extractRecords(ruleset, page.html, item.url, ctx);
     } catch (error: any) {
       console.error(
         `[SCRAPE QUEUE] Extraction failed for ${item.url} (ruleset ${ruleset.siteId}@${ruleset.version}): ${sanitizeForLog(error?.message ?? String(error))}`
@@ -1036,9 +1046,90 @@ export class ScrapeQueue {
       throw error instanceof Error ? error : new Error(String(error));
     }
 
-    await this.ingestEmitter!.send(extracted);
+    // D2: N sequential unary Ingest calls in array order, parent FIRST, each awaited — STOP at
+    // the first failure. The ingest server commits a record before the call resolves, so an
+    // awaited prefix guarantees every later (dependent, e.g. editionOf/offerOf) record's target
+    // already landed before it is sent. A failure here is a PARTIAL-EMIT state: logged and
+    // counted (never silently swallowed), then rethrown through the queue's existing failure
+    // handling — the retry re-fetches, re-extracts, and re-emits ALL records as new honest
+    // observations (no partial-batch ambiguity: there is no batch, only a resumable prefix).
+    let emittedCount = 0;
+    try {
+      for (const record of records) {
+        await this.ingestEmitter!.send(record);
+        emittedCount++;
+      }
+    } catch (error: any) {
+      console.error(
+        `[SCRAPE QUEUE] Ingest emit failed for ${item.url} after ${emittedCount}/${records.length} records emitted ` +
+          `(ruleset ${ruleset.siteId}@${ruleset.version}): ${sanitizeForLog(error?.message ?? String(error))}`
+      );
+      throw error instanceof Error ? error : new Error(String(error));
+    }
 
-    return extracted.fields as ScrapedData;
+    console.log(
+      `[SCRAPE QUEUE] Ingest complete for ${item.url}: records emitted=${emittedCount}/${records.length} (ruleset ${ruleset.siteId}@${ruleset.version})`
+    );
+
+    // [0] is always the page's own record (extractMany's documented contract; the single-record
+    // fallback's one-element array trivially satisfies it too) — handleSuccess/the /ingest/scrape
+    // response stay parent-shaped, unchanged from today.
+    return records[0].fields as ScrapedData;
+  }
+
+  /**
+   * Build the ExtractContext for one item's extraction (B3, spec.md D1/D8/D9). Only
+   * `scraping.fetchBody` is truly implemented (engineServices/extractContext.ts); it reuses the
+   * SAME capturing fetch + the store's OWN declared `searchFetch` transport as the primary fetch,
+   * so a same-store follow-up (e.g. orzgk's variation-batch endpoint) still lands in the capture
+   * sink under the 'api' lane, courtesy-gapped against `primaryFetchedAt`.
+   */
+  private buildIngestExtractContext(
+    item: QueueItem,
+    ruleset: ExtractionRuleset,
+    searchFetch: SearchFetch | undefined,
+    primaryFetchedAt: number,
+  ): ExtractContext {
+    let hostname: string | undefined;
+    try {
+      hostname = new URL(item.url).hostname;
+    } catch {
+      hostname = undefined;
+    }
+    const caps = hostname ? this.profiles?.forHost(hostname) : undefined;
+    // Fallback SiteConfig for the (should-be-rare) case a ruleset resolved but its store isn't in
+    // the capability index — e.g. a stale/DI'd registry in tests. Mirrors the queue's own global
+    // adaptive-lane defaults (RATE_LIMIT above) so a missing profile degrades to a sane, documented
+    // gap rather than an undefined one.
+    const config: SiteConfig =
+      caps ?? {
+        siteId: ruleset.siteId,
+        name: ruleset.siteId,
+        domains: hostname ? [hostname] : [],
+        rateLimit: {
+          domain: hostname ?? '',
+          baseDelayMs: RATE_LIMIT.BASE_DELAY,
+          minDelayMs: RATE_LIMIT.MIN_DELAY,
+          maxDelayMs: RATE_LIMIT.MAX_DELAY,
+          backoffMultiplier: RATE_LIMIT.BACKOFF_MULTIPLIER,
+          recoveryDivisor: RATE_LIMIT.RECOVERY_DIVISOR,
+          successThreshold: RATE_LIMIT.SUCCESS_THRESHOLD,
+        },
+        requiresBrowser: false,
+        allowedCookies: [],
+      };
+
+    return buildExtractContext({
+      config,
+      logger: createPluginLogger(ruleset.siteId),
+      scraping: this.getRawPageFetcher(),
+      capturingFetch: this.getCapturingFetch(),
+      searchFetch,
+      cookies: item.cookies,
+      primaryUrl: item.url,
+      primaryFetchedAt,
+      baseDelayMs: caps?.rateLimit?.baseDelayMs,
+    });
   }
 
   /**


### PR DESCRIPTION
## What — orzgk Slice B increment B3: engine multi-record extract + sequential emit
Spec of record `~/tmp/orzgk-slice-b/spec.md` (D1/D2/D7/D8; §10 amendments). Consumes plugin-contract 0.4.0 (#257).

- **`extractRecords(ruleset, html, url, ctx)`** — dispatch `extractMany` > `extractAsync` > `extract`; always returns an array (single-record rulesets ⇒ `[record]`, today's path); validates non-empty, distinct `source.itemId`, and target-before-child for `editionOf`/`offerOf` (throws clearly — never reorders or drops silently).
- **`buildExtractContext`** — `scraping.fetchBody` over the **same capturing fetch** as the primary (store's declared `searchFetch` transport; raw bytes still reach the capture sink under the api lane), waits `primaryFetchedAt + baseDelayMs` for the *same host only* (injectable clock; `DEFAULT_FETCH_BODY_GAP_MS=2000` for undeclared stores), cookies passed; returns `{html, statusCode?}`; `browserFetch`/`withBrowser`/`withPage` stubbed to throw; `batchFetch`/`officialApi` left undefined.
- **`scrapeQueue.processViaIngest`** — builds ctx, calls `extractRecords`, then emits **every record sequentially** with `await ingestEmitter.send()` in array order (parent first); **stop at first failure** (item marked failed, `records emitted=N/M` logged — partial-emit is never swallowed); `handleSuccess` gets `[0].fields` as today. **No batch RPC, no ingest-contract change** — the ingest server commits the parent before returning, so children forward-resolve in fc-aggregation's lane E/S.
- **crawlWorker / assembleCrawlDriver parity** — array emit + `resolveContext` threaded; unit-tested, dormant until the driver soaks.

## Verification (independently reproduced by the orchestrator)
- **Red→green by me**: reverting `scrapeQueue.ts` to develop fails all 5 multi-record queue tests; restored → green.
- jest **658/59** (baseline 624/56; +3 suites/+34 tests, zero regressions), `typecheck` + `typecheck:tests` clean.
- Red-team `ordering-emit` ran a *hanging-promise probe* proving `send(child)` is not invoked until `send(parent)` settles (structurally a `for…await` loop at `scrapeQueue.ts:1058`, not `Promise.all`), plus grandchild target-first ordering; `fetchBody` verified capture-sink-backed on impersonate/http lanes; 3 lenses passed, 0 survivors.
- Coverage on the new modules 100%; no bare `fetch` (lint-fetch discipline).

## Disclosures
- 7 pre-existing queue-test assertions gained a 3rd-arg `expect.anything()` matcher (extractRecords now always forwards `ctx`, matching the driver's existing 3-arg convention) — behavior unchanged, driver tests needed zero edits.
- `extractRecords` also rejects a record with no `source.itemId` (a guard beyond D11; live rulesets always set it).
- The courtesy gap anchors on `primaryFetchedAt` only (a ruleset issuing >1 `fetchBody` to the same host is not re-gapped) — a hardening item alongside H1 (per-host pacing on the live queue), not a Slice B gate.
- Cookie pass-through on the `http` transport lane is a pre-existing property of `capturingFetch.ts` (#255), unchanged here; orzgk is cookieless.

## Deploy
Engine image build → repin `scraper.yaml` image digest. Live behavior for existing single-record stores is unchanged; multi-record activates only when a ruleset implements `extractMany` (rulesets 0.9.0 / B2). Squash-merge (the branch's commit body is 5 lines).
