### PR TITLE
Route /resolve through extractRecords with per-host pacing and real capture sink

### DIFF
--- a/src/__tests__/unit/engineLookup.test.ts
+++ b/src/__tests__/unit/engineLookup.test.ts
@@ -92,4 +92,18 @@ describe('httpFetchBody', () => {
       global.fetch = orig;
     }
   });
+
+  it('bounds the fetch with an abort signal — a tarpitted endpoint must not ride undici\'s ~300s defaults on a synchronous caller', async () => {
+    const orig = global.fetch;
+    const fetchMock = jest.fn(async (_url: string, _init?: RequestInit) => ({ text: async () => 'ok' }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      await httpFetchBody('https://store.example/api.json');
+      const init = fetchMock.mock.calls[0]?.[1];
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      expect(init?.signal?.aborted).toBe(false);
+    } finally {
+      global.fetch = orig;
+    }
+  });
 });

--- a/src/__tests__/unit/engineResolve.test.ts
+++ b/src/__tests__/unit/engineResolve.test.ts
@@ -192,6 +192,80 @@ describe('createEngineResolve', () => {
     expect(out.results[0]?.records).toEqual([edition]);
   });
 
+  it('falls back to forSite when the byId template\'s host sits OUTSIDE the store\'s indexed domains — store caps still resolve', async () => {
+    // The forHost-miss → forSite-HIT branch's motivating case (engineResolve's own comment): the
+    // detail host is not in domains[], but the ruleset's siteId IS registered — the ctx must carry
+    // the STORE's config, gap, and transport, not the synthesized last-resort default.
+    const SOLARIS: StoreCapabilities = {
+      siteId: 'solaris', name: 'Solaris Japan', domains: ['solaris-japan.com'], requiresBrowser: false, allowedCookies: [],
+      rateLimit: { domain: 'solaris-japan.com', baseDelayMs: 1234, minDelayMs: 500, maxDelayMs: 10000, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+      retrieval: { byId: { urlTemplate: 'https://details.solaris-cdn.example/item/{id}', idKind: 'store-internal' } },
+      searchFetch: { transport: 'http' },
+    };
+    let seenCtx: ExtractContext | undefined;
+    const ruleset: ExtractionRuleset = {
+      siteId: 'solaris',
+      version: '1.0.0',
+      extract: async (_html, _url, ctx) => {
+        seenCtx = ctx;
+        await ctx!.scraping.fetchBody!('https://details.solaris-cdn.example/api/item/9');
+        return record('solaris', '9', { name: 'ok' });
+      },
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const registry: LookupRegistry = { allStores: () => [SOLARIS], getRulesetForUrl: () => ruleset };
+    const http = jest.fn(async () => '{}');
+    const { now, sleep } = fakeClock(1_000_000);
+
+    const out = await createEngineResolve(
+      registry,
+      jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+      { scraping: fakeScraping(), transports: { http }, sink: { capture: jest.fn(async () => undefined) }, now, sleep },
+    ).resolve('solaris', ['9']);
+
+    expect(out.failed).toEqual([]);
+    // forHost('details.solaris-cdn.example') misses; forSite('solaris') hits → the STORE's caps:
+    expect(seenCtx?.config.name).toBe('Solaris Japan');
+    expect(seenCtx?.config.rateLimit.baseDelayMs).toBe(1234);
+    // …the same-host follow-up waited the STORE's declared gap, not the synthesized default…
+    expect(sleep).toHaveBeenCalledWith(1234);
+    // …and the store's declared http transport carried it (searchFetch resolved via the caps too).
+    expect(http).toHaveBeenCalledWith('https://details.solaris-cdn.example/api/item/9');
+  });
+
+  it('synthesizes a SiteConfig carrying the PARSED hostname as its domain when neither forHost nor forSite resolves', async () => {
+    // Line-77 truthy half (`domains: hostname ? [hostname] : []`): parseable template URL, but the
+    // ruleset's siteId is unregistered and the host is outside every indexed domain.
+    const HOST_STORE: StoreCapabilities = {
+      siteId: 'host-store', name: 'host-store', domains: ['host-store.example'], requiresBrowser: false, allowedCookies: [],
+      rateLimit: { domain: 'host-store.example', baseDelayMs: 100, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+      retrieval: { byId: { urlTemplate: 'https://unindexed.example/item/{id}', idKind: 'store-internal' } },
+    };
+    let seenCtx: ExtractContext | undefined;
+    const ruleset: ExtractionRuleset = {
+      siteId: 'phantom',
+      version: '1.0.0',
+      extract: (_html, _url, ctx) => {
+        seenCtx = ctx;
+        return record('phantom', 'X1', { name: 'ok' });
+      },
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const registry: LookupRegistry = { allStores: () => [HOST_STORE], getRulesetForUrl: () => ruleset };
+    const { now, sleep } = fakeClock(1_000_000);
+
+    const out = await createEngineResolve(
+      registry,
+      jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+      { scraping: fakeScraping(), sink: { capture: jest.fn(async () => undefined) }, now, sleep },
+    ).resolve('host-store', ['X1']);
+
+    expect(out.failed).toEqual([]);
+    expect(seenCtx?.config.siteId).toBe('phantom');
+    expect(seenCtx?.config.domains).toEqual(['unindexed.example']);
+    expect(seenCtx?.config.rateLimit.baseDelayMs).toBe(DEFAULT_FETCH_BODY_GAP_MS);
+  });
+
   it('degrades to the synthesized SiteConfig + browser-lane fetchBody when the ruleset has no registered profile', async () => {
     // Unparseable byId URL (no hostname) + a ruleset whose siteId is NOT a registered store —
     // the ctx must still build: default gap, undeclared transport → browser lane, no crash.

--- a/src/__tests__/unit/engineResolve.test.ts
+++ b/src/__tests__/unit/engineResolve.test.ts
@@ -1,32 +1,201 @@
 /**
  * createEngineResolve — builds a Resolve from the engine registry (allStores → ProfileRegistry) + a
  * detail fetch, and byId-confirms an id into full ExtractedData.
+ *
+ * Extraction dispatches through the SAME machinery as the ingest path (extractRecords +
+ * buildExtractContext): extractAsync/extractMany rulesets get a real ExtractContext whose
+ * `scraping.fetchBody` rides the store's OWN declared transport (impersonate for amiami) through
+ * the capturing fetch (raw bytes → capture sink, 'api' lane) with the D8 courtesy gap. All
+ * transports, sink, clock, and sleep are injected fakes — no live fetches, no real waiting.
  */
 import { createEngineResolve } from '../../services/engineResolve';
+import { DEFAULT_FETCH_BODY_GAP_MS } from '../../services/engineServices/extractContext';
 import type { LookupRegistry } from '../../services/engineLookup';
-import type { ExtractionRuleset, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import type {
+  ExtractContext,
+  ExtractedData,
+  ExtractionRuleset,
+  StoreCapabilities,
+} from '@figurecollecting/scraper-plugin-contract';
 
-const STORE: StoreCapabilities = {
-  siteId: 'amiami', name: 'AmiAmi', domains: ['api.amiami.com'], requiresBrowser: false, allowedCookies: [],
-  rateLimit: { domain: 'api.amiami.com', baseDelayMs: 0, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+const AMIAMI: StoreCapabilities = {
+  siteId: 'amiami', name: 'AmiAmi', domains: ['amiami.com', 'api.amiami.com'], requiresBrowser: false, allowedCookies: [],
+  rateLimit: { domain: 'amiami.com', baseDelayMs: 3000, minDelayMs: 500, maxDelayMs: 10000, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
   retrieval: { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } },
+  searchFetch: { transport: 'impersonate', browser: 'chrome142' },
 };
 
-const RULESET: ExtractionRuleset = {
-  siteId: 'amiami', version: '1.0.0',
-  extract: () => ({ source: { site: 'amiami', itemId: 'x', extractedAt: '2026-08-11T00:00:00.000Z' }, fields: { gtin14: '04570232591424' }, warnings: [] }),
-  validate: () => ({ valid: true, errors: [], warnings: [] }),
+const ORZGK: StoreCapabilities = {
+  siteId: 'orzgk', name: 'orzgk', domains: ['orzgk.com'], requiresBrowser: false, allowedCookies: [],
+  rateLimit: { domain: 'orzgk.com', baseDelayMs: 3000, minDelayMs: 500, maxDelayMs: 10000, backoffMultiplier: 1.5, recoveryDivisor: 1.5, successThreshold: 3 },
+  retrieval: { byId: { urlTemplate: 'https://orzgk.com/product/{id}', idKind: 'store-internal' } },
+  searchFetch: { transport: 'http' },
+};
+
+const record = (site: string, itemId: string, fields: Record<string, unknown>): ExtractedData => ({
+  source: { site, itemId, extractedAt: '2026-08-25T00:00:00.000Z' },
+  fields,
+  warnings: [],
+});
+
+const fakeScraping = () => ({
+  scrapePage: jest.fn(async () => ({ html: '<page/>', url: '', title: '', statusCode: 200 })),
+  scrapePageStealth: jest.fn(async () => ({ html: '<page/>', url: '', title: '', statusCode: 200 })),
+});
+
+/** Fake clock: now() reads a mutable instant, sleep(ms) advances it — zero real waiting. */
+const fakeClock = (t0: number) => {
+  const state = { clock: t0 };
+  return {
+    state,
+    now: jest.fn(() => state.clock),
+    sleep: jest.fn(async (ms: number) => {
+      state.clock += ms;
+    }),
+  };
 };
 
 describe('createEngineResolve', () => {
   it('builds a Resolve from the registry that byId-confirms via the injected fetchDetail', async () => {
-    const registry: LookupRegistry = { allStores: () => [STORE], getRulesetForUrl: () => RULESET };
+    const ruleset: ExtractionRuleset = {
+      siteId: 'amiami', version: '1.0.0',
+      extract: () => record('amiami', 'x', { gtin14: '04570232591424' }),
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const registry: LookupRegistry = { allStores: () => [AMIAMI], getRulesetForUrl: () => ruleset };
     const fetchDetail = jest.fn(async () => ({ html: '<html/>', statusCode: 200 }));
 
-    const out = await createEngineResolve(registry, fetchDetail).resolve('amiami', ['FIGURE-206235']);
+    const out = await createEngineResolve(registry, fetchDetail, { scraping: fakeScraping() })
+      .resolve('amiami', ['FIGURE-206235']);
 
     expect(fetchDetail).toHaveBeenCalledWith('https://www.amiami.com/eng/detail/?gcode=FIGURE-206235');
     expect(out.unsupported).toBe(false);
     expect(out.results[0]?.data?.fields.gtin14).toBe('04570232591424');
+  });
+
+  it('gives extractAsync a buildExtractContext ctx whose fetchBody rides the store\'s declared impersonate transport into the capture sink', async () => {
+    const apiUrl = 'https://api.amiami.com/api/v1.0/item?gcode=FIGURE-190355-R';
+    let seenCtx: ExtractContext | undefined;
+    const ruleset: ExtractionRuleset & {
+      extractAsync?: (html: string, url: string, ctx?: ExtractContext) => Promise<ExtractedData>;
+    } = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => record('amiami', 'FIGURE-190355-R', {}),
+      extractAsync: async (_html, _url, ctx) => {
+        seenCtx = ctx;
+        const api = await ctx!.scraping.fetchBody!(apiUrl);
+        const parsed = JSON.parse(api.html) as { name: string; jan: string };
+        return record('amiami', 'FIGURE-190355-R', { name: parsed.name, jan: parsed.jan });
+      },
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const registry: LookupRegistry = { allStores: () => [AMIAMI], getRulesetForUrl: () => ruleset };
+    const impersonate = jest.fn(async () => JSON.stringify({ name: 'Gyaru Tomie x Hello Kitty', jan: '4570232591424' }));
+    const sink = { capture: jest.fn(async () => undefined) };
+    const { now, sleep } = fakeClock(1_000_000);
+
+    const out = await createEngineResolve(
+      registry,
+      jest.fn(async () => ({ html: '<div id="__nuxt"></div>', statusCode: 200 })),
+      { scraping: fakeScraping(), transports: { impersonate }, sink, now, sleep },
+    ).resolve('amiami', ['FIGURE-190355-R']);
+
+    // The confirm is FULL — the item API populated the fields (prod red: {} + Nuxt warning).
+    expect(out.failed).toEqual([]);
+    expect(out.results[0]?.data?.fields).toEqual({ name: 'Gyaru Tomie x Hello Kitty', jan: '4570232591424' });
+
+    // Transport: the store's declared searchFetch (impersonate, chrome142) carried the follow-up.
+    expect(impersonate).toHaveBeenCalledWith(apiUrl, expect.objectContaining({ browser: 'chrome142' }));
+
+    // Capture: the follow-up's raw bytes landed in the sink under the 'api' lane.
+    expect(sink.capture).toHaveBeenCalledTimes(1);
+    expect(sink.capture).toHaveBeenCalledWith(expect.objectContaining({ url: apiUrl, lane: 'api' }));
+
+    // api.amiami.com ≠ the detail page's host (amiami.com) — a cross-host follow-up owes no
+    // courtesy gap (extractContext's same-host gate), so no wait happened.
+    expect(sleep).not.toHaveBeenCalled();
+
+    // Structural proof the ctx came from buildExtractContext: config resolved from the store's
+    // caps, and the members it deliberately does not provide throw its loud not-supported error.
+    expect(seenCtx?.config.siteId).toBe('amiami');
+    expect(() => seenCtx!.scraping.browserFetch('https://x/')).toThrow(/not available via ExtractContext/);
+  });
+
+  it('courtesy-gaps a SAME-host extractMany follow-up against the primary detail fetch, and surfaces children via records[]', async () => {
+    const followUpUrl = 'https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=77';
+    const parent = record('orzgk', '77', { name: 'WLOP GK' });
+    const edition = record('orzgk', '77__a', { name: 'WLOP GK — 1/4', editionOf: '77' });
+    const ruleset: ExtractionRuleset = {
+      siteId: 'orzgk',
+      version: '1.0.0',
+      extract: () => parent,
+      extractMany: async (_html, _url, ctx) => {
+        await ctx!.scraping.fetchBody!(followUpUrl);
+        return [parent, edition];
+      },
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const registry: LookupRegistry = { allStores: () => [ORZGK], getRulesetForUrl: () => ruleset };
+    const http = jest.fn(async () => '{"variations":[]}');
+    const sink = { capture: jest.fn(async () => undefined) };
+    const { now, sleep } = fakeClock(1_000_000);
+
+    const out = await createEngineResolve(
+      registry,
+      jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+      { scraping: fakeScraping(), transports: { http }, sink, now, sleep },
+    ).resolve('orzgk', ['77']);
+
+    // D8: the follow-up waited the store's OWN baseDelayMs (3000) against primaryFetchedAt,
+    // on the fake clock — sleep BEFORE the transport dispatch, zero real waiting.
+    expect(sleep).toHaveBeenCalledWith(3000);
+    expect(sleep.mock.invocationCallOrder[0]).toBeLessThan(http.mock.invocationCallOrder[0]);
+    expect(http).toHaveBeenCalledWith(followUpUrl);
+
+    // Multi-record shape: data stays the parent (today's shape); records[] is the additive extra.
+    expect(out.results[0]?.data).toEqual(parent);
+    expect(out.results[0]?.records).toEqual([edition]);
+  });
+
+  it('degrades to the synthesized SiteConfig + browser-lane fetchBody when the ruleset has no registered profile', async () => {
+    // Unparseable byId URL (no hostname) + a ruleset whose siteId is NOT a registered store —
+    // the ctx must still build: default gap, undeclared transport → browser lane, no crash.
+    const GHOST_STORE: StoreCapabilities = {
+      siteId: 'ghost-store', name: 'ghost-store', domains: ['ghost.example'], requiresBrowser: false, allowedCookies: [],
+      rateLimit: { domain: 'ghost.example', baseDelayMs: 100, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+      retrieval: { byId: { urlTemplate: 'not-a-url-{id}', idKind: 'store-internal' } },
+    };
+    let seenCtx: ExtractContext | undefined;
+    const ruleset: ExtractionRuleset = {
+      siteId: 'ghost',
+      version: '1.0.0',
+      extract: async (_html, _url, ctx) => {
+        seenCtx = ctx;
+        const followUp = await ctx!.scraping.fetchBody!('https://elsewhere.example/data.json');
+        return record('ghost', 'X1', { name: followUp.html });
+      },
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const registry: LookupRegistry = { allStores: () => [GHOST_STORE], getRulesetForUrl: () => ruleset };
+    const scraping = fakeScraping();
+    const { now, sleep } = fakeClock(1_000_000);
+
+    const out = await createEngineResolve(
+      registry,
+      jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+      { scraping, sink: { capture: jest.fn(async () => undefined) }, now, sleep },
+    ).resolve('ghost-store', ['X1']);
+
+    expect(out.failed).toEqual([]);
+    expect(out.results[0]?.data?.fields.name).toBe('<page/>');
+    // Synthesized config: the ruleset's own siteId, no domains (unparseable URL), the default gap.
+    expect(seenCtx?.config.siteId).toBe('ghost');
+    expect(seenCtx?.config.domains).toEqual([]);
+    expect(seenCtx?.config.rateLimit.baseDelayMs).toBe(DEFAULT_FETCH_BODY_GAP_MS);
+    // Undeclared searchFetch → the capturing fetch's browser lane served the follow-up.
+    expect(scraping.scrapePage).toHaveBeenCalledWith('https://elsewhere.example/data.json');
+    // No primary host to owe courtesy to → no wait.
+    expect(sleep).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/unit/engineResolve.test.ts
+++ b/src/__tests__/unit/engineResolve.test.ts
@@ -122,6 +122,40 @@ describe('createEngineResolve', () => {
     expect(() => seenCtx!.scraping.browserFetch('https://x/')).toThrow(/not available via ExtractContext/);
   });
 
+  it('holds a per-host floor ACROSS sibling ids: follow-up hits to the store\'s API host land >= baseDelayMs apart (no cross-id burst)', async () => {
+    const ruleset: ExtractionRuleset & {
+      extractAsync?: (html: string, url: string, ctx?: ExtractContext) => Promise<ExtractedData>;
+    } = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => record('amiami', 'x', {}),
+      extractAsync: async (_html, url, ctx) => {
+        const gcode = new URL(url).searchParams.get('gcode') ?? 'x';
+        const api = await ctx!.scraping.fetchBody!(`https://api.amiami.com/api/v1.0/item?gcode=${gcode}`);
+        const parsed = JSON.parse(api.html) as { jan: string };
+        return record('amiami', gcode, { jan: parsed.jan });
+      },
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+    const registry: LookupRegistry = { allStores: () => [AMIAMI], getRulesetForUrl: () => ruleset };
+    const { now, sleep } = fakeClock(1_000_000);
+    const apiHitAt: number[] = [];
+    const impersonate = jest.fn(async () => { apiHitAt.push(now()); return JSON.stringify({ jan: '4570232591424' }); });
+
+    const out = await createEngineResolve(
+      registry,
+      jest.fn(async () => ({ html: '<div id="__nuxt"></div>', statusCode: 200 })),
+      { scraping: fakeScraping(), transports: { impersonate }, sink: { capture: jest.fn(async () => undefined) }, now, sleep },
+    ).resolve('amiami', ['FIGURE-1', 'FIGURE-2']);
+
+    expect(out.failed).toEqual([]);
+    expect(apiHitAt).toHaveLength(2);
+    // The floor: amiami's declared baseDelayMs (3000) separates the two API hits. Before the
+    // shared per-call pacing, both ids ran concurrently with private per-ctx maps and the
+    // cross-host D8 gate — so the CF-fronted API took both hits in one synchronized burst.
+    expect(apiHitAt[1]! - apiHitAt[0]!).toBeGreaterThanOrEqual(3000);
+  });
+
   it('courtesy-gaps a SAME-host extractMany follow-up against the primary detail fetch, and surfaces children via records[]', async () => {
     const followUpUrl = 'https://orzgk.com/wp-json/wc/store/v1/products?type=variation&parent=77';
     const parent = record('orzgk', '77', { name: 'WLOP GK' });

--- a/src/__tests__/unit/engineServices/capturingScrapingService.test.ts
+++ b/src/__tests__/unit/engineServices/capturingScrapingService.test.ts
@@ -1,0 +1,27 @@
+/**
+ * createCapturingScrapingService — the pooled browser surface the /lookup + /resolve mount uses,
+ * REQUIRED to be backed by the shared raw-capture sink (ingest-queue parity): a bare
+ * createScrapingService() defaults to a NoopCaptureSink, which silently drops the wire+dom
+ * captures of every navigation made through it. That miswiring is exactly what this pins against.
+ */
+jest.mock('../../../services/engineServices/scrapingService');
+jest.mock('../../../services/s3ObjectStore');
+
+import { createCapturingScrapingService } from '../../../services/engineServices/capturingScrapingService';
+import { createScrapingService } from '../../../services/engineServices/scrapingService';
+import { getRawCaptureSink } from '../../../services/s3ObjectStore';
+
+describe('createCapturingScrapingService', () => {
+  it('builds the pooled surface over the SHARED raw-capture sink — never the silent Noop default', () => {
+    const sink = { capture: jest.fn() };
+    const service = { marker: 'pooled-service' };
+    (getRawCaptureSink as jest.Mock).mockReturnValue(sink);
+    (createScrapingService as jest.Mock).mockReturnValue(service);
+
+    const out = createCapturingScrapingService();
+
+    expect(getRawCaptureSink).toHaveBeenCalledTimes(1);
+    expect(createScrapingService).toHaveBeenCalledWith(sink);
+    expect(out).toBe(service);
+  });
+});

--- a/src/__tests__/unit/resolveRoute.test.ts
+++ b/src/__tests__/unit/resolveRoute.test.ts
@@ -5,7 +5,15 @@
 import express from 'express';
 import request from 'supertest';
 import { createResolveRoute } from '../../routes/resolve';
+import { createEngineResolve } from '../../services/engineResolve';
+import type { LookupRegistry } from '../../services/engineLookup';
 import type { Resolve, ResolveResult } from '../../driver/assembleResolve';
+import type {
+  ExtractContext,
+  ExtractedData,
+  ExtractionRuleset,
+  StoreCapabilities,
+} from '@figurecollecting/scraper-plugin-contract';
 
 const result = (over: Partial<ResolveResult> = {}): ResolveResult => ({
   site: 'amiami', results: [], unsupported: false, failed: [], ...over,
@@ -60,5 +68,79 @@ describe('POST /resolve', () => {
     const res = await request(appWith(resolve)).post('/resolve').send({ site: 'amiami', ids: ['x'] });
     expect(res.status).toBe(502);
     expect(res.body.detail).toBe('pool dead');
+  });
+});
+
+/**
+ * Full route → engine chain (createResolveRoute over createEngineResolve): extraction must
+ * dispatch through extractRecords (extractMany > extractAsync > extract), same as the ingest
+ * path. Pins the prod bug: POST /resolve {site:'amiami', ids:[...]} returned fields {} + a
+ * "use extractAsync()" warning because the resolve leg called bare extract().
+ */
+describe('POST /resolve — engine-wired extraction dispatch', () => {
+  const AMIAMI: StoreCapabilities = {
+    siteId: 'amiami', name: 'AmiAmi', domains: ['amiami.com'], requiresBrowser: false, allowedCookies: [],
+    rateLimit: { domain: 'amiami.com', baseDelayMs: 0, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+    retrieval: { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } },
+    searchFetch: { transport: 'impersonate', browser: 'chrome142' },
+  };
+
+  const record = (itemId: string, fields: Record<string, unknown>, warnings: string[] = []): ExtractedData => ({
+    source: { site: 'amiami', itemId, extractedAt: '2026-08-25T00:00:00.000Z' },
+    fields,
+    warnings,
+  });
+
+  const engineApp = (ruleset: ExtractionRuleset) => {
+    const registry: LookupRegistry = { allStores: () => [AMIAMI], getRulesetForUrl: () => ruleset };
+    const scraping = {
+      scrapePage: jest.fn(async () => ({ html: '<page/>', url: '', title: '', statusCode: 200 })),
+      scrapePageStealth: jest.fn(async () => ({ html: '<page/>', url: '', title: '', statusCode: 200 })),
+    };
+    const resolve = createEngineResolve(
+      registry,
+      jest.fn(async () => ({ html: '<div id="__nuxt"></div>', statusCode: 200 })),
+      { scraping, sink: { capture: jest.fn(async () => undefined) }, now: () => 1_000_000, sleep: jest.fn(async () => undefined) },
+    );
+    return appWith(resolve);
+  };
+
+  it('an async-only store (amiami) confirms with POPULATED fields — no Nuxt warning, no empty bag', async () => {
+    const ruleset: ExtractionRuleset & {
+      extractAsync?: (html: string, url: string, ctx?: ExtractContext) => Promise<ExtractedData>;
+    } = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => record('FIGURE-190355-R', {}, ['AmiAmi product pages render client-side (Nuxt) — use extractAsync() so the item API is used']),
+      extractAsync: async () => record('FIGURE-190355-R', { name: 'Gyaru Tomie x Hello Kitty', jan: '4570232591424' }),
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+
+    const res = await request(engineApp(ruleset)).post('/resolve').send({ site: 'amiami', ids: ['FIGURE-190355-R'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.failed).toEqual([]);
+    expect(res.body.results[0].data.fields).toEqual({ name: 'Gyaru Tomie x Hello Kitty', jan: '4570232591424' });
+    expect(res.body.results[0].data.warnings).toEqual([]);
+    // Single record → today's response shape exactly: no additive records field.
+    expect('records' in res.body.results[0]).toBe(false);
+  });
+
+  it('an extractMany store returns data=record[0] plus the additive records[] through the route JSON', async () => {
+    const parent = record('LISTING-9', { name: 'GK Statue' });
+    const edition = record('LISTING-9__a', { name: 'GK Statue — 1/4', editionOf: 'LISTING-9' });
+    const ruleset: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => record('LISTING-9', { name: 'WRONG — extractMany must win' }),
+      extractMany: () => [parent, edition],
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+
+    const res = await request(engineApp(ruleset)).post('/resolve').send({ site: 'amiami', ids: ['LISTING-9'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].data.fields.name).toBe('GK Statue');
+    expect(res.body.results[0].records).toEqual([edition]);
   });
 });

--- a/src/__tests__/unit/resolveRoute.test.ts
+++ b/src/__tests__/unit/resolveRoute.test.ts
@@ -126,6 +126,26 @@ describe('POST /resolve — engine-wired extraction dispatch', () => {
     expect('records' in res.body.results[0]).toBe(false);
   });
 
+  it('a malformed id (lone surrogate — encodeURIComponent throws) lands in failed[]; siblings resolve, no batch 502', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // '\ud800' passes the route's string/trim filter (lone surrogates are not whitespace) but
+    // resolveByIdUrl's encodeURIComponent throws URIError on it — that throw must fail ONLY this
+    // id, not poison the sibling into a batch-wide 502.
+    const ruleset: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => record('OK-1', { name: 'ok' }),
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+
+    const res = await request(engineApp(ruleset)).post('/resolve').send({ site: 'amiami', ids: ['OK-1', '\ud800'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results.map((r: { itemId: string }) => r.itemId)).toEqual(['OK-1']);
+    expect(res.body.failed).toHaveLength(1);
+    warn.mockRestore();
+  });
+
   it('an extractMany store returns data=record[0] plus the additive records[] through the route JSON', async () => {
     const parent = record('LISTING-9', { name: 'GK Statue' });
     const edition = record('LISTING-9__a', { name: 'GK Statue — 1/4', editionOf: 'LISTING-9' });

--- a/src/driver/__tests__/assembleResolve.test.ts
+++ b/src/driver/__tests__/assembleResolve.test.ts
@@ -105,6 +105,55 @@ describe('assembleResolve — byId confirm', () => {
     warn.mockRestore();
   });
 
+  it('processes ids SEQUENTIALLY — the next id\'s detail fetch waits for the previous id to finish (no same-host burst)', async () => {
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => { releaseFirst = r; });
+    const fetchDetail = jest.fn(async (url: string) => {
+      if (url.includes('ID-1')) await gate;
+      return { html: 'ok', statusCode: 200 };
+    });
+
+    const pending = assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => stub(() => extracted('1')),
+      fetchDetail,
+    }).resolve('amiami', ['ID-1', 'ID-2']);
+
+    await new Promise((r) => setImmediate(r));
+    // Only ID-1's fetch may be in flight — a Promise.all fan-out would have fired both already.
+    expect(fetchDetail).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    const out = await pending;
+    expect(fetchDetail).toHaveBeenCalledTimes(2);
+    expect(out.results.map((r) => r.itemId)).toEqual(['ID-1', 'ID-2']);
+  });
+
+  it('courtesy-gaps sibling ids\' SAME-HOST primary fetches by the store\'s baseDelayMs (H1 parity), on the injected clock', async () => {
+    const store: StoreCapabilities = {
+      ...caps('amiami', 'amiami.com', { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } }),
+      rateLimit: { domain: 'amiami.com', baseDelayMs: 3000, minDelayMs: 500, maxDelayMs: 10000, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+    };
+    let clock = 1_000_000;
+    const now = jest.fn(() => clock);
+    const sleep = jest.fn(async (ms: number) => { clock += ms; });
+    const fetchedAt: number[] = [];
+    const fetchDetail = jest.fn(async () => { fetchedAt.push(now()); return { html: 'ok', statusCode: 200 }; });
+
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([store]),
+      getRulesetForUrl: () => stub(() => extracted('1')),
+      fetchDetail,
+      now,
+      sleep,
+    }).resolve('amiami', ['A-1', 'A-2']);
+
+    expect(out.failed).toEqual([]);
+    expect(sleep).toHaveBeenCalledWith(3000);
+    // The per-host floor held: the second primary dispatched >= baseDelayMs after the first.
+    expect(fetchedAt[1]! - fetchedAt[0]!).toBeGreaterThanOrEqual(3000);
+  });
+
   it('a throw from URL building / ruleset lookup fails THAT id only — siblings still resolve (no batch poisoning)', async () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     // getRulesetForUrl deliberately propagates new URL() throws (extractionRegistry), and
@@ -197,7 +246,7 @@ describe('assembleResolve — extraction dispatch parity (extractRecords)', () =
     expect(out.results[0]?.records).toEqual([editionA, editionB]);
   });
 
-  it('threads the resolveContext seam: ctx built per id (ruleset, url, primaryFetchedAt=now()) and handed to the extraction', async () => {
+  it('threads the resolveContext seam: ctx built per id (ruleset, url, primaryFetchedAt=now(), shared host map) and handed to the extraction', async () => {
     const ctx = { marker: 'built-by-buildExtractContext' } as unknown as ExtractContext;
     const resolveContext = jest.fn(() => ctx);
     const extract = jest.fn(() => record('FIGURE-1', { name: 'x' }));
@@ -214,7 +263,7 @@ describe('assembleResolve — extraction dispatch parity (extractRecords)', () =
     }).resolve('amiami', ['FIGURE-1']);
 
     expect(out.failed).toEqual([]);
-    expect(resolveContext).toHaveBeenCalledWith(ruleset, 'https://www.amiami.com/eng/detail/?gcode=FIGURE-1', 777_000);
+    expect(resolveContext).toHaveBeenCalledWith(ruleset, 'https://www.amiami.com/eng/detail/?gcode=FIGURE-1', 777_000, expect.any(Map));
     expect(extract).toHaveBeenCalledWith('<html/>', 'https://www.amiami.com/eng/detail/?gcode=FIGURE-1', ctx);
   });
 

--- a/src/driver/__tests__/assembleResolve.test.ts
+++ b/src/driver/__tests__/assembleResolve.test.ts
@@ -105,6 +105,25 @@ describe('assembleResolve — byId confirm', () => {
     warn.mockRestore();
   });
 
+  it('a throw from URL building / ruleset lookup fails THAT id only — siblings still resolve (no batch poisoning)', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // getRulesetForUrl deliberately propagates new URL() throws (extractionRegistry), and
+    // resolveByIdUrl's encodeURIComponent throws URIError on a lone-surrogate id — either must
+    // land in failed[] through the per-id isolation, not reject the whole resolve() batch.
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: (url) => {
+        if (url.includes('BOOM')) throw new Error('Invalid URL');
+        return stub(() => extracted('123'));
+      },
+      fetchDetail: jest.fn(async () => ({ html: 'ok', statusCode: 200 })),
+    }).resolve('amiami', ['GOOD', 'BOOM']);
+
+    expect(out.results.map((r) => r.itemId)).toEqual(['GOOD']);
+    expect(out.failed).toEqual(['BOOM']);
+    warn.mockRestore();
+  });
+
   it('an id with no matching ruleset is failed (not fetched)', async () => {
     const fetchDetail = jest.fn(async () => ({ html: 'x' }));
     const out = await assembleResolve({ profiles: buildProfileRegistry([AMIAMI]), getRulesetForUrl: () => undefined, fetchDetail })

--- a/src/driver/__tests__/assembleResolve.test.ts
+++ b/src/driver/__tests__/assembleResolve.test.ts
@@ -6,7 +6,7 @@
  */
 import { assembleResolve, type ResolveServices } from '../assembleResolve';
 import { buildProfileRegistry } from '../profileRegistry';
-import type { ExtractedData, ExtractionRuleset, RetrievalCapability, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
+import type { ExtractContext, ExtractedData, ExtractionRuleset, RetrievalCapability, StoreCapabilities } from '@figurecollecting/scraper-plugin-contract';
 
 const caps = (siteId: string, host: string, retrieval?: RetrievalCapability): StoreCapabilities => ({
   siteId, name: siteId, domains: [host], requiresBrowser: false, allowedCookies: [],
@@ -113,5 +113,124 @@ describe('assembleResolve — byId confirm', () => {
     expect(out.failed).toEqual(['x']);
     expect(out.results).toEqual([]);
     expect(fetchDetail).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Extraction dispatch parity with the ingest path (extractRecords: extractMany > extractAsync >
+ * extract). The prod bug this pins: /resolve called bare extract(), so async-only stores (amiami)
+ * confirmed with EMPTY fields + a "use extractAsync()" warning while the ingest path resolved the
+ * same page fully.
+ */
+describe('assembleResolve — extraction dispatch parity (extractRecords)', () => {
+  type AsyncCapableRuleset = ExtractionRuleset & {
+    extractAsync?: (html: string, url: string, ctx?: ExtractContext) => Promise<ExtractedData>;
+  };
+
+  const record = (itemId: string, fields: Record<string, unknown>, warnings: string[] = []): ExtractedData => ({
+    source: { site: 'amiami', itemId, extractedAt: '2026-08-25T00:00:00.000Z' },
+    fields,
+    warnings,
+  });
+
+  it('dispatches an async-only ruleset via extractAsync — fields POPULATED, not bare extract()\'s empty bag', async () => {
+    // Mirrors prod amiami: extract() cannot parse the client-rendered page; extractAsync can.
+    const ruleset: AsyncCapableRuleset = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => record('FIGURE-190355-R', {}, ['AmiAmi product pages render client-side (Nuxt) — use extractAsync() so the item API is used']),
+      extractAsync: async () => record('FIGURE-190355-R', { name: 'Gyaru Tomie x Hello Kitty', jan: '4570232591424' }),
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => ruleset,
+      fetchDetail: jest.fn(async () => ({ html: '<div id="__nuxt"></div>', statusCode: 200 })),
+    }).resolve('amiami', ['FIGURE-190355-R']);
+
+    expect(out.failed).toEqual([]);
+    expect(out.results[0]?.data?.fields).toEqual({ name: 'Gyaru Tomie x Hello Kitty', jan: '4570232591424' });
+    expect(out.results[0]?.data?.warnings).toEqual([]);
+  });
+
+  it('extractMany: data = record[0] (the listing) and the additive records[] carries the children', async () => {
+    const parent = record('LISTING-1', { name: 'GK Statue', gtin14: '04570232591424' });
+    const editionA = record('LISTING-1__a', { name: 'GK Statue — 1/4', editionOf: 'LISTING-1' });
+    const editionB = record('LISTING-1__b', { name: 'GK Statue — 1/6', editionOf: 'LISTING-1' });
+    const ruleset: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => record('LISTING-1', { name: 'WRONG — extractMany must win' }),
+      extractMany: () => [parent, editionA, editionB],
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => ruleset,
+      fetchDetail: jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+    }).resolve('amiami', ['LISTING-1']);
+
+    expect(out.failed).toEqual([]);
+    expect(out.results[0]?.data).toEqual(parent);
+    expect(out.results[0]?.gtin14).toBe('04570232591424');
+    expect(out.results[0]?.records).toEqual([editionA, editionB]);
+  });
+
+  it('threads the resolveContext seam: ctx built per id (ruleset, url, primaryFetchedAt=now()) and handed to the extraction', async () => {
+    const ctx = { marker: 'built-by-buildExtractContext' } as unknown as ExtractContext;
+    const resolveContext = jest.fn(() => ctx);
+    const extract = jest.fn(() => record('FIGURE-1', { name: 'x' }));
+    const ruleset: ExtractionRuleset = {
+      siteId: 'amiami', version: '1.0.0', extract, validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => ruleset,
+      fetchDetail: jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+      resolveContext,
+      now: () => 777_000,
+    }).resolve('amiami', ['FIGURE-1']);
+
+    expect(out.failed).toEqual([]);
+    expect(resolveContext).toHaveBeenCalledWith(ruleset, 'https://www.amiami.com/eng/detail/?gcode=FIGURE-1', 777_000);
+    expect(extract).toHaveBeenCalledWith('<html/>', 'https://www.amiami.com/eng/detail/?gcode=FIGURE-1', ctx);
+  });
+
+  it('a single-record ruleset keeps today\'s response shape exactly — NO records field', async () => {
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => stub(() => extracted('04570232591424')),
+      fetchDetail: jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+    }).resolve('amiami', ['FIGURE-1']);
+
+    expect(out.results[0]?.data?.fields.gtin14).toBe('04570232591424');
+    expect(out.results[0] && 'records' in out.results[0]).toBe(false);
+  });
+
+  it('a D11 guard violation (duplicate itemIds from extractMany) fails THAT id only — others still resolve', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const good = record('GOOD', { name: 'ok' });
+    const dup = record('BAD', { name: 'dup' });
+    const ruleset: ExtractionRuleset = {
+      siteId: 'amiami',
+      version: '1.0.0',
+      extract: () => good,
+      extractMany: (_html, url) => (url.includes('BAD') ? [dup, dup] : [good]),
+      validate: () => ({ valid: true, errors: [], warnings: [] }),
+    };
+
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([AMIAMI]),
+      getRulesetForUrl: () => ruleset,
+      fetchDetail: jest.fn(async () => ({ html: '<html/>', statusCode: 200 })),
+    }).resolve('amiami', ['GOOD', 'BAD']);
+
+    expect(out.results.map((r) => r.itemId)).toEqual(['GOOD']);
+    expect(out.failed).toEqual(['BAD']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate source.itemId'));
+    warn.mockRestore();
   });
 });

--- a/src/driver/__tests__/assembleResolve.test.ts
+++ b/src/driver/__tests__/assembleResolve.test.ts
@@ -154,6 +154,25 @@ describe('assembleResolve — byId confirm', () => {
     expect(fetchedAt[1]! - fetchedAt[0]!).toBeGreaterThanOrEqual(3000);
   });
 
+  it('paces with REAL time when no clock/sleep are injected (the default now/sleep path) — the same-host gap is measurable', async () => {
+    const store: StoreCapabilities = {
+      ...caps('amiami', 'amiami.com', { byId: { urlTemplate: 'https://www.amiami.com/eng/detail/?gcode={id}', idKind: 'store-internal' } }),
+      rateLimit: { domain: 'amiami.com', baseDelayMs: 25, minDelayMs: 0, maxDelayMs: 100, backoffMultiplier: 2, recoveryDivisor: 2, successThreshold: 3 },
+    };
+    const fetchedAt: number[] = [];
+    const fetchDetail = jest.fn(async () => { fetchedAt.push(Date.now()); return { html: 'ok', statusCode: 200 }; });
+
+    const out = await assembleResolve({
+      profiles: buildProfileRegistry([store]),
+      getRulesetForUrl: () => stub(() => extracted('1')),
+      fetchDetail,
+    }).resolve('amiami', ['R-1', 'R-2']);
+
+    expect(out.failed).toEqual([]);
+    // Real setTimeout floor — allow scheduler slack, but the ~25ms courtesy gap must be visible.
+    expect(fetchedAt[1]! - fetchedAt[0]!).toBeGreaterThanOrEqual(20);
+  });
+
   it('a throw from URL building / ruleset lookup fails THAT id only — siblings still resolve (no batch poisoning)', async () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     // getRulesetForUrl deliberately propagates new URL() throws (extractionRegistry), and

--- a/src/driver/assembleResolve.ts
+++ b/src/driver/assembleResolve.ts
@@ -1,18 +1,23 @@
 /**
  * assembleResolve — the byId CONFIRM runtime (the matcher's pass-2 bridge, and /resolve's engine).
  * Given a store + item ids (e.g. the `resolveTargets` a record-mode lookup surfaced, or a candidate
- * the caller picked), it fetches each item's DETAIL page and runs the store's `ruleset.extract` →
- * full `ExtractedData` (whose `fields.gtin14` the private byId ruleset populates). Unlike the crawl
- * worker, it RETURNS the data and NEVER emits to the spine or touches a ledger.
+ * the caller picked), it fetches each item's DETAIL page and dispatches the store's ruleset through
+ * `extractRecords` (extractMany > extractAsync > extract — the SAME dispatch the ingest queue and
+ * crawl worker use, engineServices/extractRecords.ts) → full `ExtractedData` (whose `fields.gtin14`
+ * the private byId ruleset populates). `records[0]` (the page's own record) is the confirm's `data`;
+ * an extractMany ruleset's EXTRA records (editions/offers) ride the additive `ResolveItem.records`.
+ * Unlike the crawl worker, it RETURNS the data and NEVER emits to the spine or touches a ledger.
  *
- * Composed from three existing primitives — `resolveByIdUrl` + an injected detail fetch + the
- * ruleset's `extract` — so it reuses the same substrate the crawl worker is built from, one layer
+ * Composed from existing primitives — `resolveByIdUrl` + an injected detail fetch + the shared
+ * `extractRecords` dispatch (fed an `ExtractContext` via the optional `resolveContext` seam, the
+ * crawlWorker pattern) — so it reuses the same substrate the crawl worker is built from, one layer
  * down, without the spine/ledger coupling. Everything injected → deterministic in tests.
  */
 import { resolveByIdUrl } from './retrievalPlanner.js';
+import { extractRecords } from '../services/engineServices/extractRecords.js';
 import { sanitizeForLog } from '../utils/security.js';
 import type { ProfileRegistry } from './profileRegistry.js';
-import type { ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
+import type { ExtractContext, ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
 
 export interface ResolveServices {
   /** The store registry (built from the engine's registered capabilities). */
@@ -21,6 +26,15 @@ export interface ResolveServices {
   getRulesetForUrl: (url: string) => ExtractionRuleset | undefined;
   /** Fetch a detail page's body (the pooled ScrapingService's scrapePage at the mount). */
   fetchDetail: (url: string) => Promise<{ html: string; statusCode?: number }>;
+  /**
+   * OPTIONAL per-id `ExtractContext` resolver (the crawlWorker `resolveContext` seam): the wiring
+   * (engineResolve) builds it via `buildExtractContext`, so an extractAsync/extractMany ruleset's
+   * follow-up fetches ride the store's declared transport into the capture sink, courtesy-gapped
+   * against `primaryFetchedAt` (epoch ms when THIS id's detail fetch completed).
+   */
+  resolveContext?: (ruleset: ExtractionRuleset, url: string, primaryFetchedAt: number) => ExtractContext | undefined;
+  /** Injectable clock anchoring `primaryFetchedAt` (default `Date.now`). */
+  now?: () => number;
 }
 
 export interface ResolveItem {
@@ -28,6 +42,13 @@ export interface ResolveItem {
   url: string;
   /** The confirmed record when fetch + extract succeeded. */
   data?: ExtractedData;
+  /**
+   * ADDITIVE (multi-record rulesets only): the records BEYOND the page's own — extractMany's
+   * children (editions/offers), in the same target-first order the ingest path emits them. ABSENT
+   * when extraction yielded exactly one record, so single-record confirms keep today's shape
+   * byte-for-byte. `data` above is always `records[0]` of the full extraction (the listing/parent).
+   */
+  records?: ExtractedData[];
   /**
    * The gtin14 the byId extract recovered, surfaced for the matcher. UNDEFINED means the confirm did
    * NOT yield a barcode (a no-JAN statue, OR an SPA/CF page the browser fetch under-extracted) — so
@@ -73,9 +94,20 @@ export function assembleResolve(services: ResolveServices): Resolve {
             if (statusCode !== undefined && statusCode >= 400) {
               throw new Error(`detail fetch returned HTTP ${statusCode}`);
             }
-            const data = await ruleset.extract(html, url);
+            // The courtesy-gap anchor: the instant the PRIMARY detail fetch completed (D8), so a
+            // same-host ctx.scraping.fetchBody follow-up waits the store's gap against THIS fetch.
+            const primaryFetchedAt = (services.now ?? Date.now)();
+            // Same dispatch as ingest/crawl: extractMany > extractAsync > extract, D11-guarded —
+            // a guard violation throws into this id's OWN failure handling below, same as ingest.
+            const records = await extractRecords(
+              ruleset,
+              html,
+              url,
+              services.resolveContext?.(ruleset, url, primaryFetchedAt),
+            );
+            const data = records[0];
             const gtin14 = typeof data.fields.gtin14 === 'string' ? data.fields.gtin14 : undefined;
-            return { itemId, url, data, gtin14 };
+            return { itemId, url, data, ...(records.length > 1 ? { records: records.slice(1) } : {}), gtin14 };
           } catch (err) {
             // eslint-disable-next-line no-console
             console.warn(`[resolve] ${sanitizeForLog(site)}/${sanitizeForLog(itemId)} failed: ${sanitizeForLog(err instanceof Error ? err.message : String(err))}`);

--- a/src/driver/assembleResolve.ts
+++ b/src/driver/assembleResolve.ts
@@ -12,9 +12,16 @@
  * `extractRecords` dispatch (fed an `ExtractContext` via the optional `resolveContext` seam, the
  * crawlWorker pattern) — so it reuses the same substrate the crawl worker is built from, one layer
  * down, without the spine/ledger coupling. Everything injected → deterministic in tests.
+ *
+ * PACING (H1 parity): ids are processed SEQUENTIALLY, and one per-call, per-host last-fetch map
+ * (shared with every id's ExtractContext) floors each fetch — primary or follow-up — at the
+ * store's `rateLimit.baseDelayMs` against the call's previous fetch to the same host. This is the
+ * queue's `hostLastDispatch` semantic for the resolve leg: a multi-id confirm never fires
+ * synchronized same-host bursts, at the price of response time scaling with ids × gap.
  */
 import { resolveByIdUrl } from './retrievalPlanner.js';
 import { extractRecords } from '../services/engineServices/extractRecords.js';
+import { DEFAULT_FETCH_BODY_GAP_MS, safeHostname } from '../services/engineServices/extractContext.js';
 import { sanitizeForLog } from '../utils/security.js';
 import type { ProfileRegistry } from './profileRegistry.js';
 import type { ExtractContext, ExtractedData, ExtractionRuleset } from '@figurecollecting/scraper-plugin-contract';
@@ -32,9 +39,17 @@ export interface ResolveServices {
    * follow-up fetches ride the store's declared transport into the capture sink, courtesy-gapped
    * against `primaryFetchedAt` (epoch ms when THIS id's detail fetch completed).
    */
-  resolveContext?: (ruleset: ExtractionRuleset, url: string, primaryFetchedAt: number) => ExtractContext | undefined;
-  /** Injectable clock anchoring `primaryFetchedAt` (default `Date.now`). */
+  resolveContext?: (
+    ruleset: ExtractionRuleset,
+    url: string,
+    primaryFetchedAt: number,
+    /** The call's SHARED per-host last-fetch map — thread it into the ctx so follow-ups re-gap across sibling ids too. */
+    lastFetchedAt: Map<string, number>,
+  ) => ExtractContext | undefined;
+  /** Injectable clock anchoring `primaryFetchedAt` and the pacing floor (default `Date.now`). */
   now?: () => number;
+  /** Injectable sleep for the cross-id courtesy gap (default: a real `setTimeout` promise). */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 export interface ResolveItem {
@@ -78,49 +93,70 @@ export function assembleResolve(services: ResolveServices): Resolve {
         return { site, results: [], unsupported: true, failed: [] };
       }
 
-      const failed: string[] = [];
-      const settled = await Promise.all(
-        ids.map(async (itemId): Promise<ResolveItem | null> => {
-          try {
-            // INSIDE the try: resolveByIdUrl's encodeURIComponent throws on a lone-surrogate id,
-            // and getRulesetForUrl deliberately propagates new URL() errors — either must fail
-            // ONLY this id (failed[]), never reject the whole batch into the route's 502.
-            const url = resolveByIdUrl(caps.retrieval, itemId);
-            const ruleset = url ? services.getRulesetForUrl(url) : undefined;
-            if (!url || !ruleset) {
-              failed.push(itemId);
-              return null;
-            }
-            const { html, statusCode } = await services.fetchDetail(url);
-            // A 4xx/5xx page (CF challenge / gone / error) is NOT a confirm — extract would happily
-            // parse the error body into empty fields WITHOUT throwing, so gate on status explicitly.
-            if (statusCode !== undefined && statusCode >= 400) {
-              throw new Error(`detail fetch returned HTTP ${statusCode}`);
-            }
-            // The courtesy-gap anchor: the instant the PRIMARY detail fetch completed (D8), so a
-            // same-host ctx.scraping.fetchBody follow-up waits the store's gap against THIS fetch.
-            const primaryFetchedAt = (services.now ?? Date.now)();
-            // Same dispatch as ingest/crawl: extractMany > extractAsync > extract, D11-guarded —
-            // a guard violation throws into this id's OWN failure handling below, same as ingest.
-            const records = await extractRecords(
-              ruleset,
-              html,
-              url,
-              services.resolveContext?.(ruleset, url, primaryFetchedAt),
-            );
-            const data = records[0];
-            const gtin14 = typeof data.fields.gtin14 === 'string' ? data.fields.gtin14 : undefined;
-            return { itemId, url, data, ...(records.length > 1 ? { records: records.slice(1) } : {}), gtin14 };
-          } catch (err) {
-            // eslint-disable-next-line no-console
-            console.warn(`[resolve] ${sanitizeForLog(site)}/${sanitizeForLog(itemId)} failed: ${sanitizeForLog(err instanceof Error ? err.message : String(err))}`);
-            failed.push(itemId);
-            return null;
-          }
-        }),
-      );
+      const now = services.now ?? Date.now;
+      const sleep = services.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+      const gapMs = caps.rateLimit?.baseDelayMs ?? DEFAULT_FETCH_BODY_GAP_MS;
+      // ONE per-host last-fetch map for the WHOLE call (H1 parity, cross-id): every id in a call
+      // targets the same store, so the queue would space them by the store's baseDelayMs — this
+      // map (shared with each id's ExtractContext below) is the resolve leg's equivalent floor.
+      const lastFetchedAt = new Map<string, number>();
 
-      return { site, results: settled.filter((r): r is ResolveItem => r !== null), unsupported: false, failed };
+      const results: ResolveItem[] = [];
+      const failed: string[] = [];
+      // SEQUENTIAL by design, not Promise.all: concurrent ids would fire same-host bursts the
+      // check-then-sleep gap cannot prevent (all readers see the same stale timestamp). The queue
+      // is sequential per host for the same reason; per-id failure isolation is unchanged.
+      for (const itemId of ids) {
+        try {
+          // INSIDE the try: resolveByIdUrl's encodeURIComponent throws on a lone-surrogate id,
+          // and getRulesetForUrl deliberately propagates new URL() errors — either must fail
+          // ONLY this id (failed[]), never reject the whole batch into the route's 502.
+          const url = resolveByIdUrl(caps.retrieval, itemId);
+          const ruleset = url ? services.getRulesetForUrl(url) : undefined;
+          if (!url || !ruleset) {
+            failed.push(itemId);
+            continue;
+          }
+          // Cross-id courtesy floor on the PRIMARY fetch: wait out the store's gap against the
+          // call's last fetch to this host (a sibling's primary, or its same-host follow-up).
+          const host = safeHostname(url);
+          const last = host === undefined ? undefined : lastFetchedAt.get(host);
+          if (last !== undefined) {
+            const remaining = last + gapMs - now();
+            if (remaining > 0) await sleep(remaining);
+          }
+          // Record the attempt win or lose (the host was contacted either way — H1 records at
+          // dispatch), completion-anchored like D8 so one map carries one consistent semantic.
+          const { html, statusCode } = await services.fetchDetail(url).finally(() => {
+            if (host !== undefined) lastFetchedAt.set(host, now());
+          });
+          // A 4xx/5xx page (CF challenge / gone / error) is NOT a confirm — extract would happily
+          // parse the error body into empty fields WITHOUT throwing, so gate on status explicitly.
+          if (statusCode !== undefined && statusCode >= 400) {
+            throw new Error(`detail fetch returned HTTP ${statusCode}`);
+          }
+          // The courtesy-gap anchor: the instant the PRIMARY detail fetch completed (D8), so a
+          // same-host ctx.scraping.fetchBody follow-up waits the store's gap against THIS fetch.
+          const primaryFetchedAt = now();
+          // Same dispatch as ingest/crawl: extractMany > extractAsync > extract, D11-guarded —
+          // a guard violation throws into this id's OWN failure handling below, same as ingest.
+          const records = await extractRecords(
+            ruleset,
+            html,
+            url,
+            services.resolveContext?.(ruleset, url, primaryFetchedAt, lastFetchedAt),
+          );
+          const data = records[0];
+          const gtin14 = typeof data.fields.gtin14 === 'string' ? data.fields.gtin14 : undefined;
+          results.push({ itemId, url, data, ...(records.length > 1 ? { records: records.slice(1) } : {}), gtin14 });
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(`[resolve] ${sanitizeForLog(site)}/${sanitizeForLog(itemId)} failed: ${sanitizeForLog(err instanceof Error ? err.message : String(err))}`);
+          failed.push(itemId);
+        }
+      }
+
+      return { site, results, unsupported: false, failed };
     },
   };
 }

--- a/src/driver/assembleResolve.ts
+++ b/src/driver/assembleResolve.ts
@@ -81,13 +81,16 @@ export function assembleResolve(services: ResolveServices): Resolve {
       const failed: string[] = [];
       const settled = await Promise.all(
         ids.map(async (itemId): Promise<ResolveItem | null> => {
-          const url = resolveByIdUrl(caps.retrieval, itemId);
-          const ruleset = url ? services.getRulesetForUrl(url) : undefined;
-          if (!url || !ruleset) {
-            failed.push(itemId);
-            return null;
-          }
           try {
+            // INSIDE the try: resolveByIdUrl's encodeURIComponent throws on a lone-surrogate id,
+            // and getRulesetForUrl deliberately propagates new URL() errors — either must fail
+            // ONLY this id (failed[]), never reject the whole batch into the route's 502.
+            const url = resolveByIdUrl(caps.retrieval, itemId);
+            const ruleset = url ? services.getRulesetForUrl(url) : undefined;
+            if (!url || !ruleset) {
+              failed.push(itemId);
+              return null;
+            }
             const { html, statusCode } = await services.fetchDetail(url);
             // A 4xx/5xx page (CF challenge / gone / error) is NOT a confirm — extract would happily
             // parse the error body into empty fields WITHOUT throwing, so gate on status explicitly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,9 +108,14 @@ async function startServer(): Promise<void> {
     app.use('/', createLookupRoute(createEngineLookup(registry, {
       browser: (url, opts) => lookupScraping.browserFetch(url, opts),
     })));
-    // POST /resolve — byId confirm (detail fetch + ruleset.extract → full ExtractedData incl gtin14),
-    // the matcher pass-2 bridge. Detail fetch shares the same pooled ScrapingService as /lookup.
-    app.use('/', createResolveRoute(createEngineResolve(registry, (url) => lookupScraping.scrapePage(url))));
+    // POST /resolve — byId confirm (detail fetch + extractRecords dispatch → full ExtractedData incl
+    // gtin14), the matcher pass-2 bridge. Detail fetch shares the same pooled ScrapingService as
+    // /lookup; that service also backs the ExtractContext (extractAsync/extractMany follow-ups ride
+    // the store's declared transport — impit/http default inside createEngineResolve — into the
+    // capture sink, courtesy-gapped, exactly like the ingest queue's extraction).
+    app.use('/', createResolveRoute(createEngineResolve(registry, (url) => lookupScraping.scrapePage(url), {
+      scraping: lookupScraping,
+    })));
     if (plugins.length > 0) {
       console.log(`[PAGE-SCRAPER] Loaded ${plugins.length} plugin(s): ${plugins.map(p => `${p.name}@${p.version}`).join(', ')}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { createLookupRoute } from './routes/lookup.js';
 import { createEngineLookup } from './services/engineLookup.js';
 import { createResolveRoute } from './routes/resolve.js';
 import { createEngineResolve } from './services/engineResolve.js';
-import { createScrapingService } from './services/engineServices/scrapingService.js';
+import { createCapturingScrapingService } from './services/engineServices/capturingScrapingService.js';
 import { scraperDebug } from './utils/logger.js';
 
 // Import browser pool functionality
@@ -103,8 +103,11 @@ async function startServer(): Promise<void> {
     // Mount the cross-store buy-decision search (GET /lookup) now that the registry is populated.
     // Each store fetches via the transport its `searchFetch` declares (http / impersonate / browser);
     // http + impersonate use the engine defaults, and the `browser` transport is backed here by the
-    // pooled ScrapingService (createScrapingService wraps the static BrowserPool → shares the queue's pool).
-    const lookupScraping = createScrapingService();
+    // pooled ScrapingService (wraps the static BrowserPool → shares the queue's pool). The surface
+    // is RAW-CAPTURE-SINK backed (queue parity): /resolve's primary detail fetches and browser-lane
+    // follow-ups navigate through it, and their wire+dom bytes must land in the raw store — a bare
+    // createScrapingService() would default to a Noop sink and silently drop them.
+    const lookupScraping = createCapturingScrapingService();
     app.use('/', createLookupRoute(createEngineLookup(registry, {
       browser: (url, opts) => lookupScraping.browserFetch(url, opts),
     })));

--- a/src/routes/resolve.ts
+++ b/src/routes/resolve.ts
@@ -1,8 +1,12 @@
 /**
  * POST /resolve { site, ids: [...] } — the byId CONFIRM endpoint. Fetches each id's detail page and
- * runs the store ruleset's extract() → full ExtractedData (incl fields.gtin14), returning per-id
- * results + `failed`/`unsupported`. The matcher's pass-2 bridge: turns a record-mode lookup's
- * `resolveTargets` (or a picked candidate) into confirmed records. Never emits to the spine. Injected.
+ * dispatches the store ruleset via extractRecords (extractMany > extractAsync > extract — the same
+ * dispatch as the ingest path) → full ExtractedData (incl fields.gtin14), returning per-id results
+ * + `failed`/`unsupported`. Each result's `data` is the page's own record (records[0], today's
+ * shape); a multi-record ruleset's extra records (editions/offers) ride the ADDITIVE per-result
+ * `records` array — absent for single-record confirms. The matcher's pass-2 bridge: turns a
+ * record-mode lookup's `resolveTargets` (or a picked candidate) into confirmed records. Never
+ * emits to the spine. Injected.
  */
 import { Router, type Request, type Response } from 'express';
 import type { Resolve } from '../driver/assembleResolve.js';

--- a/src/services/engineLookup.ts
+++ b/src/services/engineLookup.ts
@@ -24,9 +24,21 @@ export interface LookupRegistry {
 const DESKTOP_UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36';
 
-/** Raw response body of a search URL via plain HTTP (Tier-1 cookieless JSON). */
+/**
+ * Abort ceiling for the plain-HTTP lane, matching impit's own 15s cap (impitFetch TIMEOUT_MS) so
+ * neither non-browser transport can outlive the other. Without it a tarpitted endpoint rides
+ * undici's ~300s header/body defaults — tolerable for the ingest queue, not for the synchronous
+ * /lookup and /resolve callers this lane also serves.
+ */
+export const HTTP_FETCH_TIMEOUT_MS = 15_000;
+
+/** Raw response body of a search URL via plain HTTP (Tier-1 cookieless JSON), abort-bounded. */
 export async function httpFetchBody(url: string): Promise<string> {
-  const res = await fetch(url, { headers: { 'user-agent': DESKTOP_UA, accept: 'application/json, text/html' } });
+  const res = await fetch(url, {
+    headers: { 'user-agent': DESKTOP_UA, accept: 'application/json, text/html' },
+    // One signal bounds headers AND body: text() streams under the same abort.
+    signal: AbortSignal.timeout(HTTP_FETCH_TIMEOUT_MS),
+  });
   return res.text();
 }
 

--- a/src/services/engineResolve.ts
+++ b/src/services/engineResolve.ts
@@ -9,7 +9,9 @@
  * one layer out): an extractAsync/extractMany ruleset's follow-up `ctx.scraping.fetchBody` rides
  * the store's OWN declared `searchFetch` transport (impersonate for amiami / http / browser)
  * through the capturing fetch, so the raw bytes land in the capture sink under the 'api' lane and
- * the D8 courtesy gap is enforced against the primary detail fetch. `transports`/`sink` default to
+ * the D8 courtesy gap is enforced against the call's LAST fetch to that host — the primary detail
+ * fetch or a SIBLING id's fetch, via the per-call shared map assembleResolve threads through
+ * (sequential ids + one map = the queue's H1 per-host floor). `transports`/`sink` default to
  * the real engine fetchers (impit / plain HTTP / the raw sink); `now`/`sleep` default to real time —
  * all injectable so tests run on fakes with zero live fetches or waiting.
  */
@@ -58,7 +60,8 @@ export function createEngineResolve(
     getRulesetForUrl: (url) => registry.getRulesetForUrl(url),
     fetchDetail,
     ...(extract.now ? { now: extract.now } : {}),
-    resolveContext: (ruleset, url, primaryFetchedAt) => {
+    ...(extract.sleep ? { sleep: extract.sleep } : {}),
+    resolveContext: (ruleset, url, primaryFetchedAt, lastFetchedAt) => {
       let hostname: string | undefined;
       try {
         hostname = new URL(url).hostname;
@@ -96,6 +99,9 @@ export function createEngineResolve(
         searchFetch: caps?.searchFetch,
         primaryUrl: url,
         primaryFetchedAt,
+        // The call-wide shared map (assembleResolve's pacer): follow-ups re-gap against SIBLING
+        // ids' fetches to the same host, not just this id's own (H1 parity, cross-id).
+        lastFetchedAt,
         baseDelayMs: caps?.rateLimit?.baseDelayMs,
         ...(extract.now ? { now: extract.now } : {}),
         ...(extract.sleep ? { sleep: extract.sleep } : {}),

--- a/src/services/engineResolve.ts
+++ b/src/services/engineResolve.ts
@@ -3,16 +3,103 @@
  * detail fetch. Mirrors createEngineLookup: the ProfileRegistry is built from the plugin-populated
  * `allStores()`, rulesets resolve via `getRulesetForUrl`, and `fetchDetail` is the pooled
  * ScrapingService's scrapePage (wired at the mount). Result: a ready `Resolve` the /resolve route calls.
+ *
+ * Extraction dispatches through the SAME machinery as the ingest queue (extractRecords, fed an
+ * `ExtractContext` built here via `buildExtractContext` — the queue's buildIngestExtractContext,
+ * one layer out): an extractAsync/extractMany ruleset's follow-up `ctx.scraping.fetchBody` rides
+ * the store's OWN declared `searchFetch` transport (impersonate for amiami / http / browser)
+ * through the capturing fetch, so the raw bytes land in the capture sink under the 'api' lane and
+ * the D8 courtesy gap is enforced against the primary detail fetch. `transports`/`sink` default to
+ * the real engine fetchers (impit / plain HTTP / the raw sink); `now`/`sleep` default to real time —
+ * all injectable so tests run on fakes with zero live fetches or waiting.
  */
 import { buildProfileRegistry } from '../driver/profileRegistry.js';
 import { assembleResolve, type Resolve } from '../driver/assembleResolve.js';
-import type { LookupRegistry } from './engineLookup.js';
+import { createCapturingFetch, type BrowserLaneFetcher, type CapturingFetchTransports } from './engineServices/capturingFetch.js';
+import { buildExtractContext, DEFAULT_FETCH_BODY_GAP_MS } from './engineServices/extractContext.js';
+import { createPluginLogger } from './engineServices/pluginLogger.js';
+import { getRawCaptureSink } from './s3ObjectStore.js';
+import { impitFetchBody } from './impitFetch.js';
+import { httpFetchBody, type LookupRegistry } from './engineLookup.js';
+import type { CaptureSink } from './captureSink.js';
+import type { SiteConfig } from '@figurecollecting/scraper-plugin-contract';
+
+/** The extraction-context dependencies the CONFIRM leg needs (real defaults at the mount). */
+export interface ResolveExtractDeps {
+  /** Pooled browser surface: `ctx.scraping` passthrough + the capturing fetch's browser lane. */
+  scraping: BrowserLaneFetcher;
+  /** Non-browser transports (default: the real impit + plain-HTTP engine fetchers). */
+  transports?: Partial<Pick<CapturingFetchTransports, 'http' | 'impersonate'>>;
+  /** Raw-capture sink for the impit/http lanes (default: the engine's shared raw sink). */
+  sink?: CaptureSink;
+  /** Injectable clock + sleep for the courtesy gap (default: real time). */
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
 
 /** Build the byId-confirm Resolve from the engine's registered stores + a detail fetch. */
 export function createEngineResolve(
   registry: LookupRegistry,
   fetchDetail: (url: string) => Promise<{ html: string; statusCode?: number }>,
+  extract: ResolveExtractDeps,
 ): Resolve {
   const profiles = buildProfileRegistry(registry.allStores());
-  return assembleResolve({ profiles, getRulesetForUrl: (url) => registry.getRulesetForUrl(url), fetchDetail });
+  const capturingFetch = createCapturingFetch(
+    {
+      http: extract.transports?.http ?? httpFetchBody,
+      impersonate: extract.transports?.impersonate ?? impitFetchBody,
+      browser: extract.scraping,
+    },
+    extract.sink ?? getRawCaptureSink(),
+  );
+
+  return assembleResolve({
+    profiles,
+    getRulesetForUrl: (url) => registry.getRulesetForUrl(url),
+    fetchDetail,
+    ...(extract.now ? { now: extract.now } : {}),
+    resolveContext: (ruleset, url, primaryFetchedAt) => {
+      let hostname: string | undefined;
+      try {
+        hostname = new URL(url).hostname;
+      } catch {
+        hostname = undefined;
+      }
+      // The detail URL's store caps (same forHost lookup as the ingest queue), falling back to the
+      // ruleset's own site — the byId template's host may sit outside the store's indexed domains.
+      const caps = (hostname ? profiles.forHost(hostname) : undefined) ?? profiles.forSite(ruleset.siteId);
+      // Last-resort SiteConfig for a ruleset with no registered profile (stale/DI'd registry in
+      // tests) — degrade to the documented default gap rather than an undefined one.
+      const config: SiteConfig =
+        caps ?? {
+          siteId: ruleset.siteId,
+          name: ruleset.siteId,
+          domains: hostname ? [hostname] : [],
+          rateLimit: {
+            domain: hostname ?? '',
+            baseDelayMs: DEFAULT_FETCH_BODY_GAP_MS,
+            minDelayMs: DEFAULT_FETCH_BODY_GAP_MS,
+            maxDelayMs: DEFAULT_FETCH_BODY_GAP_MS,
+            backoffMultiplier: 1,
+            recoveryDivisor: 1,
+            successThreshold: 1,
+          },
+          requiresBrowser: false,
+          allowedCookies: [],
+        };
+
+      return buildExtractContext({
+        config,
+        logger: createPluginLogger(ruleset.siteId),
+        scraping: extract.scraping,
+        capturingFetch,
+        searchFetch: caps?.searchFetch,
+        primaryUrl: url,
+        primaryFetchedAt,
+        baseDelayMs: caps?.rateLimit?.baseDelayMs,
+        ...(extract.now ? { now: extract.now } : {}),
+        ...(extract.sleep ? { sleep: extract.sleep } : {}),
+      });
+    },
+  });
 }

--- a/src/services/engineServices/__tests__/extractContext.test.ts
+++ b/src/services/engineServices/__tests__/extractContext.test.ts
@@ -179,6 +179,39 @@ describe('buildExtractContext — scraping.fetchBody', () => {
     expect(capturingFetch).toHaveBeenCalled();
   });
 
+  it('accepts a SHARED lastFetchedAt map: gaps against a SIBLING context\'s fetch to the same host, seeds the primary, records its own', async () => {
+    let clock = 1_000_000;
+    const now = jest.fn(() => clock);
+    const sleep = jest.fn(async (ms: number) => { clock += ms; });
+    const capturingFetch = jest.fn().mockResolvedValue({ html: '{}' });
+    // A sibling context (a previous id in the same resolve call) hit the API host at t0.
+    const shared = new Map<string, number>([['api.amiami.com', 1_000_000]]);
+
+    const ctx = buildExtractContext({
+      config: CONFIG,
+      logger: LOGGER,
+      scraping: makeScraping(),
+      capturingFetch,
+      searchFetch: { transport: 'http' },
+      primaryUrl: 'https://www.amiami.com/eng/detail/?gcode=F-2',
+      primaryFetchedAt: 1_000_500,
+      baseDelayMs: 3000,
+      now,
+      sleep,
+      lastFetchedAt: shared,
+    });
+
+    await ctx.scraping.fetchBody!('https://api.amiami.com/api/v1.0/item?gcode=F-2');
+
+    // Cross-host vs THIS context's own primary — but the SHARED map knows the sibling's API hit,
+    // so the courtesy gap still applies against it.
+    expect(sleep).toHaveBeenCalledWith(3000);
+    // The primary fetch was seeded into the shared map for the NEXT sibling to gap against...
+    expect(shared.get('amiami.com')).toBe(1_000_500);
+    // ...and this dispatch was recorded there too.
+    expect(shared.get('api.amiami.com')).toBe(1_003_000);
+  });
+
   it('dispatches via capturingFetch using the STORE\'s declared searchFetch transport', async () => {
     const capturingFetch = jest.fn().mockResolvedValue({ html: 'body' });
     const searchFetch = { transport: 'impersonate' as const, browser: 'chrome142' };

--- a/src/services/engineServices/capturingScrapingService.ts
+++ b/src/services/engineServices/capturingScrapingService.ts
@@ -1,0 +1,15 @@
+/**
+ * The pooled browser surface backed by the SHARED raw-capture sink — the same construction the
+ * ingest queue uses (scrapeQueue: `createScrapingService(getRawCaptureSink())`). Extracted so the
+ * /lookup + /resolve mount provably shares it: a bare `createScrapingService()` defaults to a
+ * NoopCaptureSink, which SILENTLY drops the wire+dom captures of every navigation made through it
+ * (the resolve leg's primary detail fetches and browser-lane follow-ups all ride this surface, and
+ * their raw-store provenance would just never appear).
+ */
+import { createScrapingService } from './scrapingService.js';
+import { getRawCaptureSink } from '../s3ObjectStore.js';
+import type { ScrapingService } from '@figurecollecting/scraper-plugin-contract';
+
+export function createCapturingScrapingService(): ScrapingService {
+  return createScrapingService(getRawCaptureSink());
+}

--- a/src/services/engineServices/extractContext.ts
+++ b/src/services/engineServices/extractContext.ts
@@ -62,6 +62,15 @@ export interface BuildExtractContextOptions {
   primaryFetchedAt: number;
   /** Courtesy gap in ms; defaults to `DEFAULT_FETCH_BODY_GAP_MS` when the store declares none. */
   baseDelayMs?: number;
+  /**
+   * OPTIONAL shared per-host last-fetch map (epoch ms, keyed by `safeHostname`). When several
+   * contexts serve ONE caller-level operation (assembleResolve's sequential multi-id confirm),
+   * passing one map threads the courtesy gap ACROSS them — a follow-up gaps against a SIBLING
+   * context's fetch to the same host, not just this context's own (H1 parity, cross-id).
+   * Callers must not run sharing contexts concurrently (the gap check is check-then-sleep).
+   * Default: a private per-context map (single-extraction behavior, unchanged).
+   */
+  lastFetchedAt?: Map<string, number>;
   /** Injectable clock (default `Date.now`). */
   now?: () => number;
   /** Injectable sleep (default a real `setTimeout` promise). */
@@ -69,7 +78,7 @@ export interface BuildExtractContextOptions {
 }
 
 /** Lowercased, `www.`-stripped hostname; `undefined` on an unparseable URL (never throws). */
-function safeHostname(url: string): string | undefined {
+export function safeHostname(url: string): string | undefined {
   try {
     return new URL(url).hostname.toLowerCase().replace(/^www\./, '');
   } catch {
@@ -102,9 +111,14 @@ export function buildExtractContext(options: BuildExtractContextOptions): Extrac
   // primary page fetch — otherwise only the FIRST follow-up ever waits, and every call after it
   // is gapped against a primaryFetchedAt that has long since elapsed. Seeded with the primary
   // fetch's own host/time so the first same-host follow-up's behaviour is unchanged.
-  const lastFetchedAt = new Map<string, number>();
+  const lastFetchedAt = options.lastFetchedAt ?? new Map<string, number>();
   if (primaryHost !== undefined) {
-    lastFetchedAt.set(primaryHost, options.primaryFetchedAt);
+    // Monotonic seed: never regress a SHARED map's entry (a sibling context may have touched the
+    // primary host even more recently than this context's own primary fetch).
+    const seeded = lastFetchedAt.get(primaryHost);
+    if (seeded === undefined || seeded < options.primaryFetchedAt) {
+      lastFetchedAt.set(primaryHost, options.primaryFetchedAt);
+    }
   }
 
   return {


### PR DESCRIPTION
## What — the CONFIRM leg gets B3's dispatch + H1's pacing
Live prod evidence (2026-08-25): `POST /resolve {site:'amiami'}` returned empty fields with the ruleset warning "use extractAsync()" — resolve ran bare `extract()` while ingest already dispatched `extractMany > extractAsync > extract` (B3). Now `assembleResolve` routes each id through the SAME `extractRecords` + `buildExtractContext` (store-declared transports incl. impersonate for amiami; capture-sink-backed). Response: `data` = record[0] (unchanged); NEW additive `records[]` for extractMany children (absent for single-record confirms — byte-identical today).

## Adversarial review — 9 red findings, 9 confirmed, 9 fixed (5 red-first commits)
Cross-id host **stampede** (sequential ids + per-host `lastFetchedAt` floored at `baseDelayMs` — H1 parity); `/lookup`+`/resolve` mount was writing browser-lane captures to a **Noop sink** (now `createCapturingScrapingService`, the queue's construction); malformed id 502'd the whole batch (now lands in `failed[]`); http-lane timeout + follow-up cap; index.ts mount now covered.

## Verification
Suite 60 suites / 684 passed / 3 todo (baseline 674), both typechecks clean, lint:fetch clean, no live fetches (fake clocks). Verifier: every substantive gate held; sole flag = one 79-char commit subject (squash landing message is compliant). Orchestrator: rebased clean onto develop, 6 commits, tree clean.

Prod acceptance after deploy: `/resolve amiami FIGURE-190355-R` → populated fields via the item API.

https://claude.ai/code/session_01CxnRbCJUfDGE26mxyyNcgT