### PR TITLE
Add per-host pacing: live-queue floor, driver fetchBody via HostRateLimiter, per-host ctx re-gap (H1)

### DIFF
--- a/src/__tests__/unit/scrapeQueueHostPacing.test.ts
+++ b/src/__tests__/unit/scrapeQueueHostPacing.test.ts
@@ -203,6 +203,27 @@ describe('ScrapeQueue — live queue per-host pacing (H1)', () => {
     expect(scraping.scrapePage.mock.calls[2][0]).toBe('https://host-a.test/item/a1');
   });
 
+  it("falls back to DEFAULT_FETCH_BODY_GAP_MS (2000ms) — not the store's declared baseDelayMs — when the item's host has no resolved store profile, even though its ruleset matched via the subdomain fallback", async () => {
+    // The registered store's declared floor is 5000ms, but the items below hit a SUBDOMAIN
+    // ('sub.host-a.test') that extractionRegistry's own subdomain fallback resolves to the
+    // 'host-a' ruleset, while ProfileRegistry's byHost index (exact-domain only, no subdomain
+    // wildcard) does NOT resolve it — so profiles.forHost('sub.host-a.test') is undefined and
+    // hostBaseDelayMs() must take the `?? DEFAULT_FETCH_BODY_GAP_MS` branch, not the 5000ms one.
+    const { scraping } = makeQueue([{ siteId: 'host-a', domain: 'host-a.test', baseDelayMs: 5000 }]);
+
+    queue.enqueue('u1', { priority: 'WARM', url: 'https://sub.host-a.test/item/u1' });
+    queue.enqueue('u2', { priority: 'WARM', url: 'https://sub.host-a.test/item/u2' });
+
+    await advanceAndFlush(100);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(1); // u1 dispatches (ruleset DID match)
+
+    // Past the DEFAULT gap (2000ms) but well short of the store's declared 5000ms floor: if the
+    // fallback were wrongly reading the store's own baseDelayMs, u2 would still be blocked here.
+    await advanceAndFlush(2200);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(2);
+    expect(scraping.scrapePage.mock.calls[1][0]).toBe('https://sub.host-a.test/item/u2');
+  });
+
   it('treats an item with an unparseable URL as having no host — never blocks on the pacing floor, never crashes or hangs', async () => {
     makeQueue([{ siteId: 'host-a', domain: 'host-a.test', baseDelayMs: 5000 }]);
 

--- a/src/__tests__/unit/scrapeQueueHostPacing.test.ts
+++ b/src/__tests__/unit/scrapeQueueHostPacing.test.ts
@@ -202,4 +202,17 @@ describe('ScrapeQueue — live queue per-host pacing (H1)', () => {
     expect(scraping.scrapePage).toHaveBeenCalledTimes(3);
     expect(scraping.scrapePage.mock.calls[2][0]).toBe('https://host-a.test/item/a1');
   });
+
+  it('treats an item with an unparseable URL as having no host — never blocks on the pacing floor, never crashes or hangs', async () => {
+    makeQueue([{ siteId: 'host-a', domain: 'host-a.test', baseDelayMs: 5000 }]);
+
+    const result = queue.enqueue('bad1', { priority: 'WARM', url: 'not a url at all', maxRetries: 0 });
+    const outcome = result.promise.catch((e: Error) => e);
+
+    await advanceAndFlush(500);
+
+    // No ruleset matches an unparseable URL — the item fails cleanly (EXTRACTION_UNAVAILABLE)
+    // rather than hanging forever behind a pacing check that can't resolve a host.
+    expect(await outcome).toBeInstanceOf(Error);
+  });
 });

--- a/src/__tests__/unit/scrapeQueueHostPacing.test.ts
+++ b/src/__tests__/unit/scrapeQueueHostPacing.test.ts
@@ -1,0 +1,205 @@
+/**
+ * TDD (red first) — H1: live-queue per-host pacing (spec.md orzgk Slice B D8, §4 Rate row,
+ * §6 B6 H1). Today processNext paces only the GLOBAL lane on `currentDelay`, so two items for
+ * the SAME host are separated only by that shared delay — the store's own declared
+ * `rateLimit.baseDelayMs` (the store-caps index the ingest path already builds from
+ * setPluginRegistry) is never consulted for spacing between successive dispatches to the same
+ * host. These tests add a per-host floor: a host whose baseDelayMs exceeds the current global
+ * lane delay must still be respected; a different, never-touched host must NOT be penalized by
+ * another host's floor; and a HOT item whose host is paced must not block a WARM item for a
+ * ready, different host (ordering preserved BETWEEN other hosts under deferral).
+ *
+ * Fake timers throughout (jest.useFakeTimers({ advanceTimers: true }), the SAME pattern already
+ * used by scrapeQueueProcessing.test.ts) — no real sleeps, no live fetches.
+ */
+
+const mockNotifyItemSuccess = jest.fn().mockResolvedValue(true);
+const mockNotifyItemFailed = jest.fn().mockResolvedValue(true);
+const mockNotifyItemSkipped = jest.fn().mockResolvedValue(true);
+
+jest.mock('../../services/genericScraper', () => ({
+  BrowserPool: {
+    getStealthBrowser: jest.fn(),
+    getBrowser: jest.fn(),
+    returnBrowser: jest.fn(),
+    getPoolSize: jest.fn().mockReturnValue(2),
+    getPoolCapacity: jest.fn().mockReturnValue(3),
+    reset: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/webhookClient', () => ({
+  notifyItemSuccess: (...args: any[]) => mockNotifyItemSuccess(...args),
+  notifyItemFailed: (...args: any[]) => mockNotifyItemFailed(...args),
+  notifyItemSkipped: (...args: any[]) => mockNotifyItemSkipped(...args),
+}));
+
+import { ScrapeQueue, resetScrapeQueue } from '../../services/scrapeQueue';
+import { createExtractionRegistry, ExtractionRegistryImpl } from '../../services/extractionRegistry';
+
+interface SiteSpec {
+  siteId: string;
+  domain: string;
+  baseDelayMs: number;
+}
+
+/** Registry with N sites, each on its own domain and its own declared baseDelayMs. */
+function makeMultiHostRegistry(sites: SiteSpec[]): ExtractionRegistryImpl {
+  const registry = createExtractionRegistry();
+  for (const s of sites) {
+    registry.registerSite({
+      siteId: s.siteId,
+      name: s.siteId,
+      domains: [s.domain],
+      rateLimit: {
+        domain: s.domain,
+        baseDelayMs: s.baseDelayMs,
+        minDelayMs: 100,
+        maxDelayMs: 60000,
+        backoffMultiplier: 1.5,
+        recoveryDivisor: 1.5,
+        successThreshold: 3,
+      },
+      requiresBrowser: false,
+      allowedCookies: [],
+    });
+    registry.registerRuleset({
+      siteId: s.siteId,
+      version: '1.0.0',
+      extract: (_html: string, url: string) => ({
+        source: {
+          site: s.siteId,
+          itemId: new URL(url).pathname.split('/').pop() as string,
+          url,
+          extractedAt: '2026-08-19T00:00:00.000Z',
+          rulesetVersion: '1.0.0',
+        },
+        fields: { name: `Figure-${s.siteId}` },
+        warnings: [],
+      }),
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    });
+  }
+  return registry;
+}
+
+function makeScrapingStub() {
+  return {
+    scrapePage: jest.fn().mockImplementation((url: string) =>
+      Promise.resolve({ html: '<html></html>', url, title: 'Item', statusCode: 200 }),
+    ),
+    scrapePageStealth: jest.fn().mockImplementation((url: string) =>
+      Promise.resolve({ html: '<html></html>', url, title: 'Item', statusCode: 200 }),
+    ),
+  };
+}
+
+describe('ScrapeQueue — live queue per-host pacing (H1)', () => {
+  let queue: ScrapeQueue;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers({ advanceTimers: true });
+    resetScrapeQueue();
+    mockNotifyItemSuccess.mockResolvedValue(true);
+    mockNotifyItemFailed.mockResolvedValue(true);
+    mockNotifyItemSkipped.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    if (queue) {
+      queue.stop();
+      queue.clear();
+    }
+    resetScrapeQueue();
+    jest.useRealTimers();
+  });
+
+  async function advanceAndFlush(ms: number, iterations: number = 3) {
+    for (let i = 0; i < iterations; i++) {
+      jest.advanceTimersByTime(ms / iterations);
+      await jest.advanceTimersByTimeAsync(50);
+    }
+  }
+
+  function makeQueue(sites: SiteSpec[]) {
+    const scraping = makeScrapingStub();
+    const send = jest.fn().mockResolvedValue({ sourceId: 'src-1' });
+    queue = new ScrapeQueue(false);
+    queue.setPluginRegistry(makeMultiHostRegistry(sites));
+    queue.setIngestEmitter({ send });
+    queue.setScrapingService(scraping);
+    return { scraping, send };
+  }
+
+  it('defers the SECOND item for the SAME host until the store baseDelayMs has elapsed, even though the global lane delay is shorter', async () => {
+    // Store declares a 5000ms floor — well above the default global lane delay (2067ms).
+    const { scraping } = makeQueue([{ siteId: 'host-a', domain: 'host-a.test', baseDelayMs: 5000 }]);
+
+    queue.enqueue('a1', { priority: 'WARM', url: 'https://host-a.test/item/a1' });
+    queue.enqueue('a2', { priority: 'WARM', url: 'https://host-a.test/item/a2' });
+
+    // First item dispatches immediately (lastRequestTime starts at 0 — always past due).
+    await advanceAndFlush(100);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(1);
+
+    // Global lane's own delay (2067ms) has now elapsed — a global-lane-only implementation would
+    // dispatch item 2 here. The store's 5000ms floor must still hold it back.
+    await advanceAndFlush(2200);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(1);
+
+    // Once the store's declared 5000ms has elapsed since item 1's dispatch, item 2 may proceed.
+    await advanceAndFlush(3200);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(2);
+    expect(scraping.scrapePage.mock.calls[1][0]).toBe('https://host-a.test/item/a2');
+  });
+
+  it('does NOT penalize a different, never-touched host by another host\'s floor', async () => {
+    const { scraping } = makeQueue([
+      { siteId: 'host-a', domain: 'host-a.test', baseDelayMs: 5000 },
+      { siteId: 'host-b', domain: 'host-b.test', baseDelayMs: 1000 },
+    ]);
+
+    queue.enqueue('a1', { priority: 'WARM', url: 'https://host-a.test/item/a1' });
+    queue.enqueue('b1', { priority: 'WARM', url: 'https://host-b.test/item/b1' });
+
+    await advanceAndFlush(100);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(1); // host-a's item 1
+
+    // Only the GLOBAL lane delay (2067ms) gates host-b's item — host-a's 5000ms floor must not
+    // leak onto it, since host-b has never been dispatched to.
+    await advanceAndFlush(2200);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(2);
+    expect(scraping.scrapePage.mock.calls[1][0]).toBe('https://host-b.test/item/b1');
+  });
+
+  it('a HOT item whose host is still paced does not block a WARM item for a different, ready host', async () => {
+    const { scraping } = makeQueue([
+      { siteId: 'host-a', domain: 'host-a.test', baseDelayMs: 5000 },
+      { siteId: 'host-b', domain: 'host-b.test', baseDelayMs: 500 },
+    ]);
+
+    // Prime host-a's pacing clock with an initial dispatch.
+    queue.enqueue('a0', { priority: 'WARM', url: 'https://host-a.test/item/a0' });
+    await advanceAndFlush(100);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(1);
+
+    // Global lane clears at +2067ms. At that point queue a HOT item for the still-paced host-a
+    // (needs the full 5000ms from a0's dispatch) alongside a WARM item for the ready host-b.
+    await advanceAndFlush(2100);
+    queue.enqueue('a1', { priority: 'HOT', url: 'https://host-a.test/item/a1' });
+    queue.enqueue('b1', { priority: 'WARM', url: 'https://host-b.test/item/b1' });
+
+    // host-a's HOT item cannot dispatch yet (only ~2200ms since a0 < 5000ms floor); the WARM
+    // host-b item, whose host has never been touched, must be free to go instead.
+    await advanceAndFlush(100);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(2);
+    expect(scraping.scrapePage.mock.calls[1][0]).toBe('https://host-b.test/item/b1');
+
+    // host-a's HOT item still lands once its own floor clears.
+    await advanceAndFlush(3000);
+    await advanceAndFlush(3000);
+    expect(scraping.scrapePage).toHaveBeenCalledTimes(3);
+    expect(scraping.scrapePage.mock.calls[2][0]).toBe('https://host-a.test/item/a1');
+  });
+});

--- a/src/driver/__tests__/assembleCrawlDriver.test.ts
+++ b/src/driver/__tests__/assembleCrawlDriver.test.ts
@@ -194,4 +194,24 @@ describe('assembleCrawlDriver — end-to-end crawl runtime', () => {
     // (Unrouted, A2 would dispatch at t=1000 — gated only by the primary fetch at t=0.)
     expect(scrapeTimes).toEqual([0, 1500]);
   });
+
+  it('resolveContext returning undefined is passed through untouched (nothing to wrap)', async () => {
+    const rs: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '1.0',
+      extract: jest.fn((_html: string, url: string) => extracted(gcodeOf(url))),
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const resolveContext = jest.fn().mockReturnValue(undefined);
+    const { sends, driver } = build({
+      extraction: { allStores: () => [AMIAMI], getRulesetForUrl: () => rs },
+      resolveContext,
+    });
+
+    const result = await driver.crawlSite('amiami', ['A1']);
+
+    expect(rs.extract).toHaveBeenCalledWith('<html/>', expect.any(String), undefined);
+    expect(sends.map((e) => e.source.itemId)).toEqual(['A1']);
+    expect(result.coverage.done).toBe(1);
+  });
 });

--- a/src/driver/__tests__/assembleCrawlDriver.test.ts
+++ b/src/driver/__tests__/assembleCrawlDriver.test.ts
@@ -195,6 +195,65 @@ describe('assembleCrawlDriver — end-to-end crawl runtime', () => {
     expect(scrapeTimes).toEqual([0, 1500]);
   });
 
+  /**
+   * Challenger H1 finding (blocker, seam-2 host-key mismatch): the store's registered
+   * `domains[0]` (CrawlTask.host) and the fetchBody follow-up URL's own hostname are not
+   * guaranteed to be the same raw string — this repo's own fixtures already mix 'amiami.com'
+   * (assembleScheduler.test.ts) and 'www.amiami.com' (this file's AMIAMI, above) for the SAME
+   * siteId. Reruns the seam-2 wiring test with domains[0]='amiami.com' (no www) while the
+   * follow-up still hits 'www.amiami.com' — the mismatched-convention case — and asserts pacing
+   * still holds, proving the two forms are collapsed to one host entry rather than silently
+   * landing in separate ones.
+   */
+  it("routes ctx.scraping.fetchBody through the HostRateLimiter even when the store's domains[0] and the follow-up URL's hostname use different www conventions", async () => {
+    const BARE_DOMAIN: StoreCapabilities = {
+      ...AMIAMI,
+      domains: ['amiami.com'], // no www — mismatches the 'www.amiami.com' follow-up URL below
+      rateLimit: { ...AMIAMI.rateLimit, baseDelayMs: 1000 },
+    };
+    let clock = 0;
+    const now = () => clock;
+    const sleep = async (ms: number) => { clock += ms; };
+    const scrapeTimes: number[] = [];
+
+    const extractMany = jest.fn(async (_html: string, url: string, ctx: any) => {
+      await sleep(500);
+      await ctx.scraping.fetchBody('https://www.amiami.com/api/follow-up');
+      return [extracted(gcodeOf(url))];
+    });
+    const rs: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '2.0',
+      extract: jest.fn(() => { throw new Error('extract() should not run when extractMany is present'); }),
+      extractMany,
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const resolveContext = jest.fn(() => ({
+      config: {},
+      logger: {},
+      scraping: { fetchBody: jest.fn().mockResolvedValue({ html: 'follow-up' }) },
+    } as never));
+
+    const { driver } = build({
+      extraction: { allStores: () => [BARE_DOMAIN], getRulesetForUrl: () => rs },
+      scrape: jest.fn(async (url: string): Promise<ScrapePageResult> => {
+        scrapeTimes.push(now());
+        return { html: '<html/>', url, title: '', statusCode: 200 };
+      }),
+      now,
+      sleep,
+      capacity: { browser: 0, fetch: 1 },
+      resolveContext,
+    });
+
+    await driver.crawlSite('amiami', ['A1', 'A2']);
+
+    // Same expectation as the matching-convention test above: the follow-up recorded at t=500
+    // becomes host-a's real last-contact time, so A2 cannot dispatch before t=1500 — even though
+    // domains[0] ('amiami.com') and the follow-up URL's hostname ('www.amiami.com') differ.
+    expect(scrapeTimes).toEqual([0, 1500]);
+  });
+
   it('resolveContext returning undefined is passed through untouched (nothing to wrap)', async () => {
     const rs: ExtractionRuleset = {
       siteId: 'amiami',

--- a/src/driver/__tests__/assembleCrawlDriver.test.ts
+++ b/src/driver/__tests__/assembleCrawlDriver.test.ts
@@ -137,4 +137,61 @@ describe('assembleCrawlDriver — end-to-end crawl runtime', () => {
     expect(sends.map((e) => e.source.itemId)).toEqual(['A1']);
     expect(result.coverage.done).toBe(1);
   });
+
+  /**
+   * H1 seam 2 (spec.md orzgk Slice B D8 follow-on): a ruleset's in-slot `ctx.scraping.fetchBody`
+   * follow-up must be routed through the SAME HostRateLimiter the scheduler paces primary
+   * dispatches with — otherwise the NEXT primary dispatch to that host only knows about the
+   * PRIMARY fetch's timing, understating how recently the host was really hit. A single fetch-pool
+   * slot serializes A1/A2 so A2's dispatch time exposes exactly what the limiter believes host-a's
+   * last-contact time is. A fully deterministic virtual clock (now/sleep linked, no real timers)
+   * makes the two possible outcomes (1000ms vs 1500ms) an exact, non-flaky assertion.
+   */
+  it("routes a ruleset's ctx.scraping.fetchBody through the HostRateLimiter, so slot pacing for the NEXT item accounts for it", async () => {
+    const PACED: StoreCapabilities = { ...AMIAMI, rateLimit: { ...AMIAMI.rateLimit, baseDelayMs: 1000 } };
+    let clock = 0;
+    const now = () => clock;
+    const sleep = async (ms: number) => { clock += ms; };
+    const scrapeTimes: number[] = [];
+
+    const extractMany = jest.fn(async (_html: string, url: string, ctx: any) => {
+      // Simulate real elapsed work BEFORE the in-slot follow-up fires, so the follow-up's own
+      // dispatch time is provably later than the primary fetch's.
+      await sleep(500);
+      await ctx.scraping.fetchBody('https://www.amiami.com/api/follow-up');
+      return [extracted(gcodeOf(url))];
+    });
+    const rs: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '2.0',
+      extract: jest.fn(() => { throw new Error('extract() should not run when extractMany is present'); }),
+      extractMany,
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const resolveContext = jest.fn(() => ({
+      config: {},
+      logger: {},
+      scraping: { fetchBody: jest.fn().mockResolvedValue({ html: 'follow-up' }) },
+    } as never));
+
+    const { driver } = build({
+      extraction: { allStores: () => [PACED], getRulesetForUrl: () => rs },
+      scrape: jest.fn(async (url: string): Promise<ScrapePageResult> => {
+        scrapeTimes.push(now());
+        return { html: '<html/>', url, title: '', statusCode: 200 };
+      }),
+      now,
+      sleep,
+      capacity: { browser: 0, fetch: 1 }, // one slot: serializes A1 then A2
+      resolveContext,
+    });
+
+    await driver.crawlSite('amiami', ['A1', 'A2']);
+
+    // A1 dispatches at t=0. Its extractMany advances the clock to t=500 before issuing the
+    // in-slot fetchBody follow-up. Routed through the limiter, that becomes host-a's real
+    // last-dispatch time — so A2 (same host, baseDelayMs=1000) cannot dispatch before t=1500.
+    // (Unrouted, A2 would dispatch at t=1000 — gated only by the primary fetch at t=0.)
+    expect(scrapeTimes).toEqual([0, 1500]);
+  });
 });

--- a/src/driver/__tests__/hostRateLimiter.test.ts
+++ b/src/driver/__tests__/hostRateLimiter.test.ts
@@ -6,6 +6,8 @@
  * block on one host cannot slow another.
  */
 import { HostRateLimiter, wrapFetchBodyWithLimiter, type HostRateConfig } from '../hostRateLimiter';
+import { DispatchScheduler } from '../dispatchScheduler';
+import { PoolRouter } from '../poolRouter';
 import type { ExtractContext } from '@figurecollecting/scraper-plugin-contract';
 
 const cfg = (over: Partial<HostRateConfig> = {}): HostRateConfig => ({
@@ -80,6 +82,30 @@ describe('HostRateLimiter — per-host throttle', () => {
     rl.recordDispatch('a.com', 0);
     expect(rl.msUntilReady('a.com', 400)).toBe(600); // throttled from t=0, not treated as fresh
   });
+
+  /**
+   * Challenger H1 finding (blocker, seam-2 host-key mismatch): every writer/reader keys by the
+   * RAW string a caller happened to pass — CrawlTask.host comes from StoreCapabilities.domains[0]
+   * (e.g. 'amiami.com'), while wrapFetchBodyWithLimiter's follow-up dispatch is keyed by the
+   * fetched URL's own hostname (e.g. 'www.amiami.com'). This repo's own fixtures already mix both
+   * conventions for the SAME siteId ('amiami') across assembleScheduler.test.ts (no www) and
+   * assembleCrawlDriver.test.ts (www) — proving the two never being guaranteed equal is not a
+   * hypothetical. The limiter must collapse both forms to ONE host entry so a fetchBody follow-up
+   * always lands on the same state a primary dispatch already created, regardless of which form
+   * each side used.
+   */
+  it('collapses a www-prefixed host and its bare form to the SAME internal state (trimmed, lowercased)', () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000 }));
+    rl.recordDispatch('amiami.com', 1000);
+    // Read back through the www-prefixed form a fetchBody follow-up's hostnameOf() would produce.
+    expect(rl.msUntilReady('www.amiami.com', 1000)).toBe(1000);
+    expect(rl.currentDelay('www.amiami.com')).toBe(1000);
+
+    // And the reverse direction, plus stray whitespace/casing a URL hostname never has but a
+    // config string might.
+    rl.recordDispatch('  WWW.AmiAmi.com  ', 1500);
+    expect(rl.msUntilReady('amiami.com', 1500)).toBe(1000);
+  });
 });
 
 /**
@@ -139,5 +165,44 @@ describe('wrapFetchBodyWithLimiter — routes driver fetchBody dispatches throug
     await wrapped.scraping.fetchBody!('https://orzgk.com/api/x', { cookies: { a: 'b' } });
 
     expect(fetchBody).toHaveBeenCalledWith('https://orzgk.com/api/x', { cookies: { a: 'b' } });
+  });
+
+  /**
+   * Challenger H1 finding (blocker, seam-2 dispatch-time race): recordDispatch must happen when
+   * the follow-up is SENT, not once it resolves — otherwise a same-host primary dispatch decided
+   * WHILE the follow-up is still in flight sees a stale lastRequestTime and wrongly proceeds
+   * (DispatchScheduler.dispatch's OWN primary recordDispatch already does this correctly, BEFORE
+   * its await — this seam must match that convention). Proven end-to-end against the real
+   * DispatchScheduler + PoolRouter (capacity fetch:2, so a second same-host task CAN take a free
+   * slot concurrently — the exact precondition the finding calls out), with the follow-up's
+   * promise deliberately left unresolved to prove the recording cannot be waiting on it.
+   */
+  it("records the fetchBody follow-up's dispatch on the limiter BEFORE it resolves, so a same-host primary dispatch decided while it is still in flight is correctly paced", () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000 }));
+    const router = new PoolRouter({ browser: 0, fetch: 2 });
+    const scheduler = new DispatchScheduler(rl, router, () => 'fetch');
+
+    scheduler.enqueue({ id: 'A1', host: 'host-a.test' });
+    scheduler.enqueue({ id: 'A2', host: 'host-a.test' });
+
+    // A1 dispatches at t=0 (primary): takes a fetch slot, records lastRequestTime=0.
+    expect(scheduler.dispatch(0)).not.toBeNull();
+    // A2 correctly deferred at t=0 by A1's OWN primary dispatch (host throttled until t=1000).
+    expect(scheduler.dispatch(0)).toBeNull();
+
+    // Simulate A1's in-slot worker: once its own primary floor clears (t=1000) it issues an
+    // in-slot fetchBody follow-up to the SAME host — never resolved here, so any correct behavior
+    // MUST come from recording at call time, not from awaiting the promise.
+    const fetchBody = jest.fn(() => new Promise(() => {})); // never settles
+    const ctx = { config: {}, logger: {}, scraping: { ...STUB_SCRAPING, fetchBody } } as unknown as ExtractContext;
+    const wrapped = wrapFetchBodyWithLimiter(ctx, rl, () => 1000);
+    void wrapped.scraping.fetchBody!('https://host-a.test/api/follow-up'); // fire-and-forget, still pending
+
+    // A2's dispatch decision, made right after the follow-up was sent (but before it could ever
+    // resolve), must already see the follow-up's dispatch — host-a was just contacted at t=1000,
+    // so A2 must not be dispatchable until t=2000.
+    expect(scheduler.dispatch(1000)).toBeNull();
+    expect(scheduler.dispatch(1999)).toBeNull();
+    expect(scheduler.dispatch(2000)).not.toBeNull();
   });
 });

--- a/src/driver/__tests__/hostRateLimiter.test.ts
+++ b/src/driver/__tests__/hostRateLimiter.test.ts
@@ -5,7 +5,8 @@
  * `rateLimit`), so parallel stores never share a throttle and a Cloudflare
  * block on one host cannot slow another.
  */
-import { HostRateLimiter, type HostRateConfig } from '../hostRateLimiter';
+import { HostRateLimiter, wrapFetchBodyWithLimiter, type HostRateConfig } from '../hostRateLimiter';
+import type { ExtractContext } from '@figurecollecting/scraper-plugin-contract';
 
 const cfg = (over: Partial<HostRateConfig> = {}): HostRateConfig => ({
   baseDelayMs: 1000,
@@ -78,5 +79,65 @@ describe('HostRateLimiter — per-host throttle', () => {
     const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000 }));
     rl.recordDispatch('a.com', 0);
     expect(rl.msUntilReady('a.com', 400)).toBe(600); // throttled from t=0, not treated as fresh
+  });
+});
+
+/**
+ * TDD (red first): H1 seam 2 — the crawl driver's in-slot `ctx.scraping.fetchBody` follow-up is
+ * invisible to HostRateLimiter today (it is issued mid-slot, entirely outside DispatchScheduler's
+ * dispatch/settle cycle), so slot pacing for the NEXT primary dispatch to that host only knows
+ * about the PRIMARY fetch's own timing, understating how recently the host was actually hit.
+ * `wrapFetchBodyWithLimiter` closes that gap: it wraps an ExtractContext's `fetchBody` so every
+ * call also records a dispatch on the limiter for the target host.
+ */
+const STUB_SCRAPING = {
+  scrapePage: jest.fn(),
+  scrapePageStealth: jest.fn(),
+  browserFetch: jest.fn(),
+  withBrowser: jest.fn(),
+  withPage: jest.fn(),
+};
+
+describe('wrapFetchBodyWithLimiter — routes driver fetchBody dispatches through the limiter', () => {
+  it("records a dispatch on the limiter, at the call's own time, when fetchBody is invoked", async () => {
+    const rl = new HostRateLimiter(() => cfg({ baseDelayMs: 1000 }));
+    const fetchBody = jest.fn().mockResolvedValue({ html: 'x' });
+    const ctx = { config: {}, logger: {}, scraping: { ...STUB_SCRAPING, fetchBody } } as unknown as ExtractContext;
+
+    const wrapped = wrapFetchBodyWithLimiter(ctx, rl, () => 5000);
+    expect(rl.msUntilReady('orzgk.com', 5000)).toBe(0); // never dispatched yet
+
+    const result = await wrapped.scraping.fetchBody!('https://orzgk.com/api/x');
+
+    expect(result).toEqual({ html: 'x' });
+    expect(fetchBody).toHaveBeenCalledWith('https://orzgk.com/api/x', undefined);
+    expect(rl.msUntilReady('orzgk.com', 5000)).toBe(1000); // just recorded as dispatched at t=5000
+  });
+
+  it('leaves an ExtractContext with no fetchBody unchanged (same reference — nothing to wrap)', () => {
+    const rl = new HostRateLimiter(() => cfg());
+    const ctx = { config: {}, logger: {}, scraping: { ...STUB_SCRAPING } } as unknown as ExtractContext;
+
+    expect(wrapFetchBodyWithLimiter(ctx, rl)).toBe(ctx);
+  });
+
+  it('never throws and skips recording for an unparseable url', async () => {
+    const rl = new HostRateLimiter(() => cfg());
+    const fetchBody = jest.fn().mockResolvedValue({ html: 'x' });
+    const ctx = { config: {}, logger: {}, scraping: { ...STUB_SCRAPING, fetchBody } } as unknown as ExtractContext;
+    const wrapped = wrapFetchBodyWithLimiter(ctx, rl, () => 1000);
+
+    await expect(wrapped.scraping.fetchBody!('not a url')).resolves.toEqual({ html: 'x' });
+  });
+
+  it('passes opts through to the original fetchBody untouched', async () => {
+    const rl = new HostRateLimiter(() => cfg());
+    const fetchBody = jest.fn().mockResolvedValue({ html: 'x' });
+    const ctx = { config: {}, logger: {}, scraping: { ...STUB_SCRAPING, fetchBody } } as unknown as ExtractContext;
+    const wrapped = wrapFetchBodyWithLimiter(ctx, rl, () => 1000);
+
+    await wrapped.scraping.fetchBody!('https://orzgk.com/api/x', { cookies: { a: 'b' } });
+
+    expect(fetchBody).toHaveBeenCalledWith('https://orzgk.com/api/x', { cookies: { a: 'b' } });
   });
 });

--- a/src/driver/assembleCrawlDriver.ts
+++ b/src/driver/assembleCrawlDriver.ts
@@ -22,6 +22,7 @@
 import { buildProfileRegistry, type ProfileRegistry } from './profileRegistry.js';
 import { assembleScheduler } from './assembleScheduler.js';
 import { assembleCrawlWorker } from './assembleCrawlWorker.js';
+import { wrapFetchBodyWithLimiter } from './hostRateLimiter.js';
 import { CrawlLoop, type CrawlLoopStats } from './crawlLoop.js';
 import { CoverageLedger, type CoverageCounts } from './coverageLedger.js';
 import type { PoolCapacity } from './poolRouter.js';
@@ -88,18 +89,27 @@ export function assembleCrawlDriver(services: CrawlDriverServices): CrawlDriver 
       const ledger = new CoverageLedger(siteId);
       ledger.add(itemIds);
 
+      const { scheduler, limiter } = assembleScheduler(profiles, services.capacity);
+
       const worker = assembleCrawlWorker({
         scrape: services.scrape,
         getRulesetForUrl: services.extraction.getRulesetForUrl,
         retrievalFor: (h) => profiles.retrievalFor(h),
         emit: services.emit,
         ledger,
+        // H1 seam 2: route a resolved ExtractContext's ctx.scraping.fetchBody (the ruleset's
+        // in-slot same-host follow-up) through the SAME HostRateLimiter that paces primary
+        // dispatches — otherwise the follow-up is invisible to it, and the NEXT primary dispatch
+        // to that host understates how recently it was really contacted.
         ...(services.resolveContext
-          ? { resolveContext: (task, url) => services.resolveContext!(siteId, task, url) }
+          ? {
+              resolveContext: (task, url) => {
+                const ctx = services.resolveContext!(siteId, task, url);
+                return ctx ? wrapFetchBodyWithLimiter(ctx, limiter, services.now) : ctx;
+              },
+            }
           : {}),
       });
-
-      const { scheduler } = assembleScheduler(profiles, services.capacity);
       // Seed from remaining() (pending + retryable-failed) so a restored ledger resumes cleanly.
       for (const id of ledger.remaining()) scheduler.enqueue({ id, host });
 

--- a/src/driver/hostRateLimiter.ts
+++ b/src/driver/hostRateLimiter.ts
@@ -10,6 +10,8 @@
  * `now` explicitly, so behaviour is deterministic and testable without timers.
  */
 
+import type { ExtractContext } from '@figurecollecting/scraper-plugin-contract';
+
 /** The rate knobs the limiter needs. `DomainRateLimit` is structurally assignable. */
 export interface HostRateConfig {
   baseDelayMs: number;
@@ -101,4 +103,52 @@ export class HostRateLimiter {
     );
     s.consecutiveSuccesses = 0;
   }
+}
+
+/**
+ * Lowercased hostname, undefined on an unparseable URL. Deliberately NOT `www.`-stripped: the
+ * driver's own host keys (CrawlTask.host, HostRateLimiter/DispatchScheduler's map keys) are the
+ * RAW domain string from StoreCapabilities.domains (e.g. 'www.amiami.com') — ProfileRegistry
+ * strips `www.` only for its OWN internal lookup index, never for the keys it hands back out.
+ * Matching that raw form here is what lets a fetchBody dispatch land on the SAME host entry a
+ * primary dispatch already created.
+ */
+function hostnameOf(url: string): string | undefined {
+  try {
+    return new URL(url).hostname.trim().toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Wrap an ExtractContext's `scraping.fetchBody` so every in-slot follow-up call ALSO records a
+ * dispatch on the given HostRateLimiter (H1 seam 2, spec.md orzgk Slice B): without this, a
+ * ruleset's `ctx.scraping.fetchBody` (extractMany's same-store follow-up, courtesy-gapped by
+ * buildExtractContext against ITS OWN prior call) is invisible to the driver's scheduler — the
+ * NEXT primary dispatch to that host would only know about the earlier PRIMARY fetch's timing,
+ * understating how recently the host was actually contacted. A context with no `fetchBody`
+ * (nothing to route) is returned UNCHANGED (same reference), so callers that don't touch it see
+ * no behavioural difference.
+ */
+export function wrapFetchBodyWithLimiter(
+  ctx: ExtractContext,
+  limiter: HostRateLimiter,
+  now: () => number = Date.now,
+): ExtractContext {
+  const original = ctx.scraping.fetchBody;
+  if (!original) return ctx;
+
+  return {
+    ...ctx,
+    scraping: {
+      ...ctx.scraping,
+      fetchBody: async (url, opts) => {
+        const result = await original(url, opts);
+        const host = hostnameOf(url);
+        if (host !== undefined) limiter.recordDispatch(host, now());
+        return result;
+      },
+    },
+  };
 }

--- a/src/driver/hostRateLimiter.ts
+++ b/src/driver/hostRateLimiter.ts
@@ -31,6 +31,18 @@ interface HostState {
 
 const clamp = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
 
+/**
+ * Host key: lowercased, trimmed, `www.`-stripped, so domain variants collapse to ONE state entry
+ * (same normalization as ProfileRegistry.normalizeHost). Callers pass whatever raw string form
+ * they have on hand — CrawlTask.host is StoreCapabilities.domains[0] verbatim, while a fetchBody
+ * follow-up's key is parsed straight off the request URL (hostnameOf, below) — and this repo's
+ * own fixtures already mix 'amiami.com'/'www.amiami.com' for the SAME store, so those two forms
+ * are not guaranteed to be byte-identical. Normalizing here, at the single state-lookup seam
+ * every method already funnels through, is what makes a fetchBody dispatch land on the SAME host
+ * entry a primary dispatch created, regardless of which raw form either side used.
+ */
+const normalizeHost = (host: string): string => host.trim().toLowerCase().replace(/^www\./, '');
+
 const DEFAULT_CONFIG: HostRateConfig = {
   baseDelayMs: 2067,
   minDelayMs: 274,
@@ -52,7 +64,8 @@ export class HostRateLimiter {
     private readonly defaultConfig: HostRateConfig = DEFAULT_CONFIG,
   ) {}
 
-  private stateFor(host: string): HostState {
+  private stateFor(rawHost: string): HostState {
+    const host = normalizeHost(rawHost);
     let s = this.hosts.get(host);
     if (!s) {
       const config = this.configFor(host) ?? this.defaultConfig;
@@ -106,12 +119,9 @@ export class HostRateLimiter {
 }
 
 /**
- * Lowercased hostname, undefined on an unparseable URL. Deliberately NOT `www.`-stripped: the
- * driver's own host keys (CrawlTask.host, HostRateLimiter/DispatchScheduler's map keys) are the
- * RAW domain string from StoreCapabilities.domains (e.g. 'www.amiami.com') — ProfileRegistry
- * strips `www.` only for its OWN internal lookup index, never for the keys it hands back out.
- * Matching that raw form here is what lets a fetchBody dispatch land on the SAME host entry a
- * primary dispatch already created.
+ * Lowercased hostname, undefined on an unparseable URL. Handed to HostRateLimiter as-is — its own
+ * `stateFor` normalizes (www-strip/trim/lowercase) on the way in, so this need not match
+ * CrawlTask.host's raw string form; the limiter is what makes the two forms collapse.
  */
 function hostnameOf(url: string): string | undefined {
   try {
@@ -144,10 +154,13 @@ export function wrapFetchBodyWithLimiter(
     scraping: {
       ...ctx.scraping,
       fetchBody: async (url, opts) => {
-        const result = await original(url, opts);
+        // Record at CALL time (matching DispatchScheduler.dispatch's own convention for primary
+        // dispatches), not once the fetch resolves — a same-host primary dispatch decision made
+        // WHILE this follow-up is still in flight must already see it, or the two can be paced
+        // far closer together than baseDelayMs intends (H1 finding: dispatch-time race).
         const host = hostnameOf(url);
         if (host !== undefined) limiter.recordDispatch(host, now());
-        return result;
+        return original(url, opts);
       },
     },
   };

--- a/src/services/engineServices/__tests__/extractContext.test.ts
+++ b/src/services/engineServices/__tests__/extractContext.test.ts
@@ -89,6 +89,72 @@ describe('buildExtractContext — scraping.fetchBody', () => {
     expect(capturingFetch).toHaveBeenCalled();
   });
 
+  it('re-gaps a SECOND fetchBody call to the SAME host against the FIRST call\'s own dispatch — not just primaryFetchedAt', async () => {
+    let clock = 1_000_000;
+    const now = jest.fn(() => clock);
+    const sleep = jest.fn(async (ms: number) => {
+      clock += ms;
+    });
+    const capturingFetch = jest.fn().mockResolvedValue({ html: '{"variations":[]}' });
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 1_000_000, // == now() at t0
+      baseDelayMs: 3000,
+      now,
+      sleep,
+    });
+
+    const followUpUrl = 'https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1';
+    await ctx.scraping.fetchBody!(followUpUrl); // gapped against primaryFetchedAt: waits 3000
+    await ctx.scraping.fetchBody!(followUpUrl); // SAME host again: must wait ANOTHER 3000, not 0
+
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 3000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 3000);
+    expect(capturingFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks the courtesy gap PER HOST — a follow-up to a different host does not disturb the primary host\'s own gap tracking', async () => {
+    let clock = 1_000_000;
+    const now = jest.fn(() => clock);
+    const sleep = jest.fn(async (ms: number) => {
+      clock += ms;
+    });
+    const capturingFetch = jest.fn().mockResolvedValue({ html: '{}' });
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'https://orzgk.com/wp-json/wc/store/v1/products/1',
+      primaryFetchedAt: 1_000_000,
+      baseDelayMs: 3000,
+      now,
+      sleep,
+    });
+
+    // Same-host follow-up first: waits the 3000ms gap against primaryFetchedAt, clock -> 1_003_000.
+    await ctx.scraping.fetchBody!('https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1');
+    // A DIFFERENT host in between: no gap owed against it (it has no prior fetch of its own).
+    await ctx.scraping.fetchBody!('https://a-totally-different-store.example/api/x');
+    // Back to the primary host again, immediately (clock unchanged since the different-host call
+    // didn't advance it): still gapped against the FIRST same-host call, not reset by the detour.
+    await ctx.scraping.fetchBody!('https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=1');
+
+    expect(sleep).toHaveBeenCalledTimes(2); // 1st same-host call + 3rd same-host call; NOT the different-host call
+    expect(sleep).toHaveBeenNthCalledWith(1, 3000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 3000);
+    expect(capturingFetch).toHaveBeenCalledTimes(3);
+  });
+
   it('does NOT apply the courtesy gap when the follow-up targets a DIFFERENT host than the primary fetch', async () => {
     const now = jest.fn(() => 1_000_000);
     const sleep = jest.fn().mockResolvedValue(undefined);

--- a/src/services/engineServices/extractContext.ts
+++ b/src/services/engineServices/extractContext.ts
@@ -97,6 +97,16 @@ export function buildExtractContext(options: BuildExtractContextOptions): Extrac
   const gapMs = options.baseDelayMs ?? DEFAULT_FETCH_BODY_GAP_MS;
   const primaryHost = safeHostname(options.primaryUrl);
 
+  // Last-fetch-per-host (re-gap, spec.md D8 follow-on): a ruleset issuing MULTIPLE fetchBody
+  // calls to the SAME host must be courtesy-gapped against its OWN previous call, not just the
+  // primary page fetch — otherwise only the FIRST follow-up ever waits, and every call after it
+  // is gapped against a primaryFetchedAt that has long since elapsed. Seeded with the primary
+  // fetch's own host/time so the first same-host follow-up's behaviour is unchanged.
+  const lastFetchedAt = new Map<string, number>();
+  if (primaryHost !== undefined) {
+    lastFetchedAt.set(primaryHost, options.primaryFetchedAt);
+  }
+
   return {
     config: options.config,
     logger: options.logger,
@@ -109,16 +119,20 @@ export function buildExtractContext(options: BuildExtractContextOptions): Extrac
 
       async fetchBody(url, fetchOpts) {
         const targetHost = safeHostname(url);
-        // Same-host-only courtesy: an unrelated host owes nothing against THIS primary fetch.
-        if (targetHost !== undefined && targetHost === primaryHost) {
-          const waitUntil = options.primaryFetchedAt + gapMs;
+        const last = targetHost !== undefined ? lastFetchedAt.get(targetHost) : undefined;
+        if (last !== undefined) {
+          const waitUntil = last + gapMs;
           const remaining = waitUntil - now();
           if (remaining > 0) {
             await sleep(remaining);
           }
         }
         const cookies = fetchOpts?.cookies ?? options.cookies;
-        return options.capturingFetch(url, options.searchFetch, cookies ? { cookies } : {});
+        const result = await options.capturingFetch(url, options.searchFetch, cookies ? { cookies } : {});
+        if (targetHost !== undefined) {
+          lastFetchedAt.set(targetHost, now());
+        }
+        return result;
       },
     },
   };

--- a/src/services/scrapeQueue.ts
+++ b/src/services/scrapeQueue.ts
@@ -32,7 +32,7 @@ import { impitFetchBody } from './impitFetch.js';
 import { httpFetchBody } from './engineLookup.js';
 import { buildProfileRegistry, ProfileRegistry } from '../driver/profileRegistry.js';
 import { extractRecords } from './engineServices/extractRecords.js';
-import { buildExtractContext } from './engineServices/extractContext.js';
+import { buildExtractContext, DEFAULT_FETCH_BODY_GAP_MS } from './engineServices/extractContext.js';
 import { createPluginLogger } from './engineServices/pluginLogger.js';
 import type { CaptureSink } from './captureSink.js';
 import type {
@@ -292,6 +292,13 @@ export class ScrapeQueue {
 
   // Cooldown wait timer - prevents multiple concurrent timers when all items blocked
   private cooldownWaitTimerId: NodeJS.Timeout | null = null;
+
+  // Per-host pacing floor (H1, spec.md orzgk Slice B D8/§4 Rate row): last time an item was
+  // DISPATCHED to each host, keyed by normalized (lowercased, www-stripped) hostname — same
+  // normalization as ProfileRegistry so domain variants collapse to one entry. Independent of
+  // `currentDelay` (the GLOBAL lane): an item is only dispatched once BOTH the global lane AND
+  // this per-host floor are satisfied.
+  private hostLastDispatch: Map<string, number> = new Map();
 
   // Ingest seams (engine plumbing, injected — see setters below).
   // When an emitter is configured (INGEST_BASE_URL) AND the registry resolves
@@ -906,8 +913,8 @@ export class ScrapeQueue {
       return;
     }
 
-    // Get next item, considering paused sessions and cooldowns
-    const item = this.getNextProcessableItem();
+    // Get next item, considering paused sessions, cooldowns, and per-host pacing
+    const item = this.getNextProcessableItem(now);
     if (!item) {
       // Queue empty or all items blocked, stop processing
       this.isProcessing = false;
@@ -1135,11 +1142,35 @@ export class ScrapeQueue {
   /**
    * Get the next processable item, skipping paused sessions and respecting cooldowns
    */
-  private getNextProcessableItem(): QueueItem | null {
+  /** Lowercased, `www.`-stripped hostname (same normalization as ProfileRegistry); undefined on an unparseable URL. */
+  private hostOf(url: string): string | undefined {
+    try {
+      return new URL(url).hostname.toLowerCase().replace(/^www\./, '');
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * The per-host pacing floor (H1): the store's own declared `rateLimit.baseDelayMs` (the SAME
+   * store-caps index the ingest path's transport lookup already reads — buildIngestExtractContext
+   * above), falling back to `DEFAULT_FETCH_BODY_GAP_MS` (engineServices/extractContext.ts) for a
+   * host with no resolved store profile — mirroring that seam's own undeclared-store default
+   * rather than inventing a second one.
+   */
+  private hostBaseDelayMs(host: string): number {
+    return this.profiles?.forHost(host)?.rateLimit?.baseDelayMs ?? DEFAULT_FETCH_BODY_GAP_MS;
+  }
+
+  private getNextProcessableItem(now: number): QueueItem | null {
     // Try each priority queue in order
     const queues = [this.hotQueue, this.warmQueue, this.coldQueue];
     let pausedCount = 0;
     let cooldownCount = 0;
+    let hostPacedCount = 0;
+    // Smallest remaining wait among host-paced items, so a purely-pacing block can re-check
+    // precisely instead of falling back to the generic 5s cooldown poll below.
+    let minHostWaitMs = Infinity;
 
     for (const queue of queues) {
       for (let i = 0; i < queue.length; i++) {
@@ -1162,25 +1193,51 @@ export class ScrapeQueue {
           }
         }
 
-        // This item is processable - remove from queue and return
+        // Per-host floor: an item whose host was dispatched to more recently than its declared
+        // baseDelayMs must wait — but ONLY this item; other hosts' items (including lower-priority
+        // ones further down the lanes) are unaffected, so a paced host never stalls the rest of
+        // the queue.
+        const host = this.hostOf(item.url);
+        if (host !== undefined) {
+          const lastDispatch = this.hostLastDispatch.get(host);
+          if (lastDispatch !== undefined) {
+            const remaining = lastDispatch + this.hostBaseDelayMs(host) - now;
+            if (remaining > 0) {
+              hostPacedCount++;
+              if (remaining < minHostWaitMs) minHostWaitMs = remaining;
+              continue;
+            }
+          }
+        }
+
+        // This item is processable - remove from queue, record its host dispatch, and return
         queue.splice(i, 1);
+        if (host !== undefined) this.hostLastDispatch.set(host, now);
         return item;
       }
     }
 
-    // No processable items found - check if there are items waiting in cooldown
-    const totalBlocked = pausedCount + cooldownCount;
+    // No processable items found - check if there are items waiting in cooldown or host-paced
+    const totalBlocked = pausedCount + cooldownCount + hostPacedCount;
     if (totalBlocked > 0 && !this.cooldownWaitTimerId) {
+      // Purely host-paced (no paused/cooldown items in the mix): re-check exactly when the
+      // soonest-ready host clears, rather than the generic 5s poll below.
+      const waitMs = pausedCount === 0 && cooldownCount === 0 && minHostWaitMs !== Infinity
+        ? minHostWaitMs
+        : 5000;
       // Log summary once and schedule SINGLE retry timer
       // Guard with cooldownWaitTimerId to prevent multiple concurrent timers
-      console.log(`[SCRAPE QUEUE] All ${totalBlocked} items blocked (${pausedCount} paused, ${cooldownCount} in cooldown), waiting 5s...`);
+      console.log(`[SCRAPE QUEUE] All ${totalBlocked} items blocked (${pausedCount} paused, ${cooldownCount} in cooldown, ${hostPacedCount} host-paced), waiting ${waitMs}ms...`);
       this.cooldownWaitTimerId = setTimeout(() => {
         this.cooldownWaitTimerId = null; // Clear before retry to allow future timers
-        if (!this.isProcessing) {
-          this.isProcessing = true;
-          this.processNext();
-        }
-      }, 5000); // Check again in 5 seconds
+        // Always re-drive: `isProcessing` may already be true (e.g. a DIFFERENT item for another
+        // host dispatched successfully while this one stayed blocked — see H1), in which case
+        // nothing else schedules a further attempt for the item(s) that caused this timer.
+        // processNext() is itself re-entrancy-safe (guarded by the processingItem lock), so
+        // calling it unconditionally here is always correct, never a double-dispatch risk.
+        this.isProcessing = true;
+        this.processNext();
+      }, waitMs);
     }
 
     return null;


### PR DESCRIPTION
## What — orzgk-spec H1: the store's `rateLimit.baseDelayMs` now binds every request lane to a host
1. **Live queue** (`scrapeQueue.ts`): `getNextProcessableItem` defers an item whose host was dispatched more recently than the store's declared `baseDelayMs` (store-caps index; undeclared → `DEFAULT_FETCH_BODY_GAP_MS`), on top of the unchanged global lane. Deferred items are skipped, never spliced — other hosts and lower lanes flow; hot>warm>cold preserved across hosts.
2. **Driver** (`hostRateLimiter.ts` + `assembleCrawlDriver.ts`): `wrapFetchBodyWithLimiter` makes the in-slot `fetchBody` follow-up visible to `HostRateLimiter`, so the next primary dispatch paces off it (deterministic virtual-clock proof: `[0, 1500]` not `[0, 1000]`).
3. **Engine ctx** (`extractContext.ts`): `fetchBody` re-gaps each subsequent same-host call against its own prior dispatch, not just `primaryFetchedAt` (B3 disclosure closed).

Also fixes a latent pre-existing bug the seam-1 tests exposed: the all-blocked retry timer's `if (!this.isProcessing)` guard could no-op forever after a different host's item dispatched; now re-drives unconditionally (safe — `processNext` is `processingItem`-locked at :892). Orchestrator-inspected and signed off.

## Adversarial review
5 red findings → challenger independently reproduced 4 (2 claimed blockers downgraded to major, both fixed): `recordDispatch` moved to call-time (in-flight same-host race), host keys normalized (raw-vs-`www.` silently defeating the limiter — repo's own fixtures proved it), undeclared-store fallback branch test-covered, test-count narrative corrected. 1 finding refuted (pre-existing `defaultSleep` line misattributed).

## Verification (orchestrator-reproduced)
- Red→green by me: upstream `scrapeQueue.ts` → 2/5 pacing tests fail; restored → 5/5.
- `npm test`: **60 suites / 674 passed / 3 todo, zero regressions** (true measured baseline 59/658/3 — the brief's 624/56 was stale); `typecheck` + `typecheck:tests` clean.
- Coverage: 100% on hostRateLimiter/assembleCrawlDriver/extractContext; every new/changed scrapeQueue line covered (fallback branch [13,1] both sides).
- Fake timers/injectable clocks only; no live fetches; no ruleset-facing contract change.

## Notes
- Host-key conventions intentionally differ per subsystem (queue strips `www.` matching ProfileRegistry; limiter normalizes internally at `stateFor`) — documented in-code against naive unification.
- Squash-merge (branch bodies exceed the 2-line rule; the squash message below is the landing message).

https://claude.ai/code/session_01CxnRbCJUfDGE26mxyyNcgT